### PR TITLE
fix(ui labeler): fix no permission when forked pr

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,8 +1,7 @@
 name: PR Labeler
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  - pull_request_target
 
 permissions:
   contents: read
@@ -12,4 +11,5 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/checkout@v4
+      - uses: actions/labeler@v6


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix the `no permission` error when forked repo pr

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```