### PR TITLE
fix(ui): update project related style

### DIFF
--- a/ui/src/features/projects/components/ProjectsTable.tsx
+++ b/ui/src/features/projects/components/ProjectsTable.tsx
@@ -95,7 +95,7 @@ function ProjectActionsCell({
   )
 }
 
-export type ProjectsTableProps = Omit<DataTableProps<Project>, 'onBatchDelete' | 'columns'> & {
+export type ProjectsTableProps = Omit<DataTableProps<Project>, 'columns'> & {
   onDelete?: (project: Project) => void
 }
 

--- a/ui/src/features/projects/members/pages/ProjectMembersPage.tsx
+++ b/ui/src/features/projects/members/pages/ProjectMembersPage.tsx
@@ -23,7 +23,7 @@ export function ProjectMembersPage() {
   const search = membersRouteApi.useSearch()
 
   const {
-    data, isLoading, refetch,
+    data, isLoading, isFetching, refetch,
   } = useMembers(projectId, {
     q: search.q,
     page: search.page,
@@ -125,6 +125,7 @@ export function ProjectMembersPage() {
         pagination={pagination}
         page={search.page}
         loading={isLoading}
+        fetching={isFetching}
         searchValue={search.q}
         onSearchChange={handleSearchChange}
         onRefresh={handleRefresh}

--- a/ui/src/features/projects/pages/ProjectsPage.tsx
+++ b/ui/src/features/projects/pages/ProjectsPage.tsx
@@ -80,8 +80,8 @@ export function ProjectsPage() {
   return (
     <Stack gap="lg" pt="lg">
       <Group gap="sm">
-        <ProjectIcon size={24} />
-        <Title order={2}>{t('projects.title')}</Title>
+        <ProjectIcon size={32} />
+        <Title order={4}>{t('projects.title')}</Title>
       </Group>
 
       <Paper>

--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as authappProfileAccessTokenRouteImport } from './routes/(auth)/(
 import { Route as authappModelsNewRouteImport } from './routes/(auth)/(app)/models/new'
 import { Route as authappDatasetsNewRouteImport } from './routes/(auth)/(app)/datasets/new'
 import { Route as authappProjectsProjectIdRouteRouteImport } from './routes/(auth)/(app)/projects/$projectId/route'
+import { Route as authappProjectsProjectIdIndexRouteImport } from './routes/(auth)/(app)/projects/$projectId/index'
 import { Route as authAdminReplicationsReplicationIdExecutionsRouteImport } from './routes/(auth)/admin/replications_.$replicationId.executions'
 import { Route as authappProjectsProjectIdSettingsIndexRouteImport } from './routes/(auth)/(app)/projects/$projectId/settings/index'
 import { Route as authappProjectsProjectIdModelsIndexRouteImport } from './routes/(auth)/(app)/projects/$projectId/models/index'
@@ -147,6 +148,12 @@ const authappProjectsProjectIdRouteRoute =
     id: '/projects/$projectId',
     path: '/projects/$projectId',
     getParentRoute: () => authappRouteRoute,
+  } as any)
+const authappProjectsProjectIdIndexRoute =
+  authappProjectsProjectIdIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => authappProjectsProjectIdRouteRoute,
   } as any)
 const authAdminReplicationsReplicationIdExecutionsRoute =
   authAdminReplicationsReplicationIdExecutionsRouteImport.update({
@@ -279,6 +286,7 @@ export interface FileRoutesByFullPath {
   '/profile/': typeof authappProfileIndexRoute
   '/projects/': typeof authappProjectsIndexRoute
   '/admin/replications/$replicationId/executions': typeof authAdminReplicationsReplicationIdExecutionsRoute
+  '/projects/$projectId/': typeof authappProjectsProjectIdIndexRoute
   '/projects/$projectId/datasets/$datasetId': typeof authappProjectsProjectIdDatasetsDatasetIdRouteRouteWithChildren
   '/projects/$projectId/models/$modelId': typeof authappProjectsProjectIdModelsModelIdRouteRouteWithChildren
   '/projects/$projectId/datasets/': typeof authappProjectsProjectIdDatasetsIndexRoute
@@ -305,7 +313,6 @@ export interface FileRoutesByTo {
   '/admin/replications': typeof authAdminReplicationsRoute
   '/admin/users': typeof authAdminUsersRoute
   '/admin': typeof authAdminIndexRoute
-  '/projects/$projectId': typeof authappProjectsProjectIdRouteRouteWithChildren
   '/datasets/new': typeof authappDatasetsNewRoute
   '/models/new': typeof authappModelsNewRoute
   '/profile/access-token': typeof authappProfileAccessTokenRoute
@@ -315,6 +322,7 @@ export interface FileRoutesByTo {
   '/profile': typeof authappProfileIndexRoute
   '/projects': typeof authappProjectsIndexRoute
   '/admin/replications/$replicationId/executions': typeof authAdminReplicationsReplicationIdExecutionsRoute
+  '/projects/$projectId': typeof authappProjectsProjectIdIndexRoute
   '/projects/$projectId/datasets/$datasetId': typeof authappProjectsProjectIdDatasetsDatasetIdRouteRouteWithChildren
   '/projects/$projectId/datasets': typeof authappProjectsProjectIdDatasetsIndexRoute
   '/projects/$projectId/members': typeof authappProjectsProjectIdMembersIndexRoute
@@ -355,6 +363,7 @@ export interface FileRoutesById {
   '/(auth)/(app)/profile/': typeof authappProfileIndexRoute
   '/(auth)/(app)/projects/': typeof authappProjectsIndexRoute
   '/(auth)/admin/replications_/$replicationId/executions': typeof authAdminReplicationsReplicationIdExecutionsRoute
+  '/(auth)/(app)/projects/$projectId/': typeof authappProjectsProjectIdIndexRoute
   '/(auth)/(app)/projects_/$projectId/datasets/$datasetId': typeof authappProjectsProjectIdDatasetsDatasetIdRouteRouteWithChildren
   '/(auth)/(app)/projects_/$projectId/models/$modelId': typeof authappProjectsProjectIdModelsModelIdRouteRouteWithChildren
   '/(auth)/(app)/projects/$projectId/datasets/': typeof authappProjectsProjectIdDatasetsIndexRoute
@@ -395,6 +404,7 @@ export interface FileRouteTypes {
     | '/profile/'
     | '/projects/'
     | '/admin/replications/$replicationId/executions'
+    | '/projects/$projectId/'
     | '/projects/$projectId/datasets/$datasetId'
     | '/projects/$projectId/models/$modelId'
     | '/projects/$projectId/datasets/'
@@ -421,7 +431,6 @@ export interface FileRouteTypes {
     | '/admin/replications'
     | '/admin/users'
     | '/admin'
-    | '/projects/$projectId'
     | '/datasets/new'
     | '/models/new'
     | '/profile/access-token'
@@ -431,6 +440,7 @@ export interface FileRouteTypes {
     | '/profile'
     | '/projects'
     | '/admin/replications/$replicationId/executions'
+    | '/projects/$projectId'
     | '/projects/$projectId/datasets/$datasetId'
     | '/projects/$projectId/datasets'
     | '/projects/$projectId/members'
@@ -470,6 +480,7 @@ export interface FileRouteTypes {
     | '/(auth)/(app)/profile/'
     | '/(auth)/(app)/projects/'
     | '/(auth)/admin/replications_/$replicationId/executions'
+    | '/(auth)/(app)/projects/$projectId/'
     | '/(auth)/(app)/projects_/$projectId/datasets/$datasetId'
     | '/(auth)/(app)/projects_/$projectId/models/$modelId'
     | '/(auth)/(app)/projects/$projectId/datasets/'
@@ -638,6 +649,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof authappProjectsProjectIdRouteRouteImport
       parentRoute: typeof authappRouteRoute
     }
+    '/(auth)/(app)/projects/$projectId/': {
+      id: '/(auth)/(app)/projects/$projectId/'
+      path: '/'
+      fullPath: '/projects/$projectId/'
+      preLoaderRoute: typeof authappProjectsProjectIdIndexRouteImport
+      parentRoute: typeof authappProjectsProjectIdRouteRoute
+    }
     '/(auth)/admin/replications_/$replicationId/executions': {
       id: '/(auth)/admin/replications_/$replicationId/executions'
       path: '/replications/$replicationId/executions'
@@ -783,6 +801,7 @@ const authappProfileRouteRouteWithChildren =
   authappProfileRouteRoute._addFileChildren(authappProfileRouteRouteChildren)
 
 interface authappProjectsProjectIdRouteRouteChildren {
+  authappProjectsProjectIdIndexRoute: typeof authappProjectsProjectIdIndexRoute
   authappProjectsProjectIdDatasetsIndexRoute: typeof authappProjectsProjectIdDatasetsIndexRoute
   authappProjectsProjectIdMembersIndexRoute: typeof authappProjectsProjectIdMembersIndexRoute
   authappProjectsProjectIdModelsIndexRoute: typeof authappProjectsProjectIdModelsIndexRoute
@@ -791,6 +810,7 @@ interface authappProjectsProjectIdRouteRouteChildren {
 
 const authappProjectsProjectIdRouteRouteChildren: authappProjectsProjectIdRouteRouteChildren =
   {
+    authappProjectsProjectIdIndexRoute: authappProjectsProjectIdIndexRoute,
     authappProjectsProjectIdDatasetsIndexRoute:
       authappProjectsProjectIdDatasetsIndexRoute,
     authappProjectsProjectIdMembersIndexRoute:

--- a/ui/src/routes/(auth)/(app)/projects/$projectId/index.tsx
+++ b/ui/src/routes/(auth)/(app)/projects/$projectId/index.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/(auth)/(app)/projects/$projectId/')({
+  beforeLoad: ({ params: { projectId } }) => {
+    throw redirect({
+      to: '/projects/$projectId/models',
+      params: { projectId },
+    })
+  },
+})

--- a/ui/src/routes/(auth)/(app)/projects/$projectId/models/index.tsx
+++ b/ui/src/routes/(auth)/(app)/projects/$projectId/models/index.tsx
@@ -7,10 +7,10 @@ import { ProjectModelsPage } from '@/features/projects/pages/ProjectModelsPage'
 // -- URL search schema (route concern) --
 
 const modelsSearchSchema = z.object({
-  q: z.string().transform(v => v.trim()).catch(''),
-  sort: z.literal('updatedAt').catch('updatedAt'),
-  order: z.enum(['asc', 'desc']).catch('desc'),
-  page: z.coerce.number().int().positive().catch(1),
+  q: z.string().optional().transform(v => v?.trim() ?? '').catch(''),
+  sort: z.literal('updatedAt').optional().transform(v => v ?? 'updatedAt').catch('updatedAt'),
+  order: z.enum(['asc', 'desc']).optional().transform(v => v ?? 'desc').catch('desc'),
+  page: z.coerce.number().int().positive().optional().transform(v => v ?? 1).catch(1),
 })
 
 // -- Route definition --

--- a/ui/src/routes/(auth)/(app)/projects/$projectId/route.tsx
+++ b/ui/src/routes/(auth)/(app)/projects/$projectId/route.tsx
@@ -72,15 +72,19 @@ function RouteComponent() {
   return (
     <Box>
       <Space h="lg" />
-      <Group gap={4} wrap="nowrap">
-        <ProjectIcon size={20} style={{ color: 'var(--mantine-gray-7)' }} />
-        <Text size="md" c="gray.8">
-          {projectId}
-          {' '}
-          /
-          {' '}
-          {activeTabLabel}
-        </Text>
+      <Group gap={8} wrap="nowrap" align="center">
+        <ProjectIcon size={32} style={{ color: 'var(--mantine-color-gray-9)' }} />
+        <Group gap={4} wrap="nowrap" align="center">
+          <Text size="lg" lh="28px" c="gray.9">
+            {projectId}
+          </Text>
+          <Text size="lg" lh="24px" w="24" c="gray.6" ta="center">
+            /
+          </Text>
+          <Text size="lg" lh="24px" c="gray.9">
+            {activeTabLabel}
+          </Text>
+        </Group>
       </Group>
 
       <Tabs

--- a/ui/src/shared/components/DataTable.tsx
+++ b/ui/src/shared/components/DataTable.tsx
@@ -248,17 +248,19 @@ export function DataTable<TData extends MRT_RowData>({
               <IconRefresh size={24} />
             </ActionIcon>
           )}
-          <Button
-            color="red"
-            variant="light"
-            disabled={!showBatchDelete}
-            leftSection={<IconTrash size={16} />}
-            onClick={onBatchDelete}
-          >
-            {!selectedCount
-              ? t('shared.batchDelete')
-              : t('shared.batchDeleteWithCount', { count: selectedCount })}
-          </Button>
+          {onBatchDelete && (
+            <Button
+              color="red"
+              variant="light"
+              disabled={!showBatchDelete}
+              leftSection={<IconTrash size={16} />}
+              onClick={onBatchDelete}
+            >
+              {!selectedCount
+                ? t('shared.batchDelete')
+                : t('shared.batchDeleteWithCount', { count: selectedCount })}
+            </Button>
+          )}
 
           {toolbarExtra}
         </SearchToolbar>


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

1. **Auto-redirect on project detail entry**: Previously, navigating to `/projects/$projectId` would render the layout shell without loading any tab content. A new **index route** (`projects/$projectId/index.tsx`) was added that performs a `beforeLoad` redirect to `/projects/$projectId/models`, ensuring users always land on the first available tab (Models).

2. **Search params made optional for redirect compatibility**: The models route's Zod search schema (`q`, `sort`, `order`, `page`) was updated to make all fields `.optional()` with fallback defaults. This allows the redirect to work without explicitly passing every search parameter.

3. **Project detail header redesign**: The breadcrumb-style header (`projectId / tabLabel`) was restyled — larger icon (20→32px), bigger text (`md`→`lg`), proper color tokens (`gray-9` instead of `gray-7`/`gray-8`), and better layout structure with separate `<Text>` elements for the project name, slash separator, and active tab label.

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```