### PR TITLE
fix: change resource_type to enum array and add GetReplication API

### DIFF
--- a/api/go/v1alpha1/replication.pb.go
+++ b/api/go/v1alpha1/replication.pb.go
@@ -231,7 +231,7 @@ type PullBasePolicy struct {
 	state              protoimpl.MessageState `protogen:"open.v1"`
 	SourceRegistryId   uint32                 `protobuf:"varint,1,opt,name=source_registry_id,json=sourceRegistryId,proto3" json:"source_registry_id,omitempty"`
 	ResourceName       string                 `protobuf:"bytes,2,opt,name=resource_name,json=resourceName,proto3" json:"resource_name,omitempty"`
-	ResourceType       ResourceType           `protobuf:"varint,3,opt,name=resource_type,json=resourceType,proto3,enum=matrixhub.v1alpha1.ResourceType" json:"resource_type,omitempty"`
+	ResourceTypes      []ResourceType         `protobuf:"varint,3,rep,packed,name=resource_types,json=resourceTypes,proto3,enum=matrixhub.v1alpha1.ResourceType" json:"resource_types,omitempty"`
 	TargetResourceName string                 `protobuf:"bytes,4,opt,name=target_resource_name,json=targetResourceName,proto3" json:"target_resource_name,omitempty"`
 	// post or put do not require this field.
 	SourceRegistry *Registry `protobuf:"bytes,5,opt,name=source_registry,json=sourceRegistry,proto3" json:"source_registry,omitempty"`
@@ -283,11 +283,11 @@ func (x *PullBasePolicy) GetResourceName() string {
 	return ""
 }
 
-func (x *PullBasePolicy) GetResourceType() ResourceType {
+func (x *PullBasePolicy) GetResourceTypes() []ResourceType {
 	if x != nil {
-		return x.ResourceType
+		return x.ResourceTypes
 	}
-	return ResourceType_RESOURCE_TYPE_UNSPECIFIED
+	return nil
 }
 
 func (x *PullBasePolicy) GetTargetResourceName() string {
@@ -307,7 +307,7 @@ func (x *PullBasePolicy) GetSourceRegistry() *Registry {
 type PushBasePolicy struct {
 	state              protoimpl.MessageState `protogen:"open.v1"`
 	ResourceName       string                 `protobuf:"bytes,1,opt,name=resource_name,json=resourceName,proto3" json:"resource_name,omitempty"`
-	ResourceType       ResourceType           `protobuf:"varint,2,opt,name=resource_type,json=resourceType,proto3,enum=matrixhub.v1alpha1.ResourceType" json:"resource_type,omitempty"`
+	ResourceTypes      []ResourceType         `protobuf:"varint,2,rep,packed,name=resource_types,json=resourceTypes,proto3,enum=matrixhub.v1alpha1.ResourceType" json:"resource_types,omitempty"`
 	TargetRegistryId   uint32                 `protobuf:"varint,3,opt,name=target_registry_id,json=targetRegistryId,proto3" json:"target_registry_id,omitempty"`
 	TargetResourceName string                 `protobuf:"bytes,4,opt,name=target_resource_name,json=targetResourceName,proto3" json:"target_resource_name,omitempty"`
 	// post or put do not require this field.
@@ -353,11 +353,11 @@ func (x *PushBasePolicy) GetResourceName() string {
 	return ""
 }
 
-func (x *PushBasePolicy) GetResourceType() ResourceType {
+func (x *PushBasePolicy) GetResourceTypes() []ResourceType {
 	if x != nil {
-		return x.ResourceType
+		return x.ResourceTypes
 	}
-	return ResourceType_RESOURCE_TYPE_UNSPECIFIED
+	return nil
 }
 
 func (x *PushBasePolicy) GetTargetRegistryId() uint32 {
@@ -1092,6 +1092,94 @@ func (x *ListReplicationsResponse) GetPagination() *Pagination {
 	return nil
 }
 
+type GetReplicationRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ReplicationId int32                  `protobuf:"varint,1,opt,name=replication_id,json=replicationId,proto3" json:"replication_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetReplicationRequest) Reset() {
+	*x = GetReplicationRequest{}
+	mi := &file_v1alpha1_replication_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetReplicationRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetReplicationRequest) ProtoMessage() {}
+
+func (x *GetReplicationRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_v1alpha1_replication_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetReplicationRequest.ProtoReflect.Descriptor instead.
+func (*GetReplicationRequest) Descriptor() ([]byte, []int) {
+	return file_v1alpha1_replication_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *GetReplicationRequest) GetReplicationId() int32 {
+	if x != nil {
+		return x.ReplicationId
+	}
+	return 0
+}
+
+type GetReplicationResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Replication   *ReplicationItem       `protobuf:"bytes,1,opt,name=replication,proto3" json:"replication,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetReplicationResponse) Reset() {
+	*x = GetReplicationResponse{}
+	mi := &file_v1alpha1_replication_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetReplicationResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetReplicationResponse) ProtoMessage() {}
+
+func (x *GetReplicationResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_v1alpha1_replication_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetReplicationResponse.ProtoReflect.Descriptor instead.
+func (*GetReplicationResponse) Descriptor() ([]byte, []int) {
+	return file_v1alpha1_replication_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *GetReplicationResponse) GetReplication() *ReplicationItem {
+	if x != nil {
+		return x.Replication
+	}
+	return nil
+}
+
 type CreateReplicationExecutionRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ReplicationId int32                  `protobuf:"varint,1,opt,name=replication_id,json=replicationId,proto3" json:"replication_id,omitempty"`
@@ -1101,7 +1189,7 @@ type CreateReplicationExecutionRequest struct {
 
 func (x *CreateReplicationExecutionRequest) Reset() {
 	*x = CreateReplicationExecutionRequest{}
-	mi := &file_v1alpha1_replication_proto_msgTypes[11]
+	mi := &file_v1alpha1_replication_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1113,7 +1201,7 @@ func (x *CreateReplicationExecutionRequest) String() string {
 func (*CreateReplicationExecutionRequest) ProtoMessage() {}
 
 func (x *CreateReplicationExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1alpha1_replication_proto_msgTypes[11]
+	mi := &file_v1alpha1_replication_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1126,7 +1214,7 @@ func (x *CreateReplicationExecutionRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use CreateReplicationExecutionRequest.ProtoReflect.Descriptor instead.
 func (*CreateReplicationExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_v1alpha1_replication_proto_rawDescGZIP(), []int{11}
+	return file_v1alpha1_replication_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *CreateReplicationExecutionRequest) GetReplicationId() int32 {
@@ -1145,7 +1233,7 @@ type CreateReplicationExecutionResponse struct {
 
 func (x *CreateReplicationExecutionResponse) Reset() {
 	*x = CreateReplicationExecutionResponse{}
-	mi := &file_v1alpha1_replication_proto_msgTypes[12]
+	mi := &file_v1alpha1_replication_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1157,7 +1245,7 @@ func (x *CreateReplicationExecutionResponse) String() string {
 func (*CreateReplicationExecutionResponse) ProtoMessage() {}
 
 func (x *CreateReplicationExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1alpha1_replication_proto_msgTypes[12]
+	mi := &file_v1alpha1_replication_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1170,7 +1258,7 @@ func (x *CreateReplicationExecutionResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use CreateReplicationExecutionResponse.ProtoReflect.Descriptor instead.
 func (*CreateReplicationExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_v1alpha1_replication_proto_rawDescGZIP(), []int{12}
+	return file_v1alpha1_replication_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *CreateReplicationExecutionResponse) GetId() int32 {
@@ -1196,7 +1284,7 @@ type ReplicationExecution struct {
 
 func (x *ReplicationExecution) Reset() {
 	*x = ReplicationExecution{}
-	mi := &file_v1alpha1_replication_proto_msgTypes[13]
+	mi := &file_v1alpha1_replication_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1208,7 +1296,7 @@ func (x *ReplicationExecution) String() string {
 func (*ReplicationExecution) ProtoMessage() {}
 
 func (x *ReplicationExecution) ProtoReflect() protoreflect.Message {
-	mi := &file_v1alpha1_replication_proto_msgTypes[13]
+	mi := &file_v1alpha1_replication_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1221,7 +1309,7 @@ func (x *ReplicationExecution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplicationExecution.ProtoReflect.Descriptor instead.
 func (*ReplicationExecution) Descriptor() ([]byte, []int) {
-	return file_v1alpha1_replication_proto_rawDescGZIP(), []int{13}
+	return file_v1alpha1_replication_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ReplicationExecution) GetId() int32 {
@@ -1292,7 +1380,7 @@ type ListReplicationExecutionsRequest struct {
 
 func (x *ListReplicationExecutionsRequest) Reset() {
 	*x = ListReplicationExecutionsRequest{}
-	mi := &file_v1alpha1_replication_proto_msgTypes[14]
+	mi := &file_v1alpha1_replication_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1304,7 +1392,7 @@ func (x *ListReplicationExecutionsRequest) String() string {
 func (*ListReplicationExecutionsRequest) ProtoMessage() {}
 
 func (x *ListReplicationExecutionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1alpha1_replication_proto_msgTypes[14]
+	mi := &file_v1alpha1_replication_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1317,7 +1405,7 @@ func (x *ListReplicationExecutionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListReplicationExecutionsRequest.ProtoReflect.Descriptor instead.
 func (*ListReplicationExecutionsRequest) Descriptor() ([]byte, []int) {
-	return file_v1alpha1_replication_proto_rawDescGZIP(), []int{14}
+	return file_v1alpha1_replication_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ListReplicationExecutionsRequest) GetReplicationId() int32 {
@@ -1358,7 +1446,7 @@ type ListReplicationExecutionsResponse struct {
 
 func (x *ListReplicationExecutionsResponse) Reset() {
 	*x = ListReplicationExecutionsResponse{}
-	mi := &file_v1alpha1_replication_proto_msgTypes[15]
+	mi := &file_v1alpha1_replication_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1370,7 +1458,7 @@ func (x *ListReplicationExecutionsResponse) String() string {
 func (*ListReplicationExecutionsResponse) ProtoMessage() {}
 
 func (x *ListReplicationExecutionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1alpha1_replication_proto_msgTypes[15]
+	mi := &file_v1alpha1_replication_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1383,7 +1471,7 @@ func (x *ListReplicationExecutionsResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ListReplicationExecutionsResponse.ProtoReflect.Descriptor instead.
 func (*ListReplicationExecutionsResponse) Descriptor() ([]byte, []int) {
-	return file_v1alpha1_replication_proto_rawDescGZIP(), []int{15}
+	return file_v1alpha1_replication_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ListReplicationExecutionsResponse) GetExecutions() []*ReplicationExecution {
@@ -1410,7 +1498,7 @@ type StopReplicationExecutionRequest struct {
 
 func (x *StopReplicationExecutionRequest) Reset() {
 	*x = StopReplicationExecutionRequest{}
-	mi := &file_v1alpha1_replication_proto_msgTypes[16]
+	mi := &file_v1alpha1_replication_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1422,7 +1510,7 @@ func (x *StopReplicationExecutionRequest) String() string {
 func (*StopReplicationExecutionRequest) ProtoMessage() {}
 
 func (x *StopReplicationExecutionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1alpha1_replication_proto_msgTypes[16]
+	mi := &file_v1alpha1_replication_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1435,7 +1523,7 @@ func (x *StopReplicationExecutionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopReplicationExecutionRequest.ProtoReflect.Descriptor instead.
 func (*StopReplicationExecutionRequest) Descriptor() ([]byte, []int) {
-	return file_v1alpha1_replication_proto_rawDescGZIP(), []int{16}
+	return file_v1alpha1_replication_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *StopReplicationExecutionRequest) GetReplicationId() int32 {
@@ -1461,7 +1549,7 @@ type StopReplicationExecutionResponse struct {
 
 func (x *StopReplicationExecutionResponse) Reset() {
 	*x = StopReplicationExecutionResponse{}
-	mi := &file_v1alpha1_replication_proto_msgTypes[17]
+	mi := &file_v1alpha1_replication_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1473,7 +1561,7 @@ func (x *StopReplicationExecutionResponse) String() string {
 func (*StopReplicationExecutionResponse) ProtoMessage() {}
 
 func (x *StopReplicationExecutionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1alpha1_replication_proto_msgTypes[17]
+	mi := &file_v1alpha1_replication_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1486,7 +1574,7 @@ func (x *StopReplicationExecutionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopReplicationExecutionResponse.ProtoReflect.Descriptor instead.
 func (*StopReplicationExecutionResponse) Descriptor() ([]byte, []int) {
-	return file_v1alpha1_replication_proto_rawDescGZIP(), []int{17}
+	return file_v1alpha1_replication_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *StopReplicationExecutionResponse) GetExecution() *ReplicationExecution {
@@ -1500,16 +1588,16 @@ var File_v1alpha1_replication_proto protoreflect.FileDescriptor
 
 const file_v1alpha1_replication_proto_rawDesc = "" +
 	"\n" +
-	"\x1av1alpha1/replication.proto\x12\x12matrixhub.v1alpha1\x1a\x1cgoogle/api/annotations.proto\x1a\x14v1alpha1/utils.proto\x1a\x17v1alpha1/registry.proto\"\xa3\x02\n" +
+	"\x1av1alpha1/replication.proto\x12\x12matrixhub.v1alpha1\x1a\x1cgoogle/api/annotations.proto\x1a\x14v1alpha1/utils.proto\x1a\x17v1alpha1/registry.proto\"\xa5\x02\n" +
 	"\x0ePullBasePolicy\x12,\n" +
 	"\x12source_registry_id\x18\x01 \x01(\rR\x10sourceRegistryId\x12#\n" +
-	"\rresource_name\x18\x02 \x01(\tR\fresourceName\x12E\n" +
-	"\rresource_type\x18\x03 \x01(\x0e2 .matrixhub.v1alpha1.ResourceTypeR\fresourceType\x120\n" +
+	"\rresource_name\x18\x02 \x01(\tR\fresourceName\x12G\n" +
+	"\x0eresource_types\x18\x03 \x03(\x0e2 .matrixhub.v1alpha1.ResourceTypeR\rresourceTypes\x120\n" +
 	"\x14target_resource_name\x18\x04 \x01(\tR\x12targetResourceName\x12E\n" +
-	"\x0fsource_registry\x18\x05 \x01(\v2\x1c.matrixhub.v1alpha1.RegistryR\x0esourceRegistry\"\xa3\x02\n" +
+	"\x0fsource_registry\x18\x05 \x01(\v2\x1c.matrixhub.v1alpha1.RegistryR\x0esourceRegistry\"\xa5\x02\n" +
 	"\x0ePushBasePolicy\x12#\n" +
-	"\rresource_name\x18\x01 \x01(\tR\fresourceName\x12E\n" +
-	"\rresource_type\x18\x02 \x01(\x0e2 .matrixhub.v1alpha1.ResourceTypeR\fresourceType\x12,\n" +
+	"\rresource_name\x18\x01 \x01(\tR\fresourceName\x12G\n" +
+	"\x0eresource_types\x18\x02 \x03(\x0e2 .matrixhub.v1alpha1.ResourceTypeR\rresourceTypes\x12,\n" +
 	"\x12target_registry_id\x18\x03 \x01(\rR\x10targetRegistryId\x120\n" +
 	"\x14target_resource_name\x18\x04 \x01(\tR\x12targetResourceName\x12E\n" +
 	"\x0ftarget_registry\x18\x05 \x01(\v2\x1c.matrixhub.v1alpha1.RegistryR\x0etargetRegistry\"\xf3\x03\n" +
@@ -1567,7 +1655,11 @@ const file_v1alpha1_replication_proto_rawDesc = "" +
 	"\freplications\x18\x01 \x03(\v2#.matrixhub.v1alpha1.ReplicationItemR\freplications\x12>\n" +
 	"\n" +
 	"pagination\x18\x02 \x01(\v2\x1e.matrixhub.v1alpha1.PaginationR\n" +
-	"pagination\"J\n" +
+	"pagination\">\n" +
+	"\x15GetReplicationRequest\x12%\n" +
+	"\x0ereplication_id\x18\x01 \x01(\x05R\rreplicationId\"_\n" +
+	"\x16GetReplicationResponse\x12E\n" +
+	"\vreplication\x18\x01 \x01(\v2#.matrixhub.v1alpha1.ReplicationItemR\vreplication\"J\n" +
 	"!CreateReplicationExecutionRequest\x12%\n" +
 	"\x0ereplication_id\x18\x01 \x01(\x05R\rreplicationId\"4\n" +
 	"\"CreateReplicationExecutionResponse\x12\x0e\n" +
@@ -1617,10 +1709,10 @@ const file_v1alpha1_replication_proto_rawDesc = "" +
 	"$REPLICATION_EXECUTION_STATUS_RUNNING\x10\x01\x12*\n" +
 	"&REPLICATION_EXECUTION_STATUS_SUCCEEDED\x10\x02\x12'\n" +
 	"#REPLICATION_EXECUTION_STATUS_FAILED\x10\x03\x12(\n" +
-	"$REPLICATION_EXECUTION_STATUS_STOPPED\x10\x042\x83\n" +
-	"\n" +
+	"$REPLICATION_EXECUTION_STATUS_STOPPED\x10\x042\xa2\v\n" +
 	"\vReplication\x12\x91\x01\n" +
-	"\x10ListReplications\x12+.matrixhub.v1alpha1.ListReplicationsRequest\x1a,.matrixhub.v1alpha1.ListReplicationsResponse\"\"\x82\xd3\xe4\x93\x02\x1c\x12\x1a/api/v1alpha1/replications\x12\x97\x01\n" +
+	"\x10ListReplications\x12+.matrixhub.v1alpha1.ListReplicationsRequest\x1a,.matrixhub.v1alpha1.ListReplicationsResponse\"\"\x82\xd3\xe4\x93\x02\x1c\x12\x1a/api/v1alpha1/replications\x12\x9c\x01\n" +
+	"\x0eGetReplication\x12).matrixhub.v1alpha1.GetReplicationRequest\x1a*.matrixhub.v1alpha1.GetReplicationResponse\"3\x82\xd3\xe4\x93\x02-\x12+/api/v1alpha1/replications/{replication_id}\x12\x97\x01\n" +
 	"\x11CreateReplication\x12,.matrixhub.v1alpha1.CreateReplicationRequest\x1a-.matrixhub.v1alpha1.CreateReplicationResponse\"%\x82\xd3\xe4\x93\x02\x1f:\x01*\"\x1a/api/v1alpha1/replications\x12\xa8\x01\n" +
 	"\x11UpdateReplication\x12,.matrixhub.v1alpha1.UpdateReplicationRequest\x1a-.matrixhub.v1alpha1.UpdateReplicationResponse\"6\x82\xd3\xe4\x93\x020:\x01*\x1a+/api/v1alpha1/replications/{replication_id}\x12\xa5\x01\n" +
 	"\x11DeleteReplication\x12,.matrixhub.v1alpha1.DeleteReplicationRequest\x1a-.matrixhub.v1alpha1.DeleteReplicationResponse\"3\x82\xd3\xe4\x93\x02-*+/api/v1alpha1/replications/{replication_id}\x12\xcb\x01\n" +
@@ -1641,7 +1733,7 @@ func file_v1alpha1_replication_proto_rawDescGZIP() []byte {
 }
 
 var file_v1alpha1_replication_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_v1alpha1_replication_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_v1alpha1_replication_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
 var file_v1alpha1_replication_proto_goTypes = []any{
 	(ReplicationPolicyType)(0),                 // 0: matrixhub.v1alpha1.ReplicationPolicyType
 	(ResourceType)(0),                          // 1: matrixhub.v1alpha1.ResourceType
@@ -1658,21 +1750,23 @@ var file_v1alpha1_replication_proto_goTypes = []any{
 	(*DeleteReplicationResponse)(nil),          // 12: matrixhub.v1alpha1.DeleteReplicationResponse
 	(*ListReplicationsRequest)(nil),            // 13: matrixhub.v1alpha1.ListReplicationsRequest
 	(*ListReplicationsResponse)(nil),           // 14: matrixhub.v1alpha1.ListReplicationsResponse
-	(*CreateReplicationExecutionRequest)(nil),  // 15: matrixhub.v1alpha1.CreateReplicationExecutionRequest
-	(*CreateReplicationExecutionResponse)(nil), // 16: matrixhub.v1alpha1.CreateReplicationExecutionResponse
-	(*ReplicationExecution)(nil),               // 17: matrixhub.v1alpha1.ReplicationExecution
-	(*ListReplicationExecutionsRequest)(nil),   // 18: matrixhub.v1alpha1.ListReplicationExecutionsRequest
-	(*ListReplicationExecutionsResponse)(nil),  // 19: matrixhub.v1alpha1.ListReplicationExecutionsResponse
-	(*StopReplicationExecutionRequest)(nil),    // 20: matrixhub.v1alpha1.StopReplicationExecutionRequest
-	(*StopReplicationExecutionResponse)(nil),   // 21: matrixhub.v1alpha1.StopReplicationExecutionResponse
-	(*Registry)(nil),                           // 22: matrixhub.v1alpha1.Registry
-	(*Pagination)(nil),                         // 23: matrixhub.v1alpha1.Pagination
+	(*GetReplicationRequest)(nil),              // 15: matrixhub.v1alpha1.GetReplicationRequest
+	(*GetReplicationResponse)(nil),             // 16: matrixhub.v1alpha1.GetReplicationResponse
+	(*CreateReplicationExecutionRequest)(nil),  // 17: matrixhub.v1alpha1.CreateReplicationExecutionRequest
+	(*CreateReplicationExecutionResponse)(nil), // 18: matrixhub.v1alpha1.CreateReplicationExecutionResponse
+	(*ReplicationExecution)(nil),               // 19: matrixhub.v1alpha1.ReplicationExecution
+	(*ListReplicationExecutionsRequest)(nil),   // 20: matrixhub.v1alpha1.ListReplicationExecutionsRequest
+	(*ListReplicationExecutionsResponse)(nil),  // 21: matrixhub.v1alpha1.ListReplicationExecutionsResponse
+	(*StopReplicationExecutionRequest)(nil),    // 22: matrixhub.v1alpha1.StopReplicationExecutionRequest
+	(*StopReplicationExecutionResponse)(nil),   // 23: matrixhub.v1alpha1.StopReplicationExecutionResponse
+	(*Registry)(nil),                           // 24: matrixhub.v1alpha1.Registry
+	(*Pagination)(nil),                         // 25: matrixhub.v1alpha1.Pagination
 }
 var file_v1alpha1_replication_proto_depIdxs = []int32{
-	1,  // 0: matrixhub.v1alpha1.PullBasePolicy.resource_type:type_name -> matrixhub.v1alpha1.ResourceType
-	22, // 1: matrixhub.v1alpha1.PullBasePolicy.source_registry:type_name -> matrixhub.v1alpha1.Registry
-	1,  // 2: matrixhub.v1alpha1.PushBasePolicy.resource_type:type_name -> matrixhub.v1alpha1.ResourceType
-	22, // 3: matrixhub.v1alpha1.PushBasePolicy.target_registry:type_name -> matrixhub.v1alpha1.Registry
+	1,  // 0: matrixhub.v1alpha1.PullBasePolicy.resource_types:type_name -> matrixhub.v1alpha1.ResourceType
+	24, // 1: matrixhub.v1alpha1.PullBasePolicy.source_registry:type_name -> matrixhub.v1alpha1.Registry
+	1,  // 2: matrixhub.v1alpha1.PushBasePolicy.resource_types:type_name -> matrixhub.v1alpha1.ResourceType
+	24, // 3: matrixhub.v1alpha1.PushBasePolicy.target_registry:type_name -> matrixhub.v1alpha1.Registry
 	0,  // 4: matrixhub.v1alpha1.ReplicationItem.policy_type:type_name -> matrixhub.v1alpha1.ReplicationPolicyType
 	2,  // 5: matrixhub.v1alpha1.ReplicationItem.trigger_type:type_name -> matrixhub.v1alpha1.triggerType
 	4,  // 6: matrixhub.v1alpha1.ReplicationItem.pull_base_policy:type_name -> matrixhub.v1alpha1.PullBasePolicy
@@ -1688,31 +1782,34 @@ var file_v1alpha1_replication_proto_depIdxs = []int32{
 	6,  // 16: matrixhub.v1alpha1.UpdateReplicationResponse.replication:type_name -> matrixhub.v1alpha1.ReplicationItem
 	6,  // 17: matrixhub.v1alpha1.DeleteReplicationResponse.replication:type_name -> matrixhub.v1alpha1.ReplicationItem
 	6,  // 18: matrixhub.v1alpha1.ListReplicationsResponse.replications:type_name -> matrixhub.v1alpha1.ReplicationItem
-	23, // 19: matrixhub.v1alpha1.ListReplicationsResponse.pagination:type_name -> matrixhub.v1alpha1.Pagination
-	2,  // 20: matrixhub.v1alpha1.ReplicationExecution.trigger_type:type_name -> matrixhub.v1alpha1.triggerType
-	3,  // 21: matrixhub.v1alpha1.ReplicationExecution.status:type_name -> matrixhub.v1alpha1.ReplicationExecutionStatus
-	17, // 22: matrixhub.v1alpha1.ListReplicationExecutionsResponse.executions:type_name -> matrixhub.v1alpha1.ReplicationExecution
-	23, // 23: matrixhub.v1alpha1.ListReplicationExecutionsResponse.pagination:type_name -> matrixhub.v1alpha1.Pagination
-	17, // 24: matrixhub.v1alpha1.StopReplicationExecutionResponse.execution:type_name -> matrixhub.v1alpha1.ReplicationExecution
-	13, // 25: matrixhub.v1alpha1.Replication.ListReplications:input_type -> matrixhub.v1alpha1.ListReplicationsRequest
-	7,  // 26: matrixhub.v1alpha1.Replication.CreateReplication:input_type -> matrixhub.v1alpha1.CreateReplicationRequest
-	9,  // 27: matrixhub.v1alpha1.Replication.UpdateReplication:input_type -> matrixhub.v1alpha1.UpdateReplicationRequest
-	11, // 28: matrixhub.v1alpha1.Replication.DeleteReplication:input_type -> matrixhub.v1alpha1.DeleteReplicationRequest
-	15, // 29: matrixhub.v1alpha1.Replication.CreateReplicationExecution:input_type -> matrixhub.v1alpha1.CreateReplicationExecutionRequest
-	18, // 30: matrixhub.v1alpha1.Replication.ListReplicationExecutions:input_type -> matrixhub.v1alpha1.ListReplicationExecutionsRequest
-	20, // 31: matrixhub.v1alpha1.Replication.StopReplicationExecution:input_type -> matrixhub.v1alpha1.StopReplicationExecutionRequest
-	14, // 32: matrixhub.v1alpha1.Replication.ListReplications:output_type -> matrixhub.v1alpha1.ListReplicationsResponse
-	8,  // 33: matrixhub.v1alpha1.Replication.CreateReplication:output_type -> matrixhub.v1alpha1.CreateReplicationResponse
-	10, // 34: matrixhub.v1alpha1.Replication.UpdateReplication:output_type -> matrixhub.v1alpha1.UpdateReplicationResponse
-	12, // 35: matrixhub.v1alpha1.Replication.DeleteReplication:output_type -> matrixhub.v1alpha1.DeleteReplicationResponse
-	16, // 36: matrixhub.v1alpha1.Replication.CreateReplicationExecution:output_type -> matrixhub.v1alpha1.CreateReplicationExecutionResponse
-	19, // 37: matrixhub.v1alpha1.Replication.ListReplicationExecutions:output_type -> matrixhub.v1alpha1.ListReplicationExecutionsResponse
-	21, // 38: matrixhub.v1alpha1.Replication.StopReplicationExecution:output_type -> matrixhub.v1alpha1.StopReplicationExecutionResponse
-	32, // [32:39] is the sub-list for method output_type
-	25, // [25:32] is the sub-list for method input_type
-	25, // [25:25] is the sub-list for extension type_name
-	25, // [25:25] is the sub-list for extension extendee
-	0,  // [0:25] is the sub-list for field type_name
+	25, // 19: matrixhub.v1alpha1.ListReplicationsResponse.pagination:type_name -> matrixhub.v1alpha1.Pagination
+	6,  // 20: matrixhub.v1alpha1.GetReplicationResponse.replication:type_name -> matrixhub.v1alpha1.ReplicationItem
+	2,  // 21: matrixhub.v1alpha1.ReplicationExecution.trigger_type:type_name -> matrixhub.v1alpha1.triggerType
+	3,  // 22: matrixhub.v1alpha1.ReplicationExecution.status:type_name -> matrixhub.v1alpha1.ReplicationExecutionStatus
+	19, // 23: matrixhub.v1alpha1.ListReplicationExecutionsResponse.executions:type_name -> matrixhub.v1alpha1.ReplicationExecution
+	25, // 24: matrixhub.v1alpha1.ListReplicationExecutionsResponse.pagination:type_name -> matrixhub.v1alpha1.Pagination
+	19, // 25: matrixhub.v1alpha1.StopReplicationExecutionResponse.execution:type_name -> matrixhub.v1alpha1.ReplicationExecution
+	13, // 26: matrixhub.v1alpha1.Replication.ListReplications:input_type -> matrixhub.v1alpha1.ListReplicationsRequest
+	15, // 27: matrixhub.v1alpha1.Replication.GetReplication:input_type -> matrixhub.v1alpha1.GetReplicationRequest
+	7,  // 28: matrixhub.v1alpha1.Replication.CreateReplication:input_type -> matrixhub.v1alpha1.CreateReplicationRequest
+	9,  // 29: matrixhub.v1alpha1.Replication.UpdateReplication:input_type -> matrixhub.v1alpha1.UpdateReplicationRequest
+	11, // 30: matrixhub.v1alpha1.Replication.DeleteReplication:input_type -> matrixhub.v1alpha1.DeleteReplicationRequest
+	17, // 31: matrixhub.v1alpha1.Replication.CreateReplicationExecution:input_type -> matrixhub.v1alpha1.CreateReplicationExecutionRequest
+	20, // 32: matrixhub.v1alpha1.Replication.ListReplicationExecutions:input_type -> matrixhub.v1alpha1.ListReplicationExecutionsRequest
+	22, // 33: matrixhub.v1alpha1.Replication.StopReplicationExecution:input_type -> matrixhub.v1alpha1.StopReplicationExecutionRequest
+	14, // 34: matrixhub.v1alpha1.Replication.ListReplications:output_type -> matrixhub.v1alpha1.ListReplicationsResponse
+	16, // 35: matrixhub.v1alpha1.Replication.GetReplication:output_type -> matrixhub.v1alpha1.GetReplicationResponse
+	8,  // 36: matrixhub.v1alpha1.Replication.CreateReplication:output_type -> matrixhub.v1alpha1.CreateReplicationResponse
+	10, // 37: matrixhub.v1alpha1.Replication.UpdateReplication:output_type -> matrixhub.v1alpha1.UpdateReplicationResponse
+	12, // 38: matrixhub.v1alpha1.Replication.DeleteReplication:output_type -> matrixhub.v1alpha1.DeleteReplicationResponse
+	18, // 39: matrixhub.v1alpha1.Replication.CreateReplicationExecution:output_type -> matrixhub.v1alpha1.CreateReplicationExecutionResponse
+	21, // 40: matrixhub.v1alpha1.Replication.ListReplicationExecutions:output_type -> matrixhub.v1alpha1.ListReplicationExecutionsResponse
+	23, // 41: matrixhub.v1alpha1.Replication.StopReplicationExecution:output_type -> matrixhub.v1alpha1.StopReplicationExecutionResponse
+	34, // [34:42] is the sub-list for method output_type
+	26, // [26:34] is the sub-list for method input_type
+	26, // [26:26] is the sub-list for extension type_name
+	26, // [26:26] is the sub-list for extension extendee
+	0,  // [0:26] is the sub-list for field type_name
 }
 
 func init() { file_v1alpha1_replication_proto_init() }
@@ -1740,7 +1837,7 @@ func file_v1alpha1_replication_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_v1alpha1_replication_proto_rawDesc), len(file_v1alpha1_replication_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   18,
+			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/go/v1alpha1/replication.pb.gw.go
+++ b/api/go/v1alpha1/replication.pb.gw.go
@@ -70,6 +70,45 @@ func local_request_Replication_ListReplications_0(ctx context.Context, marshaler
 	return msg, metadata, err
 }
 
+func request_Replication_GetReplication_0(ctx context.Context, marshaler runtime.Marshaler, client ReplicationClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetReplicationRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["replication_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "replication_id")
+	}
+	protoReq.ReplicationId, err = runtime.Int32(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "replication_id", err)
+	}
+	msg, err := client.GetReplication(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_Replication_GetReplication_0(ctx context.Context, marshaler runtime.Marshaler, server ReplicationServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetReplicationRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["replication_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "replication_id")
+	}
+	protoReq.ReplicationId, err = runtime.Int32(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "replication_id", err)
+	}
+	msg, err := server.GetReplication(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_Replication_CreateReplication_0(ctx context.Context, marshaler runtime.Marshaler, client ReplicationClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq CreateReplicationRequest
@@ -354,6 +393,26 @@ func RegisterReplicationHandlerServer(ctx context.Context, mux *runtime.ServeMux
 		}
 		forward_Replication_ListReplications_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_Replication_GetReplication_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/matrixhub.v1alpha1.Replication/GetReplication", runtime.WithHTTPPathPattern("/api/v1alpha1/replications/{replication_id}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Replication_GetReplication_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_Replication_GetReplication_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_Replication_CreateReplication_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -531,6 +590,23 @@ func RegisterReplicationHandlerClient(ctx context.Context, mux *runtime.ServeMux
 		}
 		forward_Replication_ListReplications_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_Replication_GetReplication_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/matrixhub.v1alpha1.Replication/GetReplication", runtime.WithHTTPPathPattern("/api/v1alpha1/replications/{replication_id}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Replication_GetReplication_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_Replication_GetReplication_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_Replication_CreateReplication_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -638,6 +714,7 @@ func RegisterReplicationHandlerClient(ctx context.Context, mux *runtime.ServeMux
 
 var (
 	pattern_Replication_ListReplications_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1alpha1", "replications"}, ""))
+	pattern_Replication_GetReplication_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1alpha1", "replications", "replication_id"}, ""))
 	pattern_Replication_CreateReplication_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1alpha1", "replications"}, ""))
 	pattern_Replication_UpdateReplication_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1alpha1", "replications", "replication_id"}, ""))
 	pattern_Replication_DeleteReplication_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1alpha1", "replications", "replication_id"}, ""))
@@ -648,6 +725,7 @@ var (
 
 var (
 	forward_Replication_ListReplications_0           = runtime.ForwardResponseMessage
+	forward_Replication_GetReplication_0             = runtime.ForwardResponseMessage
 	forward_Replication_CreateReplication_0          = runtime.ForwardResponseMessage
 	forward_Replication_UpdateReplication_0          = runtime.ForwardResponseMessage
 	forward_Replication_DeleteReplication_0          = runtime.ForwardResponseMessage

--- a/api/go/v1alpha1/replication.pb.validate.go
+++ b/api/go/v1alpha1/replication.pb.validate.go
@@ -61,8 +61,6 @@ func (m *PullBasePolicy) validate(all bool) error {
 
 	// no validation rules for ResourceName
 
-	// no validation rules for ResourceType
-
 	// no validation rules for TargetResourceName
 
 	if all {
@@ -195,8 +193,6 @@ func (m *PushBasePolicy) validate(all bool) error {
 	var errors []error
 
 	// no validation rules for ResourceName
-
-	// no validation rules for ResourceType
 
 	// no validation rules for TargetRegistryId
 
@@ -1685,6 +1681,241 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = ListReplicationsResponseValidationError{}
+
+// Validate checks the field values on GetReplicationRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *GetReplicationRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on GetReplicationRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// GetReplicationRequestMultiError, or nil if none found.
+func (m *GetReplicationRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *GetReplicationRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for ReplicationId
+
+	if len(errors) > 0 {
+		return GetReplicationRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// GetReplicationRequestMultiError is an error wrapping multiple validation
+// errors returned by GetReplicationRequest.ValidateAll() if the designated
+// constraints aren't met.
+type GetReplicationRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m GetReplicationRequestMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m GetReplicationRequestMultiError) AllErrors() []error { return m }
+
+// GetReplicationRequestValidationError is the validation error returned by
+// GetReplicationRequest.Validate if the designated constraints aren't met.
+type GetReplicationRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e GetReplicationRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e GetReplicationRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e GetReplicationRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e GetReplicationRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e GetReplicationRequestValidationError) ErrorName() string {
+	return "GetReplicationRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e GetReplicationRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sGetReplicationRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = GetReplicationRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = GetReplicationRequestValidationError{}
+
+// Validate checks the field values on GetReplicationResponse with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *GetReplicationResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on GetReplicationResponse with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// GetReplicationResponseMultiError, or nil if none found.
+func (m *GetReplicationResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *GetReplicationResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if all {
+		switch v := interface{}(m.GetReplication()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, GetReplicationResponseValidationError{
+					field:  "Replication",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, GetReplicationResponseValidationError{
+					field:  "Replication",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetReplication()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return GetReplicationResponseValidationError{
+				field:  "Replication",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return GetReplicationResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// GetReplicationResponseMultiError is an error wrapping multiple validation
+// errors returned by GetReplicationResponse.ValidateAll() if the designated
+// constraints aren't met.
+type GetReplicationResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m GetReplicationResponseMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m GetReplicationResponseMultiError) AllErrors() []error { return m }
+
+// GetReplicationResponseValidationError is the validation error returned by
+// GetReplicationResponse.Validate if the designated constraints aren't met.
+type GetReplicationResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e GetReplicationResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e GetReplicationResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e GetReplicationResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e GetReplicationResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e GetReplicationResponseValidationError) ErrorName() string {
+	return "GetReplicationResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e GetReplicationResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sGetReplicationResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = GetReplicationResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = GetReplicationResponseValidationError{}
 
 // Validate checks the field values on CreateReplicationExecutionRequest with
 // the rules defined in the proto definition for this message. If any rules

--- a/api/go/v1alpha1/replication_grpc.pb.go
+++ b/api/go/v1alpha1/replication_grpc.pb.go
@@ -20,6 +20,7 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	Replication_ListReplications_FullMethodName           = "/matrixhub.v1alpha1.Replication/ListReplications"
+	Replication_GetReplication_FullMethodName             = "/matrixhub.v1alpha1.Replication/GetReplication"
 	Replication_CreateReplication_FullMethodName          = "/matrixhub.v1alpha1.Replication/CreateReplication"
 	Replication_UpdateReplication_FullMethodName          = "/matrixhub.v1alpha1.Replication/UpdateReplication"
 	Replication_DeleteReplication_FullMethodName          = "/matrixhub.v1alpha1.Replication/DeleteReplication"
@@ -34,6 +35,8 @@ const (
 type ReplicationClient interface {
 	// ListReplications lists all replications.
 	ListReplications(ctx context.Context, in *ListReplicationsRequest, opts ...grpc.CallOption) (*ListReplicationsResponse, error)
+	// GetReplication gets a replication by id.
+	GetReplication(ctx context.Context, in *GetReplicationRequest, opts ...grpc.CallOption) (*GetReplicationResponse, error)
 	// CreateReplication creates a new replication.
 	CreateReplication(ctx context.Context, in *CreateReplicationRequest, opts ...grpc.CallOption) (*CreateReplicationResponse, error)
 	// UpdateReplication updates a replication.
@@ -60,6 +63,16 @@ func (c *replicationClient) ListReplications(ctx context.Context, in *ListReplic
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ListReplicationsResponse)
 	err := c.cc.Invoke(ctx, Replication_ListReplications_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *replicationClient) GetReplication(ctx context.Context, in *GetReplicationRequest, opts ...grpc.CallOption) (*GetReplicationResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetReplicationResponse)
+	err := c.cc.Invoke(ctx, Replication_GetReplication_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -132,6 +145,8 @@ func (c *replicationClient) StopReplicationExecution(ctx context.Context, in *St
 type ReplicationServer interface {
 	// ListReplications lists all replications.
 	ListReplications(context.Context, *ListReplicationsRequest) (*ListReplicationsResponse, error)
+	// GetReplication gets a replication by id.
+	GetReplication(context.Context, *GetReplicationRequest) (*GetReplicationResponse, error)
 	// CreateReplication creates a new replication.
 	CreateReplication(context.Context, *CreateReplicationRequest) (*CreateReplicationResponse, error)
 	// UpdateReplication updates a replication.
@@ -155,6 +170,9 @@ type UnimplementedReplicationServer struct{}
 
 func (UnimplementedReplicationServer) ListReplications(context.Context, *ListReplicationsRequest) (*ListReplicationsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListReplications not implemented")
+}
+func (UnimplementedReplicationServer) GetReplication(context.Context, *GetReplicationRequest) (*GetReplicationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetReplication not implemented")
 }
 func (UnimplementedReplicationServer) CreateReplication(context.Context, *CreateReplicationRequest) (*CreateReplicationResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateReplication not implemented")
@@ -208,6 +226,24 @@ func _Replication_ListReplications_Handler(srv interface{}, ctx context.Context,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ReplicationServer).ListReplications(ctx, req.(*ListReplicationsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Replication_GetReplication_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetReplicationRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ReplicationServer).GetReplication(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Replication_GetReplication_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ReplicationServer).GetReplication(ctx, req.(*GetReplicationRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -330,6 +366,10 @@ var Replication_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListReplications",
 			Handler:    _Replication_ListReplications_Handler,
+		},
+		{
+			MethodName: "GetReplication",
+			Handler:    _Replication_GetReplication_Handler,
 		},
 		{
 			MethodName: "CreateReplication",

--- a/api/openapiv2/v1alpha1/replication.swagger.json
+++ b/api/openapiv2/v1alpha1/replication.swagger.json
@@ -93,6 +93,36 @@
       }
     },
     "/api/v1alpha1/replications/{replicationId}": {
+      "get": {
+        "summary": "GetReplication gets a replication by id.",
+        "operationId": "Replication_GetReplication",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1alpha1GetReplicationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "replicationId",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "tags": [
+          "Replication"
+        ]
+      },
       "delete": {
         "summary": "DeleteReplication deletes a replication.",
         "operationId": "Replication_DeleteReplication",
@@ -398,6 +428,14 @@
         }
       }
     },
+    "v1alpha1GetReplicationResponse": {
+      "type": "object",
+      "properties": {
+        "replication": {
+          "$ref": "#/definitions/v1alpha1ReplicationItem"
+        }
+      }
+    },
     "v1alpha1ListReplicationExecutionsResponse": {
       "type": "object",
       "properties": {
@@ -464,8 +502,11 @@
         "resourceName": {
           "type": "string"
         },
-        "resourceType": {
-          "$ref": "#/definitions/v1alpha1ResourceType"
+        "resourceTypes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v1alpha1ResourceType"
+          }
         },
         "targetResourceName": {
           "type": "string"
@@ -482,8 +523,11 @@
         "resourceName": {
           "type": "string"
         },
-        "resourceType": {
-          "$ref": "#/definitions/v1alpha1ResourceType"
+        "resourceTypes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v1alpha1ResourceType"
+          }
         },
         "targetRegistryId": {
           "type": "integer",

--- a/api/proto/v1alpha1/replication.proto
+++ b/api/proto/v1alpha1/replication.proto
@@ -15,6 +15,12 @@ service Replication {
       get: "/api/v1alpha1/replications"
     };
   }
+  // GetReplication gets a replication by id.
+  rpc GetReplication(GetReplicationRequest) returns (GetReplicationResponse) {
+    option (google.api.http) = {
+      get: "/api/v1alpha1/replications/{replication_id}"
+    };
+  }
   // CreateReplication creates a new replication.
   rpc CreateReplication(CreateReplicationRequest) returns (CreateReplicationResponse) {
     option (google.api.http) = {
@@ -71,7 +77,7 @@ enum ResourceType {
 message PullBasePolicy {
   uint32 source_registry_id = 1;
   string resource_name = 2;
-  ResourceType resource_type = 3;
+  repeated ResourceType resource_types = 3;
   string target_resource_name = 4;
   // post or put do not require this field.
   Registry source_registry = 5;
@@ -79,7 +85,7 @@ message PullBasePolicy {
 
 message PushBasePolicy {
   string resource_name = 1;
-  ResourceType resource_type = 2;
+  repeated ResourceType resource_types = 2;
   uint32 target_registry_id = 3;
   string target_resource_name = 4;
   // post or put do not require this field.
@@ -167,6 +173,14 @@ message ListReplicationsRequest {
 message ListReplicationsResponse {
   repeated ReplicationItem replications = 1;
   Pagination pagination = 2;
+}
+
+message GetReplicationRequest {
+  int32 replication_id = 1;
+}
+
+message GetReplicationResponse {
+  ReplicationItem replication = 1;
 }
 
 message CreateReplicationExecutionRequest {

--- a/api/ts/v1alpha1/replication.pb.ts
+++ b/api/ts/v1alpha1/replication.pb.ts
@@ -47,14 +47,14 @@ export enum ReplicationExecutionStatus {
 export type PullBasePolicy = {
   sourceRegistryId?: number
   resourceName?: string
-  resourceType?: ResourceType
+  resourceTypes?: ResourceType[]
   targetResourceName?: string
   sourceRegistry?: MatrixhubV1alpha1Registry.Registry
 }
 
 export type PushBasePolicy = {
   resourceName?: string
-  resourceType?: ResourceType
+  resourceTypes?: ResourceType[]
   targetRegistryId?: number
   targetResourceName?: string
   targetRegistry?: MatrixhubV1alpha1Registry.Registry
@@ -129,6 +129,14 @@ export type ListReplicationsResponse = {
   pagination?: MatrixhubV1alpha1Utils.Pagination
 }
 
+export type GetReplicationRequest = {
+  replicationId?: number
+}
+
+export type GetReplicationResponse = {
+  replication?: ReplicationItem
+}
+
 export type CreateReplicationExecutionRequest = {
   replicationId?: number
 }
@@ -172,6 +180,9 @@ export type StopReplicationExecutionResponse = {
 export class Replication {
   static ListReplications(req: ListReplicationsRequest, initReq?: fm.InitReq): Promise<ListReplicationsResponse> {
     return fm.fetchReq<ListReplicationsRequest, ListReplicationsResponse>(`/api/v1alpha1/replications?${fm.renderURLSearchParams(req, [])}`, {...initReq, method: "GET"})
+  }
+  static GetReplication(req: GetReplicationRequest, initReq?: fm.InitReq): Promise<GetReplicationResponse> {
+    return fm.fetchReq<GetReplicationRequest, GetReplicationResponse>(`/api/v1alpha1/replications/${req["replicationId"]}?${fm.renderURLSearchParams(req, ["replicationId"])}`, {...initReq, method: "GET"})
   }
   static CreateReplication(req: CreateReplicationRequest, initReq?: fm.InitReq): Promise<CreateReplicationResponse> {
     return fm.fetchReq<CreateReplicationRequest, CreateReplicationResponse>(`/api/v1alpha1/replications`, {...initReq, method: "POST", body: JSON.stringify(req, fm.replacer)})


### PR DESCRIPTION
- Change resource_type field from single enum to repeated ResourceType array
- Add GetReplication RPC for fetching replication details
- Add GetReplicationRequest and GetReplicationResponse messages
- Regenerate proto files for Go, TypeScript and OpenAPI

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
 https://github.com/matrixhub-ai/matrixhub/issues/138
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```