### PR TITLE
feat(ui): optimize default error and pending router components

### DIFF
--- a/ui/src/locales/en/shared.json
+++ b/ui/src/locales/en/shared.json
@@ -17,5 +17,15 @@
     "actions": {
       "detail": "Detail"
     }
+  },
+  "components": {
+    "RouterErrorComponent": {
+      "somethingWentWrong": "Something went wrong",
+      "reload": "Reload",
+      "backToHome": "Back to Home"
+    },
+    "RouterPendingComponent": {
+      "loading": "Loading..."
+    }
   }
 }

--- a/ui/src/locales/zh/shared.json
+++ b/ui/src/locales/zh/shared.json
@@ -17,5 +17,15 @@
     "actions": {
       "detail": "详情"
     }
+  },
+  "components": {
+    "RouterErrorComponent": {
+      "somethingWentWrong": "出错了",
+      "reload": "重新加载",
+      "backToHome": "返回首页"
+    },
+    "RouterPendingComponent": {
+      "loading": "加载中..."
+    }
   }
 }

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -2,6 +2,8 @@ import { createRouter } from '@tanstack/react-router'
 
 import { queryClient } from './queryClient'
 import { routeTree } from './routeTree.gen.ts'
+import { RouterErrorComponent } from './shared/components/RouterErrorComponent'
+import { RouterPendingComponent } from './shared/components/RouterPendingComponent'
 
 const rawBasePath = import.meta.env.VITE_UI_BASE_PATH ?? '/'
 
@@ -12,6 +14,8 @@ export const router = createRouter({
   context: {
     queryClient,
   },
+  defaultErrorComponent: RouterErrorComponent,
+  defaultPendingComponent: RouterPendingComponent,
 })
 
 declare module '@tanstack/react-router' {

--- a/ui/src/shared/components/RouterErrorComponent.tsx
+++ b/ui/src/shared/components/RouterErrorComponent.tsx
@@ -1,0 +1,73 @@
+import {
+  Alert,
+  Button,
+  Center, Group, Stack, Text,
+} from '@mantine/core'
+import { IconAlertCircle, IconRefresh } from '@tabler/icons-react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useRouter } from '@tanstack/react-router'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface RouterErrorComponentProps {
+  error: unknown
+}
+
+export function RouterErrorComponent({ error }: RouterErrorComponentProps) {
+  const { t } = useTranslation()
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const [isReloading, setIsReloading] = useState(false)
+
+  const handleReload = async () => {
+    try {
+      setIsReloading(true)
+      // 1. Reset all queries in the query client
+      await queryClient.resetQueries()
+
+      // 2. Invalidate the current route to re-run the loader
+      await router.invalidate()
+    } catch (error) {
+      console.error('Failed to reload router state:', error)
+    } finally {
+      setIsReloading(false)
+    }
+  }
+
+  return (
+    <Center h="100%" p="xl" style={{ flexGrow: 1 }}>
+      <Stack align="center" gap="lg" maw={500}>
+        <Alert
+          variant="light"
+          color="red"
+          title={t('shared.components.RouterErrorComponent.somethingWentWrong')}
+          icon={<IconAlertCircle size={20} />}
+          w="100%"
+        >
+          <Text size="sm" style={{ wordBreak: 'break-word' }}>
+            {error instanceof Error ? error.message : String(error)}
+          </Text>
+        </Alert>
+        <Group>
+          <Button
+            variant="outline"
+            leftSection={<IconRefresh size={16} />}
+            loading={isReloading}
+            onClick={() => void handleReload()}
+          >
+            {t('shared.components.RouterErrorComponent.reload')}
+          </Button>
+          <Button
+            variant="filled"
+            disabled={isReloading}
+            onClick={() => {
+              router.navigate({ to: '/' })
+            }}
+          >
+            {t('shared.components.RouterErrorComponent.backToHome')}
+          </Button>
+        </Group>
+      </Stack>
+    </Center>
+  )
+}

--- a/ui/src/shared/components/RouterPendingComponent.tsx
+++ b/ui/src/shared/components/RouterPendingComponent.tsx
@@ -1,0 +1,19 @@
+import {
+  Center, Loader, Stack, Text,
+} from '@mantine/core'
+import { useTranslation } from 'react-i18next'
+
+export function RouterPendingComponent() {
+  const { t } = useTranslation()
+
+  return (
+    <Center h="100%" p="xl" style={{ flexGrow: 1 }}>
+      <Stack align="center" gap="md">
+        <Loader size="lg" type="dots" />
+        <Text c="dimmed" size="sm" fw={500}>
+          {t('shared.components.RouterPendingComponent.loading')}
+        </Text>
+      </Stack>
+    </Center>
+  )
+}


### PR DESCRIPTION
This PR improves the user experience by optimizing the default error and pending components of the router. 

Key changes:
- Created dedicated components for router error and loading states using Mantine UI.
- Implemented a 'soft reload' mechanism using queryClient.resetQueries() and router.invalidate().
- Refactored i18n loading to support nested directory structures and path-based key resolution.
- Added localized translations for both English and Chinese in a path-matching directory structure.
- Improved handleReload with a loading state to prevent multiple clicks.