### PR TITLE
feat: add ui static file serving with configurable staticDir

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -16,3 +16,6 @@ database:
 
 apiServer:
   port: 3001
+
+ui:
+  staticDir: /app

--- a/deploy/charts/matrixhub/templates/apiserver-configmap.yaml
+++ b/deploy/charts/matrixhub/templates/apiserver-configmap.yaml
@@ -21,3 +21,5 @@ data:
     migrationPath: /etc/matrixhub/migrations
     apiServer:
       port: {{ .Values.apiserver.port }}
+    ui:
+      staticDir: /app

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -291,18 +293,24 @@ func (server *APIServer) registerRoutersAndHandlers() {
 	// register routers
 	server.engine.Any("/api/v1alpha1/*any", gin.WrapF(server.gatewayMux.ServeHTTP))
 
-	// serve frontend static files
-	server.engine.Static("/assets", "/app/assets")
+	// serve ui static files if staticDir is configured
+	staticDir := server.config.UI.StaticDir
+	if staticDir != "" {
+		server.engine.Static("/assets", filepath.Join(staticDir, "assets"))
+	}
 
 	// SPA fallback - serve index.html for all non-API routes
 	server.engine.NoRoute(func(c *gin.Context) {
-		// If the request is for an API route that doesn't exist, return 404
-		if len(c.Request.URL.Path) >= 4 && c.Request.URL.Path[:4] == "/api" {
+		if strings.HasPrefix(c.Request.URL.Path, "/api") {
 			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 			return
 		}
-		// For all other routes, serve index.html (SPA routing)
-		c.File("/app/index.html")
+		if staticDir != "" {
+			c.File(filepath.Join(staticDir, "index.html"))
+			return
+		}
+		// If staticDir is not configured, return 404 for non-API routes
+		c.JSON(http.StatusNotFound, gin.H{"error": "frontend not configured"})
 	})
 
 	options := &handler.ServerOptions{

--- a/internal/infra/config/config.go
+++ b/internal/infra/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	Debug         bool             `yaml:"debug"`
 	Log           log.Config       `yaml:"log"`
 	APIServer     *APIServerConfig `yaml:"apiServer" validate:"required"`
+	UI            UIConfig         `yaml:"ui"`
 	MigrationPath string           `yaml:"migrationPath" validate:"required"`
 
 	DataDir string `yaml:"dataDir" validate:"required"`
@@ -38,6 +39,10 @@ type Config struct {
 
 type APIServerConfig struct {
 	Port int `yaml:"port" validate:"required"`
+}
+
+type UIConfig struct {
+	StaticDir string `yaml:"staticDir"`
 }
 
 func Init(configPath, sqlPath string) (*Config, error) {


### PR DESCRIPTION
Add ui.staticDir config to serve static UI files from a configurable directory. When staticDir is set, the apiserver serves /assets and index.html from that directory; otherwise returns 404 for non-API routes.

This change:
- Adds UIConfig to config struct with staticDir field
- Updates apiserver to conditionally serve static files
- Updates helm chart configmap with ui.staticDir


#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
#240

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```