### PR TITLE
feat(api): implement GetModelBlob

### DIFF
--- a/api/go/v1alpha1/dataset.pb.go
+++ b/api/go/v1alpha1/dataset.pb.go
@@ -839,7 +839,7 @@ func (x *GetDatasetTreeRequest) GetPath() string {
 
 type GetDatasetTreeResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Items         []*Files               `protobuf:"bytes,1,rep,name=items,proto3" json:"items,omitempty"`
+	Items         []*File                `protobuf:"bytes,1,rep,name=items,proto3" json:"items,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -874,7 +874,7 @@ func (*GetDatasetTreeResponse) Descriptor() ([]byte, []int) {
 	return file_v1alpha1_dataset_proto_rawDescGZIP(), []int{15}
 }
 
-func (x *GetDatasetTreeResponse) GetItems() []*Files {
+func (x *GetDatasetTreeResponse) GetItems() []*File {
 	if x != nil {
 		return x.Items
 	}
@@ -1190,9 +1190,9 @@ const file_v1alpha1_dataset_proto_rawDesc = "" +
 	"\aproject\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\aproject\x12\x1b\n" +
 	"\x04name\x18\x02 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\x04name\x12\x1a\n" +
 	"\brevision\x18\x03 \x01(\tR\brevision\x12\x12\n" +
-	"\x04path\x18\x04 \x01(\tR\x04path\"I\n" +
-	"\x16GetDatasetTreeResponse\x12/\n" +
-	"\x05items\x18\x01 \x03(\v2\x19.matrixhub.v1alpha1.FilesR\x05items\"\x87\x01\n" +
+	"\x04path\x18\x04 \x01(\tR\x04path\"H\n" +
+	"\x16GetDatasetTreeResponse\x12.\n" +
+	"\x05items\x18\x01 \x03(\v2\x18.matrixhub.v1alpha1.FileR\x05items\"\x87\x01\n" +
 	"\x15GetDatasetBlobRequest\x12!\n" +
 	"\aproject\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\aproject\x12\x1b\n" +
 	"\x04name\x18\x02 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\x04name\x12\x1a\n" +
@@ -1268,7 +1268,7 @@ var file_v1alpha1_dataset_proto_goTypes = []any{
 	(*Pagination)(nil),                    // 20: matrixhub.v1alpha1.Pagination
 	(*Revisions)(nil),                     // 21: matrixhub.v1alpha1.Revisions
 	(*Commit)(nil),                        // 22: matrixhub.v1alpha1.Commit
-	(*Files)(nil),                         // 23: matrixhub.v1alpha1.Files
+	(*File)(nil),                          // 23: matrixhub.v1alpha1.File
 	(*CloneUrls)(nil),                     // 24: matrixhub.v1alpha1.CloneUrls
 }
 var file_v1alpha1_dataset_proto_depIdxs = []int32{
@@ -1278,7 +1278,7 @@ var file_v1alpha1_dataset_proto_depIdxs = []int32{
 	21, // 3: matrixhub.v1alpha1.ListDatasetRevisionsResponse.items:type_name -> matrixhub.v1alpha1.Revisions
 	22, // 4: matrixhub.v1alpha1.ListDatasetCommitsResponse.items:type_name -> matrixhub.v1alpha1.Commit
 	20, // 5: matrixhub.v1alpha1.ListDatasetCommitsResponse.pagination:type_name -> matrixhub.v1alpha1.Pagination
-	23, // 6: matrixhub.v1alpha1.GetDatasetTreeResponse.items:type_name -> matrixhub.v1alpha1.Files
+	23, // 6: matrixhub.v1alpha1.GetDatasetTreeResponse.items:type_name -> matrixhub.v1alpha1.File
 	19, // 7: matrixhub.v1alpha1.Dataset.labels:type_name -> matrixhub.v1alpha1.Label
 	24, // 8: matrixhub.v1alpha1.Dataset.clone_urls:type_name -> matrixhub.v1alpha1.CloneUrls
 	0,  // 9: matrixhub.v1alpha1.Datasets.ListDatasetTaskLabels:input_type -> matrixhub.v1alpha1.ListDatasetTaskLabelsRequest

--- a/api/go/v1alpha1/model.pb.go
+++ b/api/go/v1alpha1/model.pb.go
@@ -1070,7 +1070,7 @@ func (x *GetModelTreeRequest) GetPath() string {
 	return ""
 }
 
-type Files struct {
+type File struct {
 	state  protoimpl.MessageState `protogen:"open.v1"`
 	Name   string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	Type   FileType               `protobuf:"varint,2,opt,name=type,proto3,enum=matrixhub.v1alpha1.FileType" json:"type,omitempty"`
@@ -1081,24 +1081,25 @@ type Files struct {
 	// commit with out diffs
 	// only file type have commit
 	Commit        *Commit `protobuf:"bytes,7,opt,name=commit,proto3" json:"commit,omitempty"`
+	Url           string  `protobuf:"bytes,8,opt,name=url,proto3" json:"url,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *Files) Reset() {
-	*x = Files{}
+func (x *File) Reset() {
+	*x = File{}
 	mi := &file_v1alpha1_model_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *Files) String() string {
+func (x *File) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*Files) ProtoMessage() {}
+func (*File) ProtoMessage() {}
 
-func (x *Files) ProtoReflect() protoreflect.Message {
+func (x *File) ProtoReflect() protoreflect.Message {
 	mi := &file_v1alpha1_model_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1110,63 +1111,70 @@ func (x *Files) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use Files.ProtoReflect.Descriptor instead.
-func (*Files) Descriptor() ([]byte, []int) {
+// Deprecated: Use File.ProtoReflect.Descriptor instead.
+func (*File) Descriptor() ([]byte, []int) {
 	return file_v1alpha1_model_proto_rawDescGZIP(), []int{18}
 }
 
-func (x *Files) GetName() string {
+func (x *File) GetName() string {
 	if x != nil {
 		return x.Name
 	}
 	return ""
 }
 
-func (x *Files) GetType() FileType {
+func (x *File) GetType() FileType {
 	if x != nil {
 		return x.Type
 	}
 	return FileType_DIR
 }
 
-func (x *Files) GetPath() string {
+func (x *File) GetPath() string {
 	if x != nil {
 		return x.Path
 	}
 	return ""
 }
 
-func (x *Files) GetSize() int64 {
+func (x *File) GetSize() int64 {
 	if x != nil {
 		return x.Size
 	}
 	return 0
 }
 
-func (x *Files) GetLfs() bool {
+func (x *File) GetLfs() bool {
 	if x != nil {
 		return x.Lfs
 	}
 	return false
 }
 
-func (x *Files) GetSha256() string {
+func (x *File) GetSha256() string {
 	if x != nil {
 		return x.Sha256
 	}
 	return ""
 }
 
-func (x *Files) GetCommit() *Commit {
+func (x *File) GetCommit() *Commit {
 	if x != nil {
 		return x.Commit
 	}
 	return nil
 }
 
+func (x *File) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
 type GetModelTreeResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Items         []*Files               `protobuf:"bytes,1,rep,name=items,proto3" json:"items,omitempty"`
+	Items         []*File                `protobuf:"bytes,1,rep,name=items,proto3" json:"items,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1201,7 +1209,7 @@ func (*GetModelTreeResponse) Descriptor() ([]byte, []int) {
 	return file_v1alpha1_model_proto_rawDescGZIP(), []int{19}
 }
 
-func (x *GetModelTreeResponse) GetItems() []*Files {
+func (x *GetModelTreeResponse) GetItems() []*File {
 	if x != nil {
 		return x.Items
 	}
@@ -1276,66 +1284,6 @@ func (x *GetModelBlobRequest) GetPath() string {
 	return ""
 }
 
-type GetModelBlobResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Lfs           bool                   `protobuf:"varint,1,opt,name=lfs,proto3" json:"lfs,omitempty"`
-	Content       string                 `protobuf:"bytes,2,opt,name=content,proto3" json:"content,omitempty"`
-	Url           string                 `protobuf:"bytes,3,opt,name=url,proto3" json:"url,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *GetModelBlobResponse) Reset() {
-	*x = GetModelBlobResponse{}
-	mi := &file_v1alpha1_model_proto_msgTypes[21]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *GetModelBlobResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*GetModelBlobResponse) ProtoMessage() {}
-
-func (x *GetModelBlobResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1alpha1_model_proto_msgTypes[21]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use GetModelBlobResponse.ProtoReflect.Descriptor instead.
-func (*GetModelBlobResponse) Descriptor() ([]byte, []int) {
-	return file_v1alpha1_model_proto_rawDescGZIP(), []int{21}
-}
-
-func (x *GetModelBlobResponse) GetLfs() bool {
-	if x != nil {
-		return x.Lfs
-	}
-	return false
-}
-
-func (x *GetModelBlobResponse) GetContent() string {
-	if x != nil {
-		return x.Content
-	}
-	return ""
-}
-
-func (x *GetModelBlobResponse) GetUrl() string {
-	if x != nil {
-		return x.Url
-	}
-	return ""
-}
-
 type Model struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	Id             int32                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -1356,7 +1304,7 @@ type Model struct {
 
 func (x *Model) Reset() {
 	*x = Model{}
-	mi := &file_v1alpha1_model_proto_msgTypes[22]
+	mi := &file_v1alpha1_model_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1368,7 +1316,7 @@ func (x *Model) String() string {
 func (*Model) ProtoMessage() {}
 
 func (x *Model) ProtoReflect() protoreflect.Message {
-	mi := &file_v1alpha1_model_proto_msgTypes[22]
+	mi := &file_v1alpha1_model_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1381,7 +1329,7 @@ func (x *Model) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Model.ProtoReflect.Descriptor instead.
 func (*Model) Descriptor() ([]byte, []int) {
-	return file_v1alpha1_model_proto_rawDescGZIP(), []int{22}
+	return file_v1alpha1_model_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *Model) GetId() int32 {
@@ -1478,7 +1426,7 @@ type CloneUrls struct {
 
 func (x *CloneUrls) Reset() {
 	*x = CloneUrls{}
-	mi := &file_v1alpha1_model_proto_msgTypes[23]
+	mi := &file_v1alpha1_model_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1490,7 +1438,7 @@ func (x *CloneUrls) String() string {
 func (*CloneUrls) ProtoMessage() {}
 
 func (x *CloneUrls) ProtoReflect() protoreflect.Message {
-	mi := &file_v1alpha1_model_proto_msgTypes[23]
+	mi := &file_v1alpha1_model_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1503,7 +1451,7 @@ func (x *CloneUrls) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloneUrls.ProtoReflect.Descriptor instead.
 func (*CloneUrls) Descriptor() ([]byte, []int) {
-	return file_v1alpha1_model_proto_rawDescGZIP(), []int{23}
+	return file_v1alpha1_model_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *CloneUrls) GetSshUrl() string {
@@ -1529,7 +1477,7 @@ type Revision struct {
 
 func (x *Revision) Reset() {
 	*x = Revision{}
-	mi := &file_v1alpha1_model_proto_msgTypes[24]
+	mi := &file_v1alpha1_model_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1541,7 +1489,7 @@ func (x *Revision) String() string {
 func (*Revision) ProtoMessage() {}
 
 func (x *Revision) ProtoReflect() protoreflect.Message {
-	mi := &file_v1alpha1_model_proto_msgTypes[24]
+	mi := &file_v1alpha1_model_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1554,7 +1502,7 @@ func (x *Revision) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Revision.ProtoReflect.Descriptor instead.
 func (*Revision) Descriptor() ([]byte, []int) {
-	return file_v1alpha1_model_proto_rawDescGZIP(), []int{24}
+	return file_v1alpha1_model_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *Revision) GetName() string {
@@ -1582,7 +1530,7 @@ type Commit struct {
 
 func (x *Commit) Reset() {
 	*x = Commit{}
-	mi := &file_v1alpha1_model_proto_msgTypes[25]
+	mi := &file_v1alpha1_model_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1594,7 +1542,7 @@ func (x *Commit) String() string {
 func (*Commit) ProtoMessage() {}
 
 func (x *Commit) ProtoReflect() protoreflect.Message {
-	mi := &file_v1alpha1_model_proto_msgTypes[25]
+	mi := &file_v1alpha1_model_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1607,7 +1555,7 @@ func (x *Commit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Commit.ProtoReflect.Descriptor instead.
 func (*Commit) Descriptor() ([]byte, []int) {
-	return file_v1alpha1_model_proto_rawDescGZIP(), []int{25}
+	return file_v1alpha1_model_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *Commit) GetId() string {
@@ -1680,74 +1628,6 @@ func (x *Commit) GetUpdatedAt() string {
 	return ""
 }
 
-type Diff struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Diff          string                 `protobuf:"bytes,1,opt,name=diff,proto3" json:"diff,omitempty"`
-	Deleted       bool                   `protobuf:"varint,2,opt,name=Deleted,proto3" json:"Deleted,omitempty"`
-	NewPath       string                 `protobuf:"bytes,3,opt,name=new_path,json=newPath,proto3" json:"new_path,omitempty"`
-	OldPath       string                 `protobuf:"bytes,4,opt,name=old_path,json=oldPath,proto3" json:"old_path,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *Diff) Reset() {
-	*x = Diff{}
-	mi := &file_v1alpha1_model_proto_msgTypes[26]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *Diff) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*Diff) ProtoMessage() {}
-
-func (x *Diff) ProtoReflect() protoreflect.Message {
-	mi := &file_v1alpha1_model_proto_msgTypes[26]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use Diff.ProtoReflect.Descriptor instead.
-func (*Diff) Descriptor() ([]byte, []int) {
-	return file_v1alpha1_model_proto_rawDescGZIP(), []int{26}
-}
-
-func (x *Diff) GetDiff() string {
-	if x != nil {
-		return x.Diff
-	}
-	return ""
-}
-
-func (x *Diff) GetDeleted() bool {
-	if x != nil {
-		return x.Deleted
-	}
-	return false
-}
-
-func (x *Diff) GetNewPath() string {
-	if x != nil {
-		return x.NewPath
-	}
-	return ""
-}
-
-func (x *Diff) GetOldPath() string {
-	if x != nil {
-		return x.OldPath
-	}
-	return ""
-}
-
 type Label struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            int32                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -1761,7 +1641,7 @@ type Label struct {
 
 func (x *Label) Reset() {
 	*x = Label{}
-	mi := &file_v1alpha1_model_proto_msgTypes[27]
+	mi := &file_v1alpha1_model_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1773,7 +1653,7 @@ func (x *Label) String() string {
 func (*Label) ProtoMessage() {}
 
 func (x *Label) ProtoReflect() protoreflect.Message {
-	mi := &file_v1alpha1_model_proto_msgTypes[27]
+	mi := &file_v1alpha1_model_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1786,7 +1666,7 @@ func (x *Label) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Label.ProtoReflect.Descriptor instead.
 func (*Label) Descriptor() ([]byte, []int) {
-	return file_v1alpha1_model_proto_rawDescGZIP(), []int{27}
+	return file_v1alpha1_model_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *Label) GetId() int32 {
@@ -1887,26 +1767,23 @@ const file_v1alpha1_model_proto_rawDesc = "" +
 	"\aproject\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\aproject\x12\x1b\n" +
 	"\x04name\x18\x02 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\x04name\x12\x1a\n" +
 	"\brevision\x18\x03 \x01(\tR\brevision\x12\x12\n" +
-	"\x04path\x18\x04 \x01(\tR\x04path\"\xd3\x01\n" +
-	"\x05Files\x12\x12\n" +
+	"\x04path\x18\x04 \x01(\tR\x04path\"\xe4\x01\n" +
+	"\x04File\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x120\n" +
 	"\x04type\x18\x02 \x01(\x0e2\x1c.matrixhub.v1alpha1.FileTypeR\x04type\x12\x12\n" +
 	"\x04path\x18\x03 \x01(\tR\x04path\x12\x12\n" +
 	"\x04size\x18\x04 \x01(\x03R\x04size\x12\x10\n" +
 	"\x03lfs\x18\x05 \x01(\bR\x03lfs\x12\x16\n" +
 	"\x06Sha256\x18\x06 \x01(\tR\x06Sha256\x122\n" +
-	"\x06commit\x18\a \x01(\v2\x1a.matrixhub.v1alpha1.CommitR\x06commit\"G\n" +
-	"\x14GetModelTreeResponse\x12/\n" +
-	"\x05items\x18\x01 \x03(\v2\x19.matrixhub.v1alpha1.FilesR\x05items\"\x85\x01\n" +
+	"\x06commit\x18\a \x01(\v2\x1a.matrixhub.v1alpha1.CommitR\x06commit\x12\x10\n" +
+	"\x03url\x18\b \x01(\tR\x03url\"F\n" +
+	"\x14GetModelTreeResponse\x12.\n" +
+	"\x05items\x18\x01 \x03(\v2\x18.matrixhub.v1alpha1.FileR\x05items\"\x85\x01\n" +
 	"\x13GetModelBlobRequest\x12!\n" +
 	"\aproject\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\aproject\x12\x1b\n" +
 	"\x04name\x18\x02 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\x04name\x12\x1a\n" +
 	"\brevision\x18\x03 \x01(\tR\brevision\x12\x12\n" +
-	"\x04path\x18\x04 \x01(\tR\x04path\"T\n" +
-	"\x14GetModelBlobResponse\x12\x10\n" +
-	"\x03lfs\x18\x01 \x01(\bR\x03lfs\x12\x18\n" +
-	"\acontent\x18\x02 \x01(\tR\acontent\x12\x10\n" +
-	"\x03url\x18\x03 \x01(\tR\x03url\"\x9b\x03\n" +
+	"\x04path\x18\x04 \x01(\tR\x04path\"\x9b\x03\n" +
 	"\x05Model\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x05R\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1a\n" +
@@ -1944,12 +1821,7 @@ const file_v1alpha1_model_proto_rawDesc = "" +
 	"created_at\x18\t \x01(\tR\tcreatedAt\x12\x1d\n" +
 	"\n" +
 	"updated_at\x18\n" +
-	" \x01(\tR\tupdatedAt\"j\n" +
-	"\x04Diff\x12\x12\n" +
-	"\x04diff\x18\x01 \x01(\tR\x04diff\x12\x18\n" +
-	"\aDeleted\x18\x02 \x01(\bR\aDeleted\x12\x19\n" +
-	"\bnew_path\x18\x03 \x01(\tR\anewPath\x12\x19\n" +
-	"\bold_path\x18\x04 \x01(\tR\aoldPath\"\xa3\x01\n" +
+	" \x01(\tR\tupdatedAt\"\xa3\x01\n" +
 	"\x05Label\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x05R\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x128\n" +
@@ -1966,7 +1838,7 @@ const file_v1alpha1_model_proto_rawDesc = "" +
 	"\aLIBRARY\x10\x01\x12\v\n" +
 	"\aLICENSE\x10\x02\x12\f\n" +
 	"\bLANGUAGE\x10\x03\x12\t\n" +
-	"\x05OTHER\x10\x042\xf7\f\n" +
+	"\x05OTHER\x10\x042\xe7\f\n" +
 	"\x06Models\x12\xa0\x01\n" +
 	"\x13ListModelTaskLabels\x12..matrixhub.v1alpha1.ListModelTaskLabelsRequest\x1a/.matrixhub.v1alpha1.ListModelTaskLabelsResponse\"(\x82\xd3\xe4\x93\x02\"\x12 /api/v1alpha1/models/task-labels\x12\xa6\x01\n" +
 	"\x14ListModelFrameLabels\x12/.matrixhub.v1alpha1.ListModelFrameLabelsRequest\x1a0.matrixhub.v1alpha1.ListModelFrameLabelsResponse\"+\x82\xd3\xe4\x93\x02%\x12#/api/v1alpha1/models/library-labels\x12y\n" +
@@ -1978,8 +1850,8 @@ const file_v1alpha1_model_proto_rawDesc = "" +
 	"\x12ListModelRevisions\x12-.matrixhub.v1alpha1.ListModelRevisionsRequest\x1a..matrixhub.v1alpha1.ListModelRevisionsResponse\"7\x82\xd3\xe4\x93\x021\x12//api/v1alpha1/models/{project}/{name}/revisions\x12\xa4\x01\n" +
 	"\x10ListModelCommits\x12+.matrixhub.v1alpha1.ListModelCommitsRequest\x1a,.matrixhub.v1alpha1.ListModelCommitsResponse\"5\x82\xd3\xe4\x93\x02/\x12-/api/v1alpha1/models/{project}/{name}/commits\x12\x93\x01\n" +
 	"\x0eGetModelCommit\x12).matrixhub.v1alpha1.GetModelCommitRequest\x1a\x1a.matrixhub.v1alpha1.Commit\":\x82\xd3\xe4\x93\x024\x122/api/v1alpha1/models/{project}/{name}/commits/{id}\x12\x95\x01\n" +
-	"\fGetModelTree\x12'.matrixhub.v1alpha1.GetModelTreeRequest\x1a(.matrixhub.v1alpha1.GetModelTreeResponse\"2\x82\xd3\xe4\x93\x02,\x12*/api/v1alpha1/models/{project}/{name}/tree\x12\x95\x01\n" +
-	"\fGetModelBlob\x12'.matrixhub.v1alpha1.GetModelBlobRequest\x1a(.matrixhub.v1alpha1.GetModelBlobResponse\"2\x82\xd3\xe4\x93\x02,\x12*/api/v1alpha1/models/{project}/{name}/blobB<Z:github.com/matrixhub-ai/matrixhub/api/go/v1alpha1;v1alpha1b\x06proto3"
+	"\fGetModelTree\x12'.matrixhub.v1alpha1.GetModelTreeRequest\x1a(.matrixhub.v1alpha1.GetModelTreeResponse\"2\x82\xd3\xe4\x93\x02,\x12*/api/v1alpha1/models/{project}/{name}/tree\x12\x85\x01\n" +
+	"\fGetModelBlob\x12'.matrixhub.v1alpha1.GetModelBlobRequest\x1a\x18.matrixhub.v1alpha1.File\"2\x82\xd3\xe4\x93\x02,\x12*/api/v1alpha1/models/{project}/{name}/blobB<Z:github.com/matrixhub-ai/matrixhub/api/go/v1alpha1;v1alpha1b\x06proto3"
 
 var (
 	file_v1alpha1_model_proto_rawDescOnce sync.Once
@@ -1994,7 +1866,7 @@ func file_v1alpha1_model_proto_rawDescGZIP() []byte {
 }
 
 var file_v1alpha1_model_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_v1alpha1_model_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_v1alpha1_model_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_v1alpha1_model_proto_goTypes = []any{
 	(FileType)(0),                        // 0: matrixhub.v1alpha1.FileType
 	(Category)(0),                        // 1: matrixhub.v1alpha1.Category
@@ -2016,33 +1888,31 @@ var file_v1alpha1_model_proto_goTypes = []any{
 	(*ListModelCommitsResponse)(nil),     // 17: matrixhub.v1alpha1.ListModelCommitsResponse
 	(*GetModelCommitRequest)(nil),        // 18: matrixhub.v1alpha1.GetModelCommitRequest
 	(*GetModelTreeRequest)(nil),          // 19: matrixhub.v1alpha1.GetModelTreeRequest
-	(*Files)(nil),                        // 20: matrixhub.v1alpha1.Files
+	(*File)(nil),                         // 20: matrixhub.v1alpha1.File
 	(*GetModelTreeResponse)(nil),         // 21: matrixhub.v1alpha1.GetModelTreeResponse
 	(*GetModelBlobRequest)(nil),          // 22: matrixhub.v1alpha1.GetModelBlobRequest
-	(*GetModelBlobResponse)(nil),         // 23: matrixhub.v1alpha1.GetModelBlobResponse
-	(*Model)(nil),                        // 24: matrixhub.v1alpha1.Model
-	(*CloneUrls)(nil),                    // 25: matrixhub.v1alpha1.CloneUrls
-	(*Revision)(nil),                     // 26: matrixhub.v1alpha1.Revision
-	(*Commit)(nil),                       // 27: matrixhub.v1alpha1.Commit
-	(*Diff)(nil),                         // 28: matrixhub.v1alpha1.Diff
-	(*Label)(nil),                        // 29: matrixhub.v1alpha1.Label
-	(*Pagination)(nil),                   // 30: matrixhub.v1alpha1.Pagination
+	(*Model)(nil),                        // 23: matrixhub.v1alpha1.Model
+	(*CloneUrls)(nil),                    // 24: matrixhub.v1alpha1.CloneUrls
+	(*Revision)(nil),                     // 25: matrixhub.v1alpha1.Revision
+	(*Commit)(nil),                       // 26: matrixhub.v1alpha1.Commit
+	(*Label)(nil),                        // 27: matrixhub.v1alpha1.Label
+	(*Pagination)(nil),                   // 28: matrixhub.v1alpha1.Pagination
 }
 var file_v1alpha1_model_proto_depIdxs = []int32{
-	29, // 0: matrixhub.v1alpha1.ListModelTaskLabelsResponse.items:type_name -> matrixhub.v1alpha1.Label
-	29, // 1: matrixhub.v1alpha1.ListModelFrameLabelsResponse.items:type_name -> matrixhub.v1alpha1.Label
-	24, // 2: matrixhub.v1alpha1.ListModelsResponse.items:type_name -> matrixhub.v1alpha1.Model
-	30, // 3: matrixhub.v1alpha1.ListModelsResponse.pagination:type_name -> matrixhub.v1alpha1.Pagination
+	27, // 0: matrixhub.v1alpha1.ListModelTaskLabelsResponse.items:type_name -> matrixhub.v1alpha1.Label
+	27, // 1: matrixhub.v1alpha1.ListModelFrameLabelsResponse.items:type_name -> matrixhub.v1alpha1.Label
+	23, // 2: matrixhub.v1alpha1.ListModelsResponse.items:type_name -> matrixhub.v1alpha1.Model
+	28, // 3: matrixhub.v1alpha1.ListModelsResponse.pagination:type_name -> matrixhub.v1alpha1.Pagination
 	15, // 4: matrixhub.v1alpha1.ListModelRevisionsResponse.items:type_name -> matrixhub.v1alpha1.Revisions
-	26, // 5: matrixhub.v1alpha1.Revisions.branches:type_name -> matrixhub.v1alpha1.Revision
-	26, // 6: matrixhub.v1alpha1.Revisions.tags:type_name -> matrixhub.v1alpha1.Revision
-	27, // 7: matrixhub.v1alpha1.ListModelCommitsResponse.items:type_name -> matrixhub.v1alpha1.Commit
-	30, // 8: matrixhub.v1alpha1.ListModelCommitsResponse.pagination:type_name -> matrixhub.v1alpha1.Pagination
-	0,  // 9: matrixhub.v1alpha1.Files.type:type_name -> matrixhub.v1alpha1.FileType
-	27, // 10: matrixhub.v1alpha1.Files.commit:type_name -> matrixhub.v1alpha1.Commit
-	20, // 11: matrixhub.v1alpha1.GetModelTreeResponse.items:type_name -> matrixhub.v1alpha1.Files
-	25, // 12: matrixhub.v1alpha1.Model.clone_urls:type_name -> matrixhub.v1alpha1.CloneUrls
-	29, // 13: matrixhub.v1alpha1.Model.labels:type_name -> matrixhub.v1alpha1.Label
+	25, // 5: matrixhub.v1alpha1.Revisions.branches:type_name -> matrixhub.v1alpha1.Revision
+	25, // 6: matrixhub.v1alpha1.Revisions.tags:type_name -> matrixhub.v1alpha1.Revision
+	26, // 7: matrixhub.v1alpha1.ListModelCommitsResponse.items:type_name -> matrixhub.v1alpha1.Commit
+	28, // 8: matrixhub.v1alpha1.ListModelCommitsResponse.pagination:type_name -> matrixhub.v1alpha1.Pagination
+	0,  // 9: matrixhub.v1alpha1.File.type:type_name -> matrixhub.v1alpha1.FileType
+	26, // 10: matrixhub.v1alpha1.File.commit:type_name -> matrixhub.v1alpha1.Commit
+	20, // 11: matrixhub.v1alpha1.GetModelTreeResponse.items:type_name -> matrixhub.v1alpha1.File
+	24, // 12: matrixhub.v1alpha1.Model.clone_urls:type_name -> matrixhub.v1alpha1.CloneUrls
+	27, // 13: matrixhub.v1alpha1.Model.labels:type_name -> matrixhub.v1alpha1.Label
 	1,  // 14: matrixhub.v1alpha1.Label.category:type_name -> matrixhub.v1alpha1.Category
 	2,  // 15: matrixhub.v1alpha1.Models.ListModelTaskLabels:input_type -> matrixhub.v1alpha1.ListModelTaskLabelsRequest
 	4,  // 16: matrixhub.v1alpha1.Models.ListModelFrameLabels:input_type -> matrixhub.v1alpha1.ListModelFrameLabelsRequest
@@ -2058,14 +1928,14 @@ var file_v1alpha1_model_proto_depIdxs = []int32{
 	3,  // 26: matrixhub.v1alpha1.Models.ListModelTaskLabels:output_type -> matrixhub.v1alpha1.ListModelTaskLabelsResponse
 	5,  // 27: matrixhub.v1alpha1.Models.ListModelFrameLabels:output_type -> matrixhub.v1alpha1.ListModelFrameLabelsResponse
 	7,  // 28: matrixhub.v1alpha1.Models.ListModels:output_type -> matrixhub.v1alpha1.ListModelsResponse
-	24, // 29: matrixhub.v1alpha1.Models.GetModel:output_type -> matrixhub.v1alpha1.Model
+	23, // 29: matrixhub.v1alpha1.Models.GetModel:output_type -> matrixhub.v1alpha1.Model
 	10, // 30: matrixhub.v1alpha1.Models.CreateModel:output_type -> matrixhub.v1alpha1.CreateModelResponse
 	12, // 31: matrixhub.v1alpha1.Models.DeleteModel:output_type -> matrixhub.v1alpha1.DeleteModelResponse
 	14, // 32: matrixhub.v1alpha1.Models.ListModelRevisions:output_type -> matrixhub.v1alpha1.ListModelRevisionsResponse
 	17, // 33: matrixhub.v1alpha1.Models.ListModelCommits:output_type -> matrixhub.v1alpha1.ListModelCommitsResponse
-	27, // 34: matrixhub.v1alpha1.Models.GetModelCommit:output_type -> matrixhub.v1alpha1.Commit
+	26, // 34: matrixhub.v1alpha1.Models.GetModelCommit:output_type -> matrixhub.v1alpha1.Commit
 	21, // 35: matrixhub.v1alpha1.Models.GetModelTree:output_type -> matrixhub.v1alpha1.GetModelTreeResponse
-	23, // 36: matrixhub.v1alpha1.Models.GetModelBlob:output_type -> matrixhub.v1alpha1.GetModelBlobResponse
+	20, // 36: matrixhub.v1alpha1.Models.GetModelBlob:output_type -> matrixhub.v1alpha1.File
 	26, // [26:37] is the sub-list for method output_type
 	15, // [15:26] is the sub-list for method input_type
 	15, // [15:15] is the sub-list for extension type_name
@@ -2085,7 +1955,7 @@ func file_v1alpha1_model_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_v1alpha1_model_proto_rawDesc), len(file_v1alpha1_model_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   28,
+			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/go/v1alpha1/model.pb.validate.go
+++ b/api/go/v1alpha1/model.pb.validate.go
@@ -2349,21 +2349,21 @@ var _ interface {
 	ErrorName() string
 } = GetModelTreeRequestValidationError{}
 
-// Validate checks the field values on Files with the rules defined in the
-// proto definition for this message. If any rules are violated, the first
-// error encountered is returned, or nil if there are no violations.
-func (m *Files) Validate() error {
+// Validate checks the field values on File with the rules defined in the proto
+// definition for this message. If any rules are violated, the first error
+// encountered is returned, or nil if there are no violations.
+func (m *File) Validate() error {
 	return m.validate(false)
 }
 
-// ValidateAll checks the field values on Files with the rules defined in the
+// ValidateAll checks the field values on File with the rules defined in the
 // proto definition for this message. If any rules are violated, the result is
-// a list of violation errors wrapped in FilesMultiError, or nil if none found.
-func (m *Files) ValidateAll() error {
+// a list of violation errors wrapped in FileMultiError, or nil if none found.
+func (m *File) ValidateAll() error {
 	return m.validate(true)
 }
 
-func (m *Files) validate(all bool) error {
+func (m *File) validate(all bool) error {
 	if m == nil {
 		return nil
 	}
@@ -2386,7 +2386,7 @@ func (m *Files) validate(all bool) error {
 		switch v := interface{}(m.GetCommit()).(type) {
 		case interface{ ValidateAll() error }:
 			if err := v.ValidateAll(); err != nil {
-				errors = append(errors, FilesValidationError{
+				errors = append(errors, FileValidationError{
 					field:  "Commit",
 					reason: "embedded message failed validation",
 					cause:  err,
@@ -2394,7 +2394,7 @@ func (m *Files) validate(all bool) error {
 			}
 		case interface{ Validate() error }:
 			if err := v.Validate(); err != nil {
-				errors = append(errors, FilesValidationError{
+				errors = append(errors, FileValidationError{
 					field:  "Commit",
 					reason: "embedded message failed validation",
 					cause:  err,
@@ -2403,7 +2403,7 @@ func (m *Files) validate(all bool) error {
 		}
 	} else if v, ok := interface{}(m.GetCommit()).(interface{ Validate() error }); ok {
 		if err := v.Validate(); err != nil {
-			return FilesValidationError{
+			return FileValidationError{
 				field:  "Commit",
 				reason: "embedded message failed validation",
 				cause:  err,
@@ -2411,19 +2411,21 @@ func (m *Files) validate(all bool) error {
 		}
 	}
 
+	// no validation rules for Url
+
 	if len(errors) > 0 {
-		return FilesMultiError(errors)
+		return FileMultiError(errors)
 	}
 
 	return nil
 }
 
-// FilesMultiError is an error wrapping multiple validation errors returned by
-// Files.ValidateAll() if the designated constraints aren't met.
-type FilesMultiError []error
+// FileMultiError is an error wrapping multiple validation errors returned by
+// File.ValidateAll() if the designated constraints aren't met.
+type FileMultiError []error
 
 // Error returns a concatenation of all the error messages it wraps.
-func (m FilesMultiError) Error() string {
+func (m FileMultiError) Error() string {
 	msgs := make([]string, 0, len(m))
 	for _, err := range m {
 		msgs = append(msgs, err.Error())
@@ -2432,11 +2434,11 @@ func (m FilesMultiError) Error() string {
 }
 
 // AllErrors returns a list of validation violation errors.
-func (m FilesMultiError) AllErrors() []error { return m }
+func (m FileMultiError) AllErrors() []error { return m }
 
-// FilesValidationError is the validation error returned by Files.Validate if
-// the designated constraints aren't met.
-type FilesValidationError struct {
+// FileValidationError is the validation error returned by File.Validate if the
+// designated constraints aren't met.
+type FileValidationError struct {
 	field  string
 	reason string
 	cause  error
@@ -2444,22 +2446,22 @@ type FilesValidationError struct {
 }
 
 // Field function returns field value.
-func (e FilesValidationError) Field() string { return e.field }
+func (e FileValidationError) Field() string { return e.field }
 
 // Reason function returns reason value.
-func (e FilesValidationError) Reason() string { return e.reason }
+func (e FileValidationError) Reason() string { return e.reason }
 
 // Cause function returns cause value.
-func (e FilesValidationError) Cause() error { return e.cause }
+func (e FileValidationError) Cause() error { return e.cause }
 
 // Key function returns key value.
-func (e FilesValidationError) Key() bool { return e.key }
+func (e FileValidationError) Key() bool { return e.key }
 
 // ErrorName returns error name.
-func (e FilesValidationError) ErrorName() string { return "FilesValidationError" }
+func (e FileValidationError) ErrorName() string { return "FileValidationError" }
 
 // Error satisfies the builtin error interface
-func (e FilesValidationError) Error() string {
+func (e FileValidationError) Error() string {
 	cause := ""
 	if e.cause != nil {
 		cause = fmt.Sprintf(" | caused by: %v", e.cause)
@@ -2471,14 +2473,14 @@ func (e FilesValidationError) Error() string {
 	}
 
 	return fmt.Sprintf(
-		"invalid %sFiles.%s: %s%s",
+		"invalid %sFile.%s: %s%s",
 		key,
 		e.field,
 		e.reason,
 		cause)
 }
 
-var _ error = FilesValidationError{}
+var _ error = FileValidationError{}
 
 var _ interface {
 	Field() string
@@ -2486,7 +2488,7 @@ var _ interface {
 	Key() bool
 	Cause() error
 	ErrorName() string
-} = FilesValidationError{}
+} = FileValidationError{}
 
 // Validate checks the field values on GetModelTreeResponse with the rules
 // defined in the proto definition for this message. If any rules are
@@ -2751,114 +2753,6 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = GetModelBlobRequestValidationError{}
-
-// Validate checks the field values on GetModelBlobResponse with the rules
-// defined in the proto definition for this message. If any rules are
-// violated, the first error encountered is returned, or nil if there are no violations.
-func (m *GetModelBlobResponse) Validate() error {
-	return m.validate(false)
-}
-
-// ValidateAll checks the field values on GetModelBlobResponse with the rules
-// defined in the proto definition for this message. If any rules are
-// violated, the result is a list of violation errors wrapped in
-// GetModelBlobResponseMultiError, or nil if none found.
-func (m *GetModelBlobResponse) ValidateAll() error {
-	return m.validate(true)
-}
-
-func (m *GetModelBlobResponse) validate(all bool) error {
-	if m == nil {
-		return nil
-	}
-
-	var errors []error
-
-	// no validation rules for Lfs
-
-	// no validation rules for Content
-
-	// no validation rules for Url
-
-	if len(errors) > 0 {
-		return GetModelBlobResponseMultiError(errors)
-	}
-
-	return nil
-}
-
-// GetModelBlobResponseMultiError is an error wrapping multiple validation
-// errors returned by GetModelBlobResponse.ValidateAll() if the designated
-// constraints aren't met.
-type GetModelBlobResponseMultiError []error
-
-// Error returns a concatenation of all the error messages it wraps.
-func (m GetModelBlobResponseMultiError) Error() string {
-	msgs := make([]string, 0, len(m))
-	for _, err := range m {
-		msgs = append(msgs, err.Error())
-	}
-	return strings.Join(msgs, "; ")
-}
-
-// AllErrors returns a list of validation violation errors.
-func (m GetModelBlobResponseMultiError) AllErrors() []error { return m }
-
-// GetModelBlobResponseValidationError is the validation error returned by
-// GetModelBlobResponse.Validate if the designated constraints aren't met.
-type GetModelBlobResponseValidationError struct {
-	field  string
-	reason string
-	cause  error
-	key    bool
-}
-
-// Field function returns field value.
-func (e GetModelBlobResponseValidationError) Field() string { return e.field }
-
-// Reason function returns reason value.
-func (e GetModelBlobResponseValidationError) Reason() string { return e.reason }
-
-// Cause function returns cause value.
-func (e GetModelBlobResponseValidationError) Cause() error { return e.cause }
-
-// Key function returns key value.
-func (e GetModelBlobResponseValidationError) Key() bool { return e.key }
-
-// ErrorName returns error name.
-func (e GetModelBlobResponseValidationError) ErrorName() string {
-	return "GetModelBlobResponseValidationError"
-}
-
-// Error satisfies the builtin error interface
-func (e GetModelBlobResponseValidationError) Error() string {
-	cause := ""
-	if e.cause != nil {
-		cause = fmt.Sprintf(" | caused by: %v", e.cause)
-	}
-
-	key := ""
-	if e.key {
-		key = "key for "
-	}
-
-	return fmt.Sprintf(
-		"invalid %sGetModelBlobResponse.%s: %s%s",
-		key,
-		e.field,
-		e.reason,
-		cause)
-}
-
-var _ error = GetModelBlobResponseValidationError{}
-
-var _ interface {
-	Field() string
-	Reason() string
-	Key() bool
-	Cause() error
-	ErrorName() string
-} = GetModelBlobResponseValidationError{}
 
 // Validate checks the field values on Model with the rules defined in the
 // proto definition for this message. If any rules are violated, the first
@@ -3362,112 +3256,6 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = CommitValidationError{}
-
-// Validate checks the field values on Diff with the rules defined in the proto
-// definition for this message. If any rules are violated, the first error
-// encountered is returned, or nil if there are no violations.
-func (m *Diff) Validate() error {
-	return m.validate(false)
-}
-
-// ValidateAll checks the field values on Diff with the rules defined in the
-// proto definition for this message. If any rules are violated, the result is
-// a list of violation errors wrapped in DiffMultiError, or nil if none found.
-func (m *Diff) ValidateAll() error {
-	return m.validate(true)
-}
-
-func (m *Diff) validate(all bool) error {
-	if m == nil {
-		return nil
-	}
-
-	var errors []error
-
-	// no validation rules for Diff
-
-	// no validation rules for Deleted
-
-	// no validation rules for NewPath
-
-	// no validation rules for OldPath
-
-	if len(errors) > 0 {
-		return DiffMultiError(errors)
-	}
-
-	return nil
-}
-
-// DiffMultiError is an error wrapping multiple validation errors returned by
-// Diff.ValidateAll() if the designated constraints aren't met.
-type DiffMultiError []error
-
-// Error returns a concatenation of all the error messages it wraps.
-func (m DiffMultiError) Error() string {
-	msgs := make([]string, 0, len(m))
-	for _, err := range m {
-		msgs = append(msgs, err.Error())
-	}
-	return strings.Join(msgs, "; ")
-}
-
-// AllErrors returns a list of validation violation errors.
-func (m DiffMultiError) AllErrors() []error { return m }
-
-// DiffValidationError is the validation error returned by Diff.Validate if the
-// designated constraints aren't met.
-type DiffValidationError struct {
-	field  string
-	reason string
-	cause  error
-	key    bool
-}
-
-// Field function returns field value.
-func (e DiffValidationError) Field() string { return e.field }
-
-// Reason function returns reason value.
-func (e DiffValidationError) Reason() string { return e.reason }
-
-// Cause function returns cause value.
-func (e DiffValidationError) Cause() error { return e.cause }
-
-// Key function returns key value.
-func (e DiffValidationError) Key() bool { return e.key }
-
-// ErrorName returns error name.
-func (e DiffValidationError) ErrorName() string { return "DiffValidationError" }
-
-// Error satisfies the builtin error interface
-func (e DiffValidationError) Error() string {
-	cause := ""
-	if e.cause != nil {
-		cause = fmt.Sprintf(" | caused by: %v", e.cause)
-	}
-
-	key := ""
-	if e.key {
-		key = "key for "
-	}
-
-	return fmt.Sprintf(
-		"invalid %sDiff.%s: %s%s",
-		key,
-		e.field,
-		e.reason,
-		cause)
-}
-
-var _ error = DiffValidationError{}
-
-var _ interface {
-	Field() string
-	Reason() string
-	Key() bool
-	Cause() error
-	ErrorName() string
-} = DiffValidationError{}
 
 // Validate checks the field values on Label with the rules defined in the
 // proto definition for this message. If any rules are violated, the first

--- a/api/go/v1alpha1/model_grpc.pb.go
+++ b/api/go/v1alpha1/model_grpc.pb.go
@@ -46,7 +46,7 @@ type ModelsClient interface {
 	ListModelCommits(ctx context.Context, in *ListModelCommitsRequest, opts ...grpc.CallOption) (*ListModelCommitsResponse, error)
 	GetModelCommit(ctx context.Context, in *GetModelCommitRequest, opts ...grpc.CallOption) (*Commit, error)
 	GetModelTree(ctx context.Context, in *GetModelTreeRequest, opts ...grpc.CallOption) (*GetModelTreeResponse, error)
-	GetModelBlob(ctx context.Context, in *GetModelBlobRequest, opts ...grpc.CallOption) (*GetModelBlobResponse, error)
+	GetModelBlob(ctx context.Context, in *GetModelBlobRequest, opts ...grpc.CallOption) (*File, error)
 }
 
 type modelsClient struct {
@@ -157,9 +157,9 @@ func (c *modelsClient) GetModelTree(ctx context.Context, in *GetModelTreeRequest
 	return out, nil
 }
 
-func (c *modelsClient) GetModelBlob(ctx context.Context, in *GetModelBlobRequest, opts ...grpc.CallOption) (*GetModelBlobResponse, error) {
+func (c *modelsClient) GetModelBlob(ctx context.Context, in *GetModelBlobRequest, opts ...grpc.CallOption) (*File, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(GetModelBlobResponse)
+	out := new(File)
 	err := c.cc.Invoke(ctx, Models_GetModelBlob_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
@@ -181,7 +181,7 @@ type ModelsServer interface {
 	ListModelCommits(context.Context, *ListModelCommitsRequest) (*ListModelCommitsResponse, error)
 	GetModelCommit(context.Context, *GetModelCommitRequest) (*Commit, error)
 	GetModelTree(context.Context, *GetModelTreeRequest) (*GetModelTreeResponse, error)
-	GetModelBlob(context.Context, *GetModelBlobRequest) (*GetModelBlobResponse, error)
+	GetModelBlob(context.Context, *GetModelBlobRequest) (*File, error)
 }
 
 // UnimplementedModelsServer should be embedded to have
@@ -221,7 +221,7 @@ func (UnimplementedModelsServer) GetModelCommit(context.Context, *GetModelCommit
 func (UnimplementedModelsServer) GetModelTree(context.Context, *GetModelTreeRequest) (*GetModelTreeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetModelTree not implemented")
 }
-func (UnimplementedModelsServer) GetModelBlob(context.Context, *GetModelBlobRequest) (*GetModelBlobResponse, error) {
+func (UnimplementedModelsServer) GetModelBlob(context.Context, *GetModelBlobRequest) (*File, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetModelBlob not implemented")
 }
 func (UnimplementedModelsServer) testEmbeddedByValue() {}

--- a/api/openapiv2/v1alpha1/dataset.swagger.json
+++ b/api/openapiv2/v1alpha1/dataset.swagger.json
@@ -615,15 +615,7 @@
     "v1alpha1DeleteDatasetResponse": {
       "type": "object"
     },
-    "v1alpha1FileType": {
-      "type": "string",
-      "enum": [
-        "DIR",
-        "FILE"
-      ],
-      "default": "DIR"
-    },
-    "v1alpha1Files": {
+    "v1alpha1File": {
       "type": "object",
       "properties": {
         "name": {
@@ -648,8 +640,19 @@
         "commit": {
           "$ref": "#/definitions/v1alpha1Commit",
           "title": "commit with out diffs\nonly file type have commit"
+        },
+        "url": {
+          "type": "string"
         }
       }
+    },
+    "v1alpha1FileType": {
+      "type": "string",
+      "enum": [
+        "DIR",
+        "FILE"
+      ],
+      "default": "DIR"
     },
     "v1alpha1GetDatasetBlobResponse": {
       "type": "object",
@@ -672,7 +675,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1alpha1Files"
+            "$ref": "#/definitions/v1alpha1File"
           }
         }
       }

--- a/api/openapiv2/v1alpha1/model.swagger.json
+++ b/api/openapiv2/v1alpha1/model.swagger.json
@@ -239,7 +239,7 @@
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/v1alpha1GetModelBlobResponse"
+              "$ref": "#/definitions/v1alpha1File"
             }
           },
           "default": {
@@ -594,15 +594,7 @@
     "v1alpha1DeleteModelResponse": {
       "type": "object"
     },
-    "v1alpha1FileType": {
-      "type": "string",
-      "enum": [
-        "DIR",
-        "FILE"
-      ],
-      "default": "DIR"
-    },
-    "v1alpha1Files": {
+    "v1alpha1File": {
       "type": "object",
       "properties": {
         "name": {
@@ -627,22 +619,19 @@
         "commit": {
           "$ref": "#/definitions/v1alpha1Commit",
           "title": "commit with out diffs\nonly file type have commit"
-        }
-      }
-    },
-    "v1alpha1GetModelBlobResponse": {
-      "type": "object",
-      "properties": {
-        "lfs": {
-          "type": "boolean"
-        },
-        "content": {
-          "type": "string"
         },
         "url": {
           "type": "string"
         }
       }
+    },
+    "v1alpha1FileType": {
+      "type": "string",
+      "enum": [
+        "DIR",
+        "FILE"
+      ],
+      "default": "DIR"
     },
     "v1alpha1GetModelTreeResponse": {
       "type": "object",
@@ -651,7 +640,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "$ref": "#/definitions/v1alpha1Files"
+            "$ref": "#/definitions/v1alpha1File"
           }
         }
       }

--- a/api/proto/v1alpha1/dataset.proto
+++ b/api/proto/v1alpha1/dataset.proto
@@ -143,7 +143,7 @@ message GetDatasetTreeRequest {
 }
 
 message GetDatasetTreeResponse {
-  repeated Files items = 1;
+  repeated File items = 1;
 }
 
 message GetDatasetBlobRequest {

--- a/api/proto/v1alpha1/model.proto
+++ b/api/proto/v1alpha1/model.proto
@@ -60,7 +60,7 @@ service Models {
       get: "/api/v1alpha1/models/{project}/{name}/tree"
     };
   }
-  rpc GetModelBlob(GetModelBlobRequest) returns (GetModelBlobResponse) {
+  rpc GetModelBlob(GetModelBlobRequest) returns (File) {
     option (google.api.http) = {
       get: "/api/v1alpha1/models/{project}/{name}/blob"
     };
@@ -160,7 +160,7 @@ message GetModelTreeRequest {
   string path = 4;
 }
 
-message Files {
+message File {
   string name = 1;
   FileType type = 2;
   string path = 3;
@@ -170,10 +170,11 @@ message Files {
   // commit with out diffs
   // only file type have commit
   Commit commit = 7;
+  string url = 8;
 }
 
 message GetModelTreeResponse {
-  repeated Files items = 1;
+  repeated File items = 1;
 }
 
 message GetModelBlobRequest {
@@ -181,12 +182,6 @@ message GetModelBlobRequest {
   string name = 2 [(validate.rules).string.min_len = 1];
   string revision = 3;
   string path = 4;
-}
-
-message GetModelBlobResponse {
-  bool lfs = 1;
-  string content = 2;
-  string url = 3;
 }
 
 message Model {
@@ -239,18 +234,10 @@ message Commit {
   string updated_at = 10;
 }
 
-message Diff {
-  string diff = 1;
-  bool Deleted = 2;
-  string new_path = 3;
-  string old_path = 4;
-}
-
 message Label {
   int32 id = 1;
   string name = 2;
   Category category = 3;
   string created_at = 4;
   string updated_at = 5;
-
 }

--- a/api/ts/v1alpha1/dataset.pb.ts
+++ b/api/ts/v1alpha1/dataset.pb.ts
@@ -87,7 +87,7 @@ export type GetDatasetTreeRequest = {
 }
 
 export type GetDatasetTreeResponse = {
-  items?: MatrixhubV1alpha1Model.Files[]
+  items?: MatrixhubV1alpha1Model.File[]
 }
 
 export type GetDatasetBlobRequest = {

--- a/api/ts/v1alpha1/model.pb.ts
+++ b/api/ts/v1alpha1/model.pb.ts
@@ -111,7 +111,7 @@ export type GetModelTreeRequest = {
   path?: string
 }
 
-export type Files = {
+export type File = {
   name?: string
   type?: FileType
   path?: string
@@ -119,10 +119,11 @@ export type Files = {
   lfs?: boolean
   sha256?: string
   commit?: Commit
+  url?: string
 }
 
 export type GetModelTreeResponse = {
-  items?: Files[]
+  items?: File[]
 }
 
 export type GetModelBlobRequest = {
@@ -130,12 +131,6 @@ export type GetModelBlobRequest = {
   name?: string
   revision?: string
   path?: string
-}
-
-export type GetModelBlobResponse = {
-  lfs?: boolean
-  content?: string
-  url?: string
 }
 
 export type Model = {
@@ -173,13 +168,6 @@ export type Commit = {
   diff?: string
   createdAt?: string
   updatedAt?: string
-}
-
-export type Diff = {
-  diff?: string
-  deleted?: boolean
-  newPath?: string
-  oldPath?: string
 }
 
 export type Label = {
@@ -221,7 +209,7 @@ export class Models {
   static GetModelTree(req: GetModelTreeRequest, initReq?: fm.InitReq): Promise<GetModelTreeResponse> {
     return fm.fetchReq<GetModelTreeRequest, GetModelTreeResponse>(`/api/v1alpha1/models/${req["project"]}/${req["name"]}/tree?${fm.renderURLSearchParams(req, ["project", "name"])}`, {...initReq, method: "GET"})
   }
-  static GetModelBlob(req: GetModelBlobRequest, initReq?: fm.InitReq): Promise<GetModelBlobResponse> {
-    return fm.fetchReq<GetModelBlobRequest, GetModelBlobResponse>(`/api/v1alpha1/models/${req["project"]}/${req["name"]}/blob?${fm.renderURLSearchParams(req, ["project", "name"])}`, {...initReq, method: "GET"})
+  static GetModelBlob(req: GetModelBlobRequest, initReq?: fm.InitReq): Promise<File> {
+    return fm.fetchReq<GetModelBlobRequest, File>(`/api/v1alpha1/models/${req["project"]}/${req["name"]}/blob?${fm.renderURLSearchParams(req, ["project", "name"])}`, {...initReq, method: "GET"})
   }
 }

--- a/internal/apiserver/handler/model_handler.go
+++ b/internal/apiserver/handler/model_handler.go
@@ -140,14 +140,14 @@ func commitToProto(c *git.Commit) *modelv1alpha1.Commit {
 	}
 }
 
-// treeEntryToProtoFile converts domain git.TreeEntry to proto Files
-func treeEntryToProtoFile(entry *git.TreeEntry) *modelv1alpha1.Files {
+// treeEntryToProtoFile converts domain git.TreeEntry to proto File
+func treeEntryToProtoFile(entry *git.TreeEntry) *modelv1alpha1.File {
 	var protoCommit *modelv1alpha1.Commit
 	if entry.Commit != nil {
 		protoCommit = commitToProto(entry.Commit)
 	}
 
-	return &modelv1alpha1.Files{
+	return &modelv1alpha1.File{
 		Name:   entry.Name,
 		Type:   modelv1alpha1.FileType(entry.Type),
 		Path:   entry.Path,
@@ -155,6 +155,7 @@ func treeEntryToProtoFile(entry *git.TreeEntry) *modelv1alpha1.Files {
 		Lfs:    entry.IsLFS,
 		Sha256: entry.Hash,
 		Commit: protoCommit,
+		Url:    entry.URL,
 	}
 }
 
@@ -393,7 +394,7 @@ func (mh *ModelHandler) GetModelTree(ctx context.Context, request *modelv1alpha1
 	}
 
 	// Convert to proto
-	items := make([]*modelv1alpha1.Files, len(entries))
+	items := make([]*modelv1alpha1.File, len(entries))
 	for i, entry := range entries {
 		items[i] = treeEntryToProtoFile(entry)
 	}
@@ -403,6 +404,22 @@ func (mh *ModelHandler) GetModelTree(ctx context.Context, request *modelv1alpha1
 	}, nil
 }
 
-func (mh *ModelHandler) GetModelBlob(ctx context.Context, request *modelv1alpha1.GetModelBlobRequest) (*modelv1alpha1.GetModelBlobResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "Not implemented")
+func (mh *ModelHandler) GetModelBlob(ctx context.Context, request *modelv1alpha1.GetModelBlobRequest) (*modelv1alpha1.File, error) {
+	if err := request.ValidateAll(); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	entry, err := mh.ms.GetModelBlob(ctx, request.Project, request.Name, request.Revision, request.Path)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "does not exist") {
+			return nil, status.Error(codes.NotFound, err.Error())
+		}
+		return nil, status.Error(codes.Internal, "failed to get blob")
+	}
+
+	if entry.Type == git.FileTypeDir {
+		return nil, status.Error(codes.InvalidArgument, "path must reference a file blob")
+	}
+
+	return treeEntryToProtoFile(entry), nil
 }

--- a/internal/repo/git_repo.go
+++ b/internal/repo/git_repo.go
@@ -62,7 +62,37 @@ func (g *gitRepo) gitPath(repoType string, project, name string) string {
 }
 
 func (g *gitRepo) buildURL(repoType, project, name, revision, path string) string {
+	if revision == "" {
+		revision = "main"
+	}
 	return fmt.Sprintf("/%s/%s/resolve/%s/%s", repoPrefix(repoType)+project, name, revision, path)
+}
+
+// resolveRef disambiguates a short revision name by trying refs/heads/ before refs/tags/.
+// Already-qualified refs (refs/heads/..., refs/tags/...) and 40-char SHAs pass through unchanged.
+func resolveRef(repo *repository.Repository, rev string) string {
+	if rev == "" || strings.HasPrefix(rev, "refs/") || isCommitSHA(rev) {
+		return rev
+	}
+	if _, err := repo.ResolveRevision("refs/heads/" + rev); err == nil {
+		return "refs/heads/" + rev
+	}
+	if _, err := repo.ResolveRevision("refs/tags/" + rev); err == nil {
+		return "refs/tags/" + rev
+	}
+	return rev
+}
+
+func isCommitSHA(s string) bool {
+	if len(s) != 40 {
+		return false
+	}
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
+			return false
+		}
+	}
+	return true
 }
 
 // CreateRepository initializes a Git repository
@@ -164,6 +194,7 @@ func (g *gitRepo) ListCommits(ctx context.Context, project, name, revision strin
 		return nil, 0, err
 	}
 
+	revision = resolveRef(repo, revision)
 	commits, err := repo.Commits(revision, nil)
 	if err != nil {
 		return nil, 0, err
@@ -246,6 +277,7 @@ func (g *gitRepo) GetTree(ctx context.Context, project, name, revision, path str
 		return nil, err
 	}
 
+	revision = resolveRef(repo, revision)
 	entries, err := repo.Tree(revision, path, &repository.TreeOptions{
 		Recursive: false,
 	})
@@ -321,6 +353,7 @@ func (g *gitRepo) GetBlob(ctx context.Context, project, name, revision, path str
 		return nil, err
 	}
 
+	revision = resolveRef(repo, revision)
 	blob, err := repo.Blob(revision, path)
 	if err != nil {
 		// Check if it's a directory


### PR DESCRIPTION


#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:
  - Rename proto message `Files` → `File` across model and dataset APIs (Go, TS, Swagger)
  - Add `url` field (field 8) to `File` message, populated from git storage resolve path
  - Change `GetModelBlob` RPC return type from `GetModelBlobResponse` to `File`, reusing the unified file structure instead of a separate response type
  - Implement `GetModelBlob` handler: validate input, delegate to service layer, reject directory paths with INVALID_ARGUMENT
  - Remove unused messages: `GetModelBlobResponse`, `Diff`
  - Regenerate all derived artifacts (pb.go, validate.go, grpc.pb.go, pb.gw.go,swagger.json, pb.ts) to reflect proto changes

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #156 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```