### PR TITLE
feat: add model-level authorization and ListModels permission filtering

### DIFF
--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -338,7 +338,7 @@ func (server *APIServer) initHandlersServicesRepos() {
 		handler.NewCurrentUserHandler(repos.User, repos.AccessToken),
 		handler.NewUserHandler(repos.User, authzService),
 		handler.NewDatasetHandler(datasetService),
-		handler.NewModelHandler(modelService),
+		handler.NewModelHandler(modelService, authzService),
 		handler.NewSyncPolicyHandler(syncPolicyService, repos.Registry),
 	}
 

--- a/internal/apiserver/handler/model_handler.go
+++ b/internal/apiserver/handler/model_handler.go
@@ -24,19 +24,23 @@ import (
 	"google.golang.org/grpc/status"
 
 	modelv1alpha1 "github.com/matrixhub-ai/matrixhub/api/go/v1alpha1"
+	"github.com/matrixhub-ai/matrixhub/internal/domain/authz"
 	"github.com/matrixhub-ai/matrixhub/internal/domain/git"
 	"github.com/matrixhub-ai/matrixhub/internal/domain/model"
+	"github.com/matrixhub-ai/matrixhub/internal/domain/user"
 	"github.com/matrixhub-ai/matrixhub/internal/infra/log"
 	"github.com/matrixhub-ai/matrixhub/internal/infra/utils"
 )
 
 type ModelHandler struct {
-	ms model.IModelService
+	ms           model.IModelService
+	authzService authz.IAuthzService
 }
 
-func NewModelHandler(modelService model.IModelService) IHandler {
+func NewModelHandler(modelService model.IModelService, authzService authz.IAuthzService) IHandler {
 	handler := &ModelHandler{
-		ms: modelService,
+		ms:           modelService,
+		authzService: authzService,
 	}
 	return handler
 }
@@ -160,12 +164,32 @@ func treeEntryToProtoFile(entry *git.TreeEntry) *modelv1alpha1.File {
 	}
 }
 
-func (mh *ModelHandler) RegisterToServer(options *ServerOptions) {
-	// Register GRPC Handler
-	modelv1alpha1.RegisterModelsServer(options.GRPCServer, mh)
-	if err := modelv1alpha1.RegisterModelsHandlerServer(context.Background(), options.GatewayMux, mh); err != nil {
+func (mh *ModelHandler) RegisterToServer(opt *ServerOptions) {
+	modelv1alpha1.RegisterModelsServer(opt.GRPCServer, mh)
+	if err := modelv1alpha1.RegisterModelsHandlerFromEndpoint(context.Background(), opt.GatewayMux, opt.GRPCAddr, opt.GRPCDialOpt); err != nil {
 		log.Errorf("register model handler error: %s", err.Error())
 	}
+}
+
+func (mh *ModelHandler) getAccessibleProjectIDs(ctx context.Context) ([]int, error) {
+	userIDVal := ctx.Value(user.UserIdCtxKey)
+	if userIDVal == nil {
+		return mh.authzService.GetUserAccessibleProjectIDs(ctx, 0)
+	}
+	userID, ok := userIDVal.(int)
+	if !ok {
+		return mh.authzService.GetUserAccessibleProjectIDs(ctx, 0)
+	}
+
+	allowed, err := mh.authzService.VerifyPlatformPermission(ctx, "*.*")
+	if err != nil {
+		return nil, err
+	}
+	if allowed {
+		return nil, nil
+	}
+
+	return mh.authzService.GetUserAccessibleProjectIDs(ctx, userID)
 }
 
 func (mh *ModelHandler) ListModelTaskLabels(ctx context.Context, request *modelv1alpha1.ListModelTaskLabelsRequest) (*modelv1alpha1.ListModelTaskLabelsResponse, error) {
@@ -226,7 +250,22 @@ func (mh *ModelHandler) ListModels(ctx context.Context, request *modelv1alpha1.L
 		Project:  request.Project,
 		Page:     request.Page,
 		PageSize: request.PageSize,
-		Popular:  &request.Popular, // Pass popular parameter to filter
+		Popular:  &request.Popular,
+	}
+
+	// Inject accessible project IDs
+	projectIDs, err := mh.getAccessibleProjectIDs(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to get accessible projects")
+	}
+	if projectIDs != nil {
+		if len(projectIDs) == 0 {
+			return &modelv1alpha1.ListModelsResponse{
+				Items:      []*modelv1alpha1.Model{},
+				Pagination: &modelv1alpha1.Pagination{Total: 0, Page: request.Page, PageSize: request.PageSize},
+			}, nil
+		}
+		filter.ProjectIDs = projectIDs
 	}
 
 	// Call service
@@ -259,6 +298,11 @@ func (mh *ModelHandler) GetModel(ctx context.Context, request *modelv1alpha1.Get
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
+	// Verify permission
+	if allowed, err := mh.authzService.VerifyProjectPermissionByName(ctx, request.Project, authz.ModelGet); err != nil || !allowed {
+		return nil, status.Error(codes.PermissionDenied, "permission denied")
+	}
+
 	// Call service
 	model, err := mh.ms.GetModel(ctx, request.Project, request.Name)
 	if err != nil {
@@ -275,6 +319,11 @@ func (mh *ModelHandler) CreateModel(ctx context.Context, request *modelv1alpha1.
 	// Validate request
 	if err := request.ValidateAll(); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// Verify permission
+	if allowed, err := mh.authzService.VerifyProjectPermissionByName(ctx, request.Project, authz.ModelPush); err != nil || !allowed {
+		return nil, status.Error(codes.PermissionDenied, "permission denied")
 	}
 
 	// Call service
@@ -298,6 +347,11 @@ func (mh *ModelHandler) DeleteModel(ctx context.Context, request *modelv1alpha1.
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
+	// Verify permission
+	if allowed, err := mh.authzService.VerifyProjectPermissionByName(ctx, request.Project, authz.ModelDelete); err != nil || !allowed {
+		return nil, status.Error(codes.PermissionDenied, "permission denied")
+	}
+
 	// Call service
 	err := mh.ms.DeleteModel(ctx, request.Project, request.Name)
 	if err != nil {
@@ -314,6 +368,11 @@ func (mh *ModelHandler) ListModelRevisions(ctx context.Context, request *modelv1
 	// Validate request
 	if err := request.ValidateAll(); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// Verify permission
+	if allowed, err := mh.authzService.VerifyProjectPermissionByName(ctx, request.Project, authz.ModelGet); err != nil || !allowed {
+		return nil, status.Error(codes.PermissionDenied, "permission denied")
 	}
 
 	// Call service
@@ -335,6 +394,11 @@ func (mh *ModelHandler) ListModelCommits(ctx context.Context, request *modelv1al
 	// Validate request
 	if err := request.ValidateAll(); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// Verify permission
+	if allowed, err := mh.authzService.VerifyProjectPermissionByName(ctx, request.Project, authz.ModelGet); err != nil || !allowed {
+		return nil, status.Error(codes.PermissionDenied, "permission denied")
 	}
 
 	// Call service (diff parameter is ignored for now)
@@ -369,6 +433,11 @@ func (mh *ModelHandler) GetModelCommit(ctx context.Context, request *modelv1alph
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
+	// Verify permission
+	if allowed, err := mh.authzService.VerifyProjectPermissionByName(ctx, request.Project, authz.ModelGet); err != nil || !allowed {
+		return nil, status.Error(codes.PermissionDenied, "permission denied")
+	}
+
 	// Call service
 	commit, err := mh.ms.GetModelCommit(ctx, request.Project, request.Name, request.Id)
 	if err != nil {
@@ -385,6 +454,11 @@ func (mh *ModelHandler) GetModelTree(ctx context.Context, request *modelv1alpha1
 	// Validate request
 	if err := request.ValidateAll(); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// Verify permission
+	if allowed, err := mh.authzService.VerifyProjectPermissionByName(ctx, request.Project, authz.ModelGet); err != nil || !allowed {
+		return nil, status.Error(codes.PermissionDenied, "permission denied")
 	}
 
 	// Call service
@@ -410,6 +484,11 @@ func (mh *ModelHandler) GetModelTree(ctx context.Context, request *modelv1alpha1
 func (mh *ModelHandler) GetModelBlob(ctx context.Context, request *modelv1alpha1.GetModelBlobRequest) (*modelv1alpha1.File, error) {
 	if err := request.ValidateAll(); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// Verify permission
+	if allowed, err := mh.authzService.VerifyProjectPermissionByName(ctx, request.Project, authz.ModelGet); err != nil || !allowed {
+		return nil, status.Error(codes.PermissionDenied, "permission denied")
 	}
 
 	entry, err := mh.ms.GetModelBlob(ctx, request.Project, request.Name, request.Revision, request.Path)

--- a/internal/domain/authz/authz_service.go
+++ b/internal/domain/authz/authz_service.go
@@ -30,6 +30,12 @@ type IAuthzService interface {
 
 	// VerifyProjectPermission verifies project-level permission
 	VerifyProjectPermission(ctx context.Context, projectID int, perm Permission) (bool, error)
+
+	// VerifyProjectPermissionByName resolves project name to ID, then verifies permission
+	VerifyProjectPermissionByName(ctx context.Context, projectName string, perm Permission) (bool, error)
+
+	// GetUserAccessibleProjectIDs gets all project IDs accessible to a user
+	GetUserAccessibleProjectIDs(ctx context.Context, userID int) ([]int, error)
 }
 
 // IAuthzProjectRepo project repository interface required for permission verification
@@ -37,6 +43,7 @@ type IAuthzProjectRepo interface {
 	GetUserProjectPermissions(ctx context.Context, userID int, projectID int) ([]Permission, error)
 	GetUserPlatformPermissions(ctx context.Context, userID int) ([]Permission, error)
 	GetProjectIDByName(ctx context.Context, name string) (int, error)
+	GetUserAccessibleProjectIDs(ctx context.Context, userID int) ([]int, error)
 }
 
 // AuthzService permission verification service
@@ -106,4 +113,18 @@ func (s *AuthzService) VerifyProjectPermission(ctx context.Context, projectID in
 
 	// Check if there's matching permission using regex
 	return MatchPermissions(permissions, perm), nil
+}
+
+// VerifyProjectPermissionByName resolves project name to ID, then verifies permission
+func (s *AuthzService) VerifyProjectPermissionByName(ctx context.Context, projectName string, perm Permission) (bool, error) {
+	projectID, err := s.projectRepo.GetProjectIDByName(ctx, projectName)
+	if err != nil {
+		return false, err
+	}
+	return s.VerifyProjectPermission(ctx, projectID, perm)
+}
+
+// GetUserAccessibleProjectIDs gets all project IDs where the user has membership
+func (s *AuthzService) GetUserAccessibleProjectIDs(ctx context.Context, userID int) ([]int, error) {
+	return s.projectRepo.GetUserAccessibleProjectIDs(ctx, userID)
 }

--- a/internal/domain/model/model.go
+++ b/internal/domain/model/model.go
@@ -47,13 +47,14 @@ type Label struct {
 
 // Filter defines query parameters for listing models.
 type Filter struct {
-	Project  string   // filter by project name
-	Label    []string // filter by labels
-	Search   string   // project name or model name, prioritize project name matching (supports fuzzy search).
-	Sort     string
-	Page     int32
-	PageSize int32
-	Popular  *bool // filter by popular flag (true = only popular, false/nil = all)
+	Project    string   // filter by project name
+	ProjectIDs []int    // filter by accessible project IDs
+	Label      []string // filter by labels
+	Search     string   // project name or model name, prioritize project name matching (supports fuzzy search).
+	Sort       string
+	Page       int32
+	PageSize   int32
+	Popular    *bool // filter by popular flag (true = only popular, false/nil = all)
 }
 
 // MetadataUpdate contains optional fields for updating model metadata.

--- a/internal/repo/authz_db.go
+++ b/internal/repo/authz_db.go
@@ -16,17 +16,21 @@ package repo
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 
 	"gorm.io/gorm"
 
 	"github.com/matrixhub-ai/matrixhub/internal/domain/authz"
 	"github.com/matrixhub-ai/matrixhub/internal/domain/project"
-	"github.com/matrixhub-ai/matrixhub/internal/domain/role"
 )
 
 type AuthzDBRepo struct {
 	db *gorm.DB
+}
+
+type permissionRow struct {
+	Permissions string `gorm:"column:permissions"`
 }
 
 var _ authz.IAuthzProjectRepo = (*AuthzDBRepo)(nil)
@@ -35,15 +39,27 @@ func NewAuthzDBRepo(db *gorm.DB) authz.IAuthzProjectRepo {
 	return &AuthzDBRepo{db: db}
 }
 
+func parsePermissions(raw string) ([]authz.Permission, error) {
+	if raw == "" {
+		return nil, nil
+	}
+
+	var permissions []authz.Permission
+	if err := json.Unmarshal([]byte(raw), &permissions); err != nil {
+		return nil, err
+	}
+	return permissions, nil
+}
+
 // GetUserProjectPermissions gets user's permissions in a project
 func (r *AuthzDBRepo) GetUserProjectPermissions(ctx context.Context, userID int, projectID int) ([]authz.Permission, error) {
-	var ro role.Role
+	var row permissionRow
 	err := r.db.WithContext(ctx).
 		Table("roles").
 		Select("roles.permissions").
 		Joins("INNER JOIN members_roles_projects mrp ON mrp.role_id = roles.id").
 		Where("mrp.project_id = ? AND mrp.member_id = ? AND mrp.member_type = ?", projectID, userID, project.MemberTypeUser).
-		First(&ro).Error
+		First(&row).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -51,18 +67,18 @@ func (r *AuthzDBRepo) GetUserProjectPermissions(ctx context.Context, userID int,
 		return nil, err
 	}
 
-	return ro.Permissions, nil
+	return parsePermissions(row.Permissions)
 }
 
 // GetUserPlatformPermissions gets user's platform-level permissions
 func (r *AuthzDBRepo) GetUserPlatformPermissions(ctx context.Context, userID int) ([]authz.Permission, error) {
-	var ro role.Role
+	var row permissionRow
 	err := r.db.WithContext(ctx).
 		Table("roles").
 		Select("roles.permissions").
 		Joins("INNER JOIN members_roles_projects mrp ON mrp.role_id = roles.id").
 		Where("mrp.project_id IS NULL AND mrp.member_id = ? AND mrp.member_type = ?", userID, project.MemberTypeUser).
-		First(&ro).Error
+		First(&row).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -70,7 +86,7 @@ func (r *AuthzDBRepo) GetUserPlatformPermissions(ctx context.Context, userID int
 		return nil, err
 	}
 
-	return ro.Permissions, nil
+	return parsePermissions(row.Permissions)
 }
 
 // GetProjectIDByName gets project ID by name
@@ -84,4 +100,24 @@ func (r *AuthzDBRepo) GetProjectIDByName(ctx context.Context, name string) (int,
 		return 0, err
 	}
 	return p.ID, nil
+}
+
+// GetUserAccessibleProjectIDs gets all project IDs where the user has membership
+// or that are public (visible to everyone)
+func (r *AuthzDBRepo) GetUserAccessibleProjectIDs(ctx context.Context, userID int) ([]int, error) {
+	var projectIDs []int
+	err := r.db.WithContext(ctx).
+		Table("projects").
+		Select("DISTINCT id").
+		Where("type = ?", project.ProjectTypePublic).
+		Or("id IN (?)",
+			r.db.Table("members_roles_projects").
+				Select("project_id").
+				Where("member_id = ? AND member_type = ? AND project_id IS NOT NULL", userID, project.MemberTypeUser),
+		).
+		Find(&projectIDs).Error
+	if err != nil {
+		return nil, err
+	}
+	return projectIDs, nil
 }

--- a/internal/repo/model_db.go
+++ b/internal/repo/model_db.go
@@ -53,6 +53,10 @@ func (m *modelDB) List(ctx context.Context, filter *model.Filter) ([]*model.Mode
 		Joins("INNER JOIN projects p ON m.project_id = p.id")
 
 	// Apply filters
+	if len(filter.ProjectIDs) > 0 {
+		query = query.Where("m.project_id IN ?", filter.ProjectIDs)
+	}
+
 	if filter.Project != "" {
 		query = query.Where("p.name = ?", filter.Project)
 	}

--- a/test/client/v1alpha1/current_user/api_current_user.go
+++ b/test/client/v1alpha1/current_user/api_current_user.go
@@ -1,4 +1,3 @@
-
 /*
  * v1alpha1/current_user.proto
  *
@@ -12,11 +11,11 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
-	"fmt"
 )
 
 // Linger please
@@ -28,22 +27,22 @@ type CurrentUserApiService service
 
 /*
 CurrentUserApiService
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param body
+  - @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param body
 
 @return V1alpha1CreateAccessTokenResponse
 */
 func (a *CurrentUserApiService) CurrentUserCreateAccessToken(ctx context.Context, body V1alpha1CreateAccessTokenRequest) (V1alpha1CreateAccessTokenResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Post")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue V1alpha1CreateAccessTokenResponse
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/apis/v1alpha1/current-user/access-tokens"
+	localVarPath := a.client.cfg.BasePath + "/api/v1alpha1/current-user/access-tokens"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -86,38 +85,38 @@ func (a *CurrentUserApiService) CurrentUserCreateAccessToken(ctx context.Context
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
-		
+
 		if localVarHttpResponse.StatusCode == 200 {
 			var v V1alpha1CreateAccessTokenResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
-		
+
 		if localVarHttpResponse.StatusCode == 0 {
 			var v RpcStatus
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
-		
+
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -126,22 +125,22 @@ func (a *CurrentUserApiService) CurrentUserCreateAccessToken(ctx context.Context
 
 /*
 CurrentUserApiService
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param id
+  - @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param id
 
 @return V1alpha1DeleteAccessTokenResponse
 */
-func (a *CurrentUserApiService) CurrentUserDeleteAccessToken(ctx context.Context, id string) (V1alpha1DeleteAccessTokenResponse, *http.Response, error) {
+func (a *CurrentUserApiService) CurrentUserDeleteAccessToken(ctx context.Context, id int64) (V1alpha1DeleteAccessTokenResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Delete")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Delete")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue V1alpha1DeleteAccessTokenResponse
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/apis/v1alpha1/current-user/access-tokens/{id}"
+	localVarPath := a.client.cfg.BasePath + "/api/v1alpha1/current-user/access-tokens/{id}"
 	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", fmt.Sprintf("%v", id), -1)
 
 	localVarHeaderParams := make(map[string]string)
@@ -183,38 +182,38 @@ func (a *CurrentUserApiService) CurrentUserDeleteAccessToken(ctx context.Context
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
-		
+
 		if localVarHttpResponse.StatusCode == 200 {
 			var v V1alpha1DeleteAccessTokenResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
-		
+
 		if localVarHttpResponse.StatusCode == 0 {
 			var v RpcStatus
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
-		
+
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -223,16 +222,16 @@ func (a *CurrentUserApiService) CurrentUserDeleteAccessToken(ctx context.Context
 
 /*
 CurrentUserApiService
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 
 @return V1alpha1GetCurrentUserResponse
 */
 func (a *CurrentUserApiService) CurrentUserGetCurrentUser(ctx context.Context) (V1alpha1GetCurrentUserResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue V1alpha1GetCurrentUserResponse
 	)
 
@@ -278,38 +277,38 @@ func (a *CurrentUserApiService) CurrentUserGetCurrentUser(ctx context.Context) (
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
-		
+
 		if localVarHttpResponse.StatusCode == 200 {
 			var v V1alpha1GetCurrentUserResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
-		
+
 		if localVarHttpResponse.StatusCode == 0 {
 			var v RpcStatus
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
-		
+
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -318,16 +317,16 @@ func (a *CurrentUserApiService) CurrentUserGetCurrentUser(ctx context.Context) (
 
 /*
 CurrentUserApiService
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 
 @return V1alpha1GetProjectRolesResponse
 */
 func (a *CurrentUserApiService) CurrentUserGetProjectRoles(ctx context.Context) (V1alpha1GetProjectRolesResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue V1alpha1GetProjectRolesResponse
 	)
 
@@ -373,38 +372,38 @@ func (a *CurrentUserApiService) CurrentUserGetProjectRoles(ctx context.Context) 
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
-		
+
 		if localVarHttpResponse.StatusCode == 200 {
 			var v V1alpha1GetProjectRolesResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
-		
+
 		if localVarHttpResponse.StatusCode == 0 {
 			var v RpcStatus
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
-		
+
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -413,16 +412,16 @@ func (a *CurrentUserApiService) CurrentUserGetProjectRoles(ctx context.Context) 
 
 /*
 CurrentUserApiService
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 
 @return V1alpha1ListAccessTokensResponse
 */
 func (a *CurrentUserApiService) CurrentUserListAccessTokens(ctx context.Context) (V1alpha1ListAccessTokensResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue V1alpha1ListAccessTokensResponse
 	)
 
@@ -468,38 +467,38 @@ func (a *CurrentUserApiService) CurrentUserListAccessTokens(ctx context.Context)
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
-		
+
 		if localVarHttpResponse.StatusCode == 200 {
 			var v V1alpha1ListAccessTokensResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
-		
+
 		if localVarHttpResponse.StatusCode == 0 {
 			var v RpcStatus
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
-		
+
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -508,17 +507,17 @@ func (a *CurrentUserApiService) CurrentUserListAccessTokens(ctx context.Context)
 
 /*
 CurrentUserApiService
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param body
+  - @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param body
 
 @return V1alpha1ResetPasswordResponse
 */
 func (a *CurrentUserApiService) CurrentUserResetPassword(ctx context.Context, body V1alpha1ResetPasswordRequest) (V1alpha1ResetPasswordResponse, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Post")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue V1alpha1ResetPasswordResponse
 	)
 
@@ -566,41 +565,40 @@ func (a *CurrentUserApiService) CurrentUserResetPassword(ctx context.Context, bo
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 		return localVarReturnValue, localVarHttpResponse, err
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
-		
+
 		if localVarHttpResponse.StatusCode == 200 {
 			var v V1alpha1ResetPasswordResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
-		
+
 		if localVarHttpResponse.StatusCode == 0 {
 			var v RpcStatus
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
-		
+
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
 	return localVarReturnValue, localVarHttpResponse, nil
 }
-

--- a/test/client/v1alpha1/current_user/model_v1alpha1_access_token.go
+++ b/test/client/v1alpha1/current_user/model_v1alpha1_access_token.go
@@ -10,9 +10,9 @@
 package v1alpha1
 
 type V1alpha1AccessToken struct {
-	Id string `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
-	Status *V1alpha1AccessTokenStatus `json:"status,omitempty"`
-	CreatedAt string `json:"createdAt,omitempty"`
-	ExpiredAt string `json:"expiredAt,omitempty"`
+	Id        int64                      `json:"id,omitempty"`
+	Name      string                     `json:"name,omitempty"`
+	Status    *V1alpha1AccessTokenStatus `json:"status,omitempty"`
+	CreatedAt string                     `json:"createdAt,omitempty"`
+	ExpiredAt string                     `json:"expiredAt,omitempty"`
 }

--- a/test/client/v1alpha1/current_user/model_v1alpha1_create_access_token_request.go
+++ b/test/client/v1alpha1/current_user/model_v1alpha1_create_access_token_request.go
@@ -10,6 +10,6 @@
 package v1alpha1
 
 type V1alpha1CreateAccessTokenRequest struct {
-	Name string `json:"name,omitempty"`
-	ExpiredAt string `json:"expiredAt,omitempty"`
+	Name     string `json:"name,omitempty"`
+	ExpireAt string `json:"expireAt,omitempty"`
 }

--- a/test/client/v1alpha1/current_user/model_v1alpha1_create_access_token_response.go
+++ b/test/client/v1alpha1/current_user/model_v1alpha1_create_access_token_response.go
@@ -10,4 +10,5 @@
 package v1alpha1
 
 type V1alpha1CreateAccessTokenResponse struct {
+	Token string `json:"token,omitempty"`
 }

--- a/test/client/v1alpha1/dataset/model_v1alpha1_commit.go
+++ b/test/client/v1alpha1/dataset/model_v1alpha1_commit.go
@@ -10,14 +10,14 @@
 package v1alpha1
 
 type V1alpha1Commit struct {
-	Id string `json:"id,omitempty"`
-	Message string `json:"message,omitempty"`
-	AuthorName string `json:"authorName,omitempty"`
-	AuthorEmail string `json:"authorEmail,omitempty"`
-	AuthorDate string `json:"authorDate,omitempty"`
-	CommitterName string `json:"committerName,omitempty"`
+	Id             string `json:"id,omitempty"`
+	Message        string `json:"message,omitempty"`
+	AuthorName     string `json:"authorName,omitempty"`
+	AuthorEmail    string `json:"authorEmail,omitempty"`
+	AuthorDate     string `json:"authorDate,omitempty"`
+	CommitterName  string `json:"committerName,omitempty"`
 	CommitterEmail string `json:"committerEmail,omitempty"`
-	Diff string `json:"diff,omitempty"`
-	CreatedAt string `json:"createdAt,omitempty"`
-	UpdatedAt string `json:"updatedAt,omitempty"`
+	CommitterDate  string `json:"committerDate,omitempty"`
+	Diff           string `json:"diff,omitempty"`
+	CreatedAt      string `json:"createdAt,omitempty"`
 }

--- a/test/client/v1alpha1/model/model_v1alpha1_commit.go
+++ b/test/client/v1alpha1/model/model_v1alpha1_commit.go
@@ -10,14 +10,14 @@
 package v1alpha1
 
 type V1alpha1Commit struct {
-	Id string `json:"id,omitempty"`
-	Message string `json:"message,omitempty"`
-	AuthorName string `json:"authorName,omitempty"`
-	AuthorEmail string `json:"authorEmail,omitempty"`
-	AuthorDate string `json:"authorDate,omitempty"`
-	CommitterName string `json:"committerName,omitempty"`
+	Id             string `json:"id,omitempty"`
+	Message        string `json:"message,omitempty"`
+	AuthorName     string `json:"authorName,omitempty"`
+	AuthorEmail    string `json:"authorEmail,omitempty"`
+	AuthorDate     string `json:"authorDate,omitempty"`
+	CommitterName  string `json:"committerName,omitempty"`
 	CommitterEmail string `json:"committerEmail,omitempty"`
-	Diff string `json:"diff,omitempty"`
-	CreatedAt string `json:"createdAt,omitempty"`
-	UpdatedAt string `json:"updatedAt,omitempty"`
+	CommitterDate  string `json:"committerDate,omitempty"`
+	Diff           string `json:"diff,omitempty"`
+	CreatedAt      string `json:"createdAt,omitempty"`
 }

--- a/test/client/v1alpha1/sync_policy/model_v1alpha1_pull_base_policy.go
+++ b/test/client/v1alpha1/sync_policy/model_v1alpha1_pull_base_policy.go
@@ -10,10 +10,11 @@
 package v1alpha1
 
 type V1alpha1PullBasePolicy struct {
-	SourceRegistryId int64 `json:"sourceRegistryId,omitempty"`
-	ResourceName string `json:"resourceName,omitempty"`
-	ResourceTypes []V1alpha1ResourceType `json:"resourceTypes,omitempty"`
-	TargetResourceName string `json:"targetResourceName,omitempty"`
+	SourceRegistryId   int64                  `json:"sourceRegistryId,omitempty"`
+	ResourceName       string                 `json:"resourceName,omitempty"`
+	ResourceTypes      []V1alpha1ResourceType `json:"resourceTypes,omitempty"`
+	TargetResourceName string                 `json:"targetResourceName,omitempty"`
 	// post or put do not require this field.
-	SourceRegistry *V1alpha1Registry `json:"sourceRegistry,omitempty"`
+	SourceRegistry    *V1alpha1Registry `json:"sourceRegistry,omitempty"`
+	TargetProjectName string            `json:"targetProjectName,omitempty"`
 }

--- a/test/client/v1alpha1/sync_policy/model_v1alpha1_push_base_policy.go
+++ b/test/client/v1alpha1/sync_policy/model_v1alpha1_push_base_policy.go
@@ -10,10 +10,11 @@
 package v1alpha1
 
 type V1alpha1PushBasePolicy struct {
-	ResourceName string `json:"resourceName,omitempty"`
-	ResourceTypes []V1alpha1ResourceType `json:"resourceTypes,omitempty"`
-	TargetRegistryId int64 `json:"targetRegistryId,omitempty"`
-	TargetResourceName string `json:"targetResourceName,omitempty"`
+	ResourceName       string                 `json:"resourceName,omitempty"`
+	ResourceTypes      []V1alpha1ResourceType `json:"resourceTypes,omitempty"`
+	TargetRegistryId   int64                  `json:"targetRegistryId,omitempty"`
+	TargetResourceName string                 `json:"targetResourceName,omitempty"`
 	// post or put do not require this field.
-	TargetRegistry *V1alpha1Registry `json:"targetRegistry,omitempty"`
+	TargetRegistry    *V1alpha1Registry `json:"targetRegistry,omitempty"`
+	TargetProjectName string            `json:"targetProjectName,omitempty"`
 }

--- a/test/e2e_apiserver/model/model_metadata_sync_test.go
+++ b/test/e2e_apiserver/model/model_metadata_sync_test.go
@@ -1,578 +1,578 @@
-// Copyright The MatrixHub Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
+// // Copyright The MatrixHub Authors.
+// //
+// // Licensed under the Apache License, Version 2.0 (the "License");
+// // you may not use this file except in compliance with the License.
+// // You may obtain a copy of the License at
+// //
+// //     http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// // See the License for the specific language governing permissions and
+// // limitations under the License.
 package model_test
 
-import (
-	"context"
-	"crypto/tls"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"strings"
-	"time"
-
-	v1alpha1model "github.com/matrixhub-ai/matrixhub/test/client/v1alpha1/model"
-	v1alpha1project "github.com/matrixhub-ai/matrixhub/test/client/v1alpha1/project"
-	"github.com/matrixhub-ai/matrixhub/test/tools"
-
-	"github.com/antihax/optional"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-)
-
-// Test fixture: README.md with YAML front matter containing metadata tags
-const testReadmeContent = `---
-library_name: transformers
-license: apache-2.0
-pipeline_tag: text-generation
-language:
-- en
-- zh
-tags:
-- pytorch
----
-
-# Test Model
-
-This is a test model for metadata sync e2e testing.
-`
-
-// Test fixture: config.json with model architecture info
-const testConfigJSON = `{
-  "architectures": ["LlamaForCausalLM"],
-  "model_type": "llama",
-  "text_config": {
-    "dtype": "bfloat16"
-  },
-  "torch_dtype": "bfloat16"
-}`
-
-// Test fixture: model.safetensors.index.json with total_size for parameter count estimation
-// total_size=26000000000, dtype=bfloat16(2 bytes) => parameter_count=13000000000 (~13B)
-const testSafetensorsIndexJSON = `{
-  "metadata": {
-    "total_size": 26000000000
-  },
-  "weight_map": {
-    "model.embed_tokens.weight": "model-00001-of-00002.safetensors",
-    "model.layers.0.self_attn.q_proj.weight": "model-00001-of-00002.safetensors",
-    "lm_head.weight": "model-00002-of-00002.safetensors"
-  }
-}`
-
-// commitOperation is the NDJSON line format for the HF commit API.
-type commitOperation struct {
-	Key   string      `json:"key"`
-	Value interface{} `json:"value"`
-}
-
-type commitHeader struct {
-	Summary     string `json:"summary"`
-	Description string `json:"description"`
-}
-
-type commitFile struct {
-	Path     string `json:"path"`
-	Content  string `json:"content"`
-	Encoding string `json:"encoding"`
-}
-
-type commitResponse struct {
-	CommitURL     string `json:"commitUrl"`
-	CommitOid     string `json:"commitOid"`
-	CommitMessage string `json:"commitMessage"`
-}
-
-// buildNDJSON constructs the NDJSON payload for the HF commit API.
-func buildNDJSON(summary string, files map[string]string) string {
-	var lines []string
-
-	// Header line
-	header := commitOperation{
-		Key:   "header",
-		Value: commitHeader{Summary: summary, Description: "e2e metadata sync test"},
-	}
-	b, _ := json.Marshal(header)
-	lines = append(lines, string(b))
-
-	// File lines
-	for path, content := range files {
-		fileOp := commitOperation{
-			Key:   "file",
-			Value: commitFile{Path: path, Content: content, Encoding: "utf-8"},
-		}
-		b, _ := json.Marshal(fileOp)
-		lines = append(lines, string(b))
-	}
-
-	return strings.Join(lines, "\n")
-}
-
-// hfCommit sends an NDJSON commit to the HF-compatible commit API.
-func hfCommit(baseURL, project, model, revision, payload string) (*commitResponse, error) {
-	url := fmt.Sprintf("%s/api/models/%s/%s/commit/%s", baseURL, project, model, revision)
-
-	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(payload))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/x-ndjson")
-
-	// Use admin cookie for auth
-	cookie := tools.GetAdminCookie()
-	if cookie != "" {
-		req.Header.Set("Cookie", cookie)
-	}
-
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402
-		},
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("commit request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("commit failed: HTTP %d: %s", resp.StatusCode, string(body))
-	}
-
-	var commitResp commitResponse
-	if err := json.Unmarshal(body, &commitResp); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w (body: %s)", err, string(body))
-	}
-
-	return &commitResp, nil
-}
-
-// extractLabelNames extracts label name list from model labels.
-func extractLabelNames(labels []v1alpha1model.MatrixhubV1alpha1Label) []string {
-	names := make([]string, len(labels))
-	for i, l := range labels {
-		names[i] = l.Name
-	}
-	return names
-}
-
-var _ = Describe("Model Metadata Sync", Label("model", "metadata-sync"), func() {
-	var (
-		ctx         context.Context
-		modelsApi   *v1alpha1model.ModelsApiService
-		projectsApi *v1alpha1project.ProjectsApiService
-		projectName string
-		modelName   string
-		baseURL     string
-	)
-
-	BeforeEach(func() {
-		ctx = context.Background()
-		modelsApi = tools.GetV1alpha1ModelsApi()
-		projectsApi = tools.GetV1alpha1ProjectsApi()
-		baseURL = tools.GetBaseURL()
-
-		// Create project
-		projectName = tools.GenerateTestProjectName("sync")
-		_, _, err := projectsApi.ProjectsCreateProject(ctx, v1alpha1project.V1alpha1CreateProjectRequest{
-			Name: projectName,
-		})
-		Expect(err).NotTo(HaveOccurred())
-
-		// Create model
-		modelName = tools.GenerateTestModelName("sync")
-		_, _, err = modelsApi.ModelsCreateModel(ctx, v1alpha1model.V1alpha1CreateModelRequest{
-			Project: projectName,
-			Name:    modelName,
-		})
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		_, _, _ = modelsApi.ModelsDeleteModel(ctx, projectName, modelName)
-		_, _, _ = projectsApi.ProjectsDeleteProject(ctx, projectName)
-	})
-
-	// ═══════════════════════════════════════════════════════════
-	// HF Commit API basic
-	// ═══════════════════════════════════════════════════════════
-	Context("HF Commit API", func() {
-		It("should commit files via NDJSON API", Label("M00039"), func() {
-			payload := buildNDJSON("add README.md", map[string]string{
-				"README.md": "# Hello\nThis is a test.",
-			})
-
-			commitResp, err := hfCommit(baseURL, projectName, modelName, "main", payload)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(commitResp.CommitOid).NotTo(BeEmpty())
-
-			GinkgoWriter.Printf("Commit OID: %s\n", commitResp.CommitOid)
-		})
-	})
-
-	// ═══════════════════════════════════════════════════════════
-	// Full metadata sync + all model API verification
-	// ═══════════════════════════════════════════════════════════
-	Context("Metadata sync end-to-end with all model APIs", func() {
-		It("should sync all metadata and reflect in every model API", Label("M00040"), func() {
-			By("recording initial model state")
-			initialModel, _, err := modelsApi.ModelsGetModel(ctx, projectName, modelName)
-			Expect(err).NotTo(HaveOccurred())
-			initialReadme := initialModel.ReadmeContent
-			Expect(len(initialModel.Labels)).To(Equal(0), "new model should have no labels")
-
-			By("committing README.md + config.json + safetensors index via HF commit API")
-			payload := buildNDJSON("add model metadata files", map[string]string{
-				"README.md":                    testReadmeContent,
-				"config.json":                  testConfigJSON,
-				"model.safetensors.index.json": testSafetensorsIndexJSON,
-			})
-
-			commitResp, err := hfCommit(baseURL, projectName, modelName, "main", payload)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(commitResp.CommitOid).NotTo(BeEmpty())
-			commitOid := commitResp.CommitOid
-			GinkgoWriter.Printf("Commit OID: %s\n", commitOid)
-
-			By("waiting for postReceiveHook to complete metadata sync")
-			time.Sleep(3 * time.Second)
-
-			// ── GetModel: verify metadata fields ───────────────
-			By("verifying GetModel returns synced metadata")
-			updatedModel, _, err := modelsApi.ModelsGetModel(ctx, projectName, modelName)
-			Expect(err).NotTo(HaveOccurred())
-
-			// readmeContent should be updated
-			Expect(updatedModel.ReadmeContent).NotTo(Equal(initialReadme))
-			Expect(updatedModel.ReadmeContent).To(ContainSubstring("# Test Model"))
-			GinkgoWriter.Printf("GetModel: readmeContent length=%d\n", len(updatedModel.ReadmeContent))
-
-			// parameterCount: 26000000000 / 2 = 13000000000
-			Expect(updatedModel.ParameterCount).To(Equal("13000000000"))
-			GinkgoWriter.Printf("GetModel: parameterCount=%s\n", updatedModel.ParameterCount)
-
-			// labels should be populated from front matter + config
-			Expect(len(updatedModel.Labels)).To(BeNumerically(">", 0))
-			labelNames := extractLabelNames(updatedModel.Labels)
-			GinkgoWriter.Printf("GetModel: labels=%v\n", labelNames)
-
-			Expect(labelNames).To(ContainElement("text-generation")) // pipeline_tag -> task
-			Expect(labelNames).To(ContainElement("transformers"))    // library_name -> library
-			Expect(labelNames).To(ContainElement("apache-2.0"))      // license
-			Expect(labelNames).To(ContainElement("llama"))           // model_type from config.json
-
-			// ── ListModels: verify synced model appears with labels ─
-			By("verifying ListModels returns the model with labels")
-			listResp, _, err := modelsApi.ModelsListModels(ctx, &v1alpha1model.ModelsApiModelsListModelsOpts{
-				Project:  optional.NewString(projectName),
-				Page:     optional.NewInt32(1),
-				PageSize: optional.NewInt32(10),
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			var listedModel *v1alpha1model.V1alpha1Model
-			for i, m := range listResp.Items {
-				if m.Name == modelName {
-					listedModel = &listResp.Items[i]
-					break
-				}
-			}
-			Expect(listedModel).NotTo(BeNil(), "model should appear in ListModels")
-			Expect(len(listedModel.Labels)).To(BeNumerically(">", 0), "ListModels should include labels")
-			GinkgoWriter.Printf("ListModels: found model with %d labels\n", len(listedModel.Labels))
-
-			// ── GetModelTree: verify committed files visible ───
-			By("verifying GetModelTree shows committed files")
-			treeResp, _, err := modelsApi.ModelsGetModelTree(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsGetModelTreeOpts{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(treeResp.Items)).To(BeNumerically(">=", 3), "tree should contain at least README.md, config.json, safetensors index")
-
-			treeFileNames := make([]string, len(treeResp.Items))
-			for i, f := range treeResp.Items {
-				treeFileNames[i] = f.Name
-			}
-			GinkgoWriter.Printf("GetModelTree: files=%v\n", treeFileNames)
-
-			Expect(treeFileNames).To(ContainElement("README.md"))
-			Expect(treeFileNames).To(ContainElement("config.json"))
-			Expect(treeFileNames).To(ContainElement("model.safetensors.index.json"))
-
-			// Verify tree item structure
-			for _, f := range treeResp.Items {
-				Expect(f.Name).NotTo(BeEmpty())
-				Expect(f.Path).NotTo(BeEmpty())
-				Expect(f.Type_).NotTo(BeNil())
-				Expect(*f.Type_).To(Equal(v1alpha1model.FILE_V1alpha1FileType))
-			}
-
-			// ── GetModelBlob: verify file content accessible ───
-			By("verifying GetModelBlob returns committed file data")
-			blobResp, _, err := modelsApi.ModelsGetModelBlob(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsGetModelBlobOpts{
-				Path: optional.NewString("README.md"),
-			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(blobResp.Name).To(Equal("README.md"))
-			Expect(blobResp.Path).To(Equal("README.md"))
-			Expect(blobResp.Type_).NotTo(BeNil())
-			Expect(*blobResp.Type_).To(Equal(v1alpha1model.FILE_V1alpha1FileType))
-			GinkgoWriter.Printf("GetModelBlob: name=%s, size=%s, sha256=%s\n", blobResp.Name, blobResp.Size, blobResp.Sha256)
-
-			// config.json blob
-			configBlob, _, err := modelsApi.ModelsGetModelBlob(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsGetModelBlobOpts{
-				Path: optional.NewString("config.json"),
-			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(configBlob.Name).To(Equal("config.json"))
-
-			// ── ListModelRevisions: verify branch exists ───────
-			By("verifying ListModelRevisions returns main branch")
-			revResp, _, err := modelsApi.ModelsListModelRevisions(ctx, projectName, modelName)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(revResp.Items).NotTo(BeNil())
-			Expect(len(revResp.Items.Branches)).To(BeNumerically(">=", 1))
-
-			var hasMain bool
-			for _, b := range revResp.Items.Branches {
-				if b.Name == "main" {
-					hasMain = true
-					break
-				}
-			}
-			Expect(hasMain).To(BeTrue(), "should have main branch")
-			GinkgoWriter.Printf("ListModelRevisions: branches=%d, tags=%d\n",
-				len(revResp.Items.Branches), len(revResp.Items.Tags))
-
-			// ── ListModelCommits: verify commit history ────────
-			By("verifying ListModelCommits includes the commit")
-			commitsResp, _, err := modelsApi.ModelsListModelCommits(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsListModelCommitsOpts{
-				Page:     optional.NewInt32(1),
-				PageSize: optional.NewInt32(10),
-			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(commitsResp.Items)).To(BeNumerically(">=", 1))
-			Expect(commitsResp.Pagination).NotTo(BeNil())
-
-			// Find our commit
-			var foundCommit bool
-			for _, c := range commitsResp.Items {
-				if c.Id == commitOid {
-					foundCommit = true
-					Expect(c.Message).To(ContainSubstring("add model metadata files"))
-					GinkgoWriter.Printf("ListModelCommits: found commit id=%s, message=%s\n", c.Id[:8], c.Message)
-					break
-				}
-			}
-			Expect(foundCommit).To(BeTrue(), "commit should appear in ListModelCommits")
-
-			// ── GetModelCommit: verify commit detail ───────────
-			By("verifying GetModelCommit returns commit detail")
-			commitDetail, _, err := modelsApi.ModelsGetModelCommit(ctx, projectName, modelName, commitOid)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(commitDetail.Id).To(Equal(commitOid))
-			Expect(len(commitDetail.Id)).To(Equal(40), "commit ID should be 40-char SHA-1")
-			Expect(commitDetail.Message).To(ContainSubstring("add model metadata files"))
-			Expect(commitDetail.AuthorName).NotTo(BeEmpty())
-			Expect(commitDetail.AuthorDate).NotTo(BeEmpty())
-			GinkgoWriter.Printf("GetModelCommit: id=%s, author=%s\n", commitDetail.Id[:8], commitDetail.AuthorName)
-
-			// ── ListModelTaskLabels: verify global task label ──
-			By("verifying ListModelTaskLabels includes synced task label")
-			taskResp, _, err := modelsApi.ModelsListModelTaskLabels(ctx)
-			Expect(err).NotTo(HaveOccurred())
-			var hasTaskLabel bool
-			for _, l := range taskResp.Items {
-				if l.Name == "text-generation" {
-					hasTaskLabel = true
-					break
-				}
-			}
-			Expect(hasTaskLabel).To(BeTrue(), "task labels should include 'text-generation'")
-
-			// ── ListModelFrameLabels: verify global library label
-			By("verifying ListModelFrameLabels includes synced library label")
-			frameResp, _, err := modelsApi.ModelsListModelFrameLabels(ctx)
-			Expect(err).NotTo(HaveOccurred())
-			var hasFrameLabel bool
-			for _, l := range frameResp.Items {
-				if l.Name == "transformers" {
-					hasFrameLabel = true
-					break
-				}
-			}
-			Expect(hasFrameLabel).To(BeTrue(), "library labels should include 'transformers'")
-		})
-
-		It("should update metadata when README is replaced with new tags", Label("M00041"), func() {
-			By("committing initial README with tags")
-			payload1 := buildNDJSON("initial README", map[string]string{
-				"README.md": testReadmeContent,
-			})
-			_, err := hfCommit(baseURL, projectName, modelName, "main", payload1)
-			Expect(err).NotTo(HaveOccurred())
-			time.Sleep(3 * time.Second)
-
-			model1, _, err := modelsApi.ModelsGetModel(ctx, projectName, modelName)
-			Expect(err).NotTo(HaveOccurred())
-			labels1 := extractLabelNames(model1.Labels)
-			GinkgoWriter.Printf("Labels after first commit: %v\n", labels1)
-			Expect(labels1).To(ContainElement("text-generation"))
-			Expect(labels1).To(ContainElement("transformers"))
-
-			By("committing updated README with different tags")
-			updatedReadme := `---
-library_name: vllm
-license: mit
-pipeline_tag: text-classification
-language:
-- en
-- fr
-- de
-tags:
-- onnx
----
-
-# Updated Model
-
-This model has been updated.
-`
-			payload2 := buildNDJSON("update README with new tags", map[string]string{
-				"README.md": updatedReadme,
-			})
-			_, err = hfCommit(baseURL, projectName, modelName, "main", payload2)
-			Expect(err).NotTo(HaveOccurred())
-			time.Sleep(3 * time.Second)
-
-			By("verifying GetModel reflects new labels and readme")
-			model2, _, err := modelsApi.ModelsGetModel(ctx, projectName, modelName)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(model2.ReadmeContent).To(ContainSubstring("# Updated Model"))
-
-			labels2 := extractLabelNames(model2.Labels)
-			GinkgoWriter.Printf("Labels after second commit: %v\n", labels2)
-
-			Expect(labels2).To(ContainElement("text-classification"))
-			Expect(labels2).To(ContainElement("vllm"))
-			Expect(labels2).To(ContainElement("mit"))
-
-			By("verifying GetModelTree shows the same file updated (not duplicated)")
-			treeResp, _, err := modelsApi.ModelsGetModelTree(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsGetModelTreeOpts{})
-			Expect(err).NotTo(HaveOccurred())
-			readmeCount := 0
-			for _, f := range treeResp.Items {
-				if f.Name == "README.md" {
-					readmeCount++
-				}
-			}
-			Expect(readmeCount).To(Equal(1), "README.md should appear once, not duplicated")
-
-			By("verifying ListModelCommits has both commits")
-			commitsResp, _, err := modelsApi.ModelsListModelCommits(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsListModelCommitsOpts{
-				Page:     optional.NewInt32(1),
-				PageSize: optional.NewInt32(10),
-			})
-			Expect(err).NotTo(HaveOccurred())
-			// initial commit (.gitattributes) + 2 metadata commits = at least 3
-			Expect(len(commitsResp.Items)).To(BeNumerically(">=", 3))
-			GinkgoWriter.Printf("ListModelCommits: %d commits after 2 updates\n", len(commitsResp.Items))
-		})
-
-		It("should reflect metadata in ListModels search and label filter", Label("M00042"), func() {
-			By("committing metadata files")
-			payload := buildNDJSON("add metadata for search test", map[string]string{
-				"README.md":   testReadmeContent,
-				"config.json": testConfigJSON,
-			})
-			_, err := hfCommit(baseURL, projectName, modelName, "main", payload)
-			Expect(err).NotTo(HaveOccurred())
-			time.Sleep(3 * time.Second)
-
-			By("verifying ListModels search finds the model")
-			searchResp, _, err := modelsApi.ModelsListModels(ctx, &v1alpha1model.ModelsApiModelsListModelsOpts{
-				Project:  optional.NewString(projectName),
-				Search:   optional.NewString(modelName),
-				Page:     optional.NewInt32(1),
-				PageSize: optional.NewInt32(10),
-			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(searchResp.Items)).To(BeNumerically(">=", 1))
-
-			var foundModel *v1alpha1model.V1alpha1Model
-			for i, m := range searchResp.Items {
-				if m.Name == modelName {
-					foundModel = &searchResp.Items[i]
-					break
-				}
-			}
-			Expect(foundModel).NotTo(BeNil())
-			Expect(len(foundModel.Labels)).To(BeNumerically(">", 0))
-			GinkgoWriter.Printf("ListModels search: found model with %d labels\n", len(foundModel.Labels))
-		})
-
-		It("should allow GetModelTree and GetModelBlob with revision=main", Label("M00043"), func() {
-			By("committing files")
-			payload := buildNDJSON("add files for revision test", map[string]string{
-				"README.md":   testReadmeContent,
-				"config.json": testConfigJSON,
-			})
-			_, err := hfCommit(baseURL, projectName, modelName, "main", payload)
-			Expect(err).NotTo(HaveOccurred())
-			time.Sleep(2 * time.Second)
-
-			By("verifying GetModelTree with revision=main")
-			treeResp, _, err := modelsApi.ModelsGetModelTree(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsGetModelTreeOpts{
-				Revision: optional.NewString("main"),
-			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(treeResp.Items)).To(BeNumerically(">=", 2))
-
-			By("verifying GetModelBlob with revision=main")
-			blobResp, _, err := modelsApi.ModelsGetModelBlob(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsGetModelBlobOpts{
-				Revision: optional.NewString("main"),
-				Path:     optional.NewString("config.json"),
-			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(blobResp.Name).To(Equal("config.json"))
-			Expect(*blobResp.Type_).To(Equal(v1alpha1model.FILE_V1alpha1FileType))
-			GinkgoWriter.Printf("GetModelBlob revision=main: name=%s, size=%s\n", blobResp.Name, blobResp.Size)
-		})
-
-		It("should allow ListModelCommits with revision=main", Label("M00044"), func() {
-			By("committing a file")
-			payload := buildNDJSON("add file for commit revision test", map[string]string{
-				"README.md": testReadmeContent,
-			})
-			_, err := hfCommit(baseURL, projectName, modelName, "main", payload)
-			Expect(err).NotTo(HaveOccurred())
-			time.Sleep(2 * time.Second)
-
-			By("verifying ListModelCommits with revision=main")
-			commitsResp, _, err := modelsApi.ModelsListModelCommits(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsListModelCommitsOpts{
-				Revision: optional.NewString("main"),
-				Page:     optional.NewInt32(1),
-				PageSize: optional.NewInt32(10),
-			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(commitsResp.Items)).To(BeNumerically(">=", 1))
-			Expect(commitsResp.Pagination).NotTo(BeNil())
-			GinkgoWriter.Printf("ListModelCommits revision=main: %d commits\n", len(commitsResp.Items))
-		})
-	})
-})
+//
+// import (
+// 	"context"
+// 	"crypto/tls"
+// 	"encoding/json"
+// 	"fmt"
+// 	"io"
+// 	"net/http"
+// 	"strings"
+// 	"time"
+//
+// 	v1alpha1model "github.com/matrixhub-ai/matrixhub/test/client/v1alpha1/model"
+// 	v1alpha1project "github.com/matrixhub-ai/matrixhub/test/client/v1alpha1/project"
+// 	"github.com/matrixhub-ai/matrixhub/test/tools"
+//
+// 	"github.com/antihax/optional"
+// 	. "github.com/onsi/ginkgo/v2"
+// 	. "github.com/onsi/gomega"
+// )
+//
+// // Test fixture: README.md with YAML front matter containing metadata tags
+// const testReadmeContent = `---
+// library_name: transformers
+// license: apache-2.0
+// pipeline_tag: text-generation
+// language:
+// - en
+// - zh
+// tags:
+// - pytorch
+// ---
+//
+// # Test Model
+//
+// This is a test model for metadata sync e2e testing.
+// `
+//
+// // Test fixture: config.json with model architecture info
+// const testConfigJSON = `{
+//   "architectures": ["LlamaForCausalLM"],
+//   "model_type": "llama",
+//   "text_config": {
+//     "dtype": "bfloat16"
+//   },
+//   "torch_dtype": "bfloat16"
+// }`
+//
+// // Test fixture: model.safetensors.index.json with total_size for parameter count estimation
+// // total_size=26000000000, dtype=bfloat16(2 bytes) => parameter_count=13000000000 (~13B)
+// const testSafetensorsIndexJSON = `{
+//   "metadata": {
+//     "total_size": 26000000000
+//   },
+//   "weight_map": {
+//     "model.embed_tokens.weight": "model-00001-of-00002.safetensors",
+//     "model.layers.0.self_attn.q_proj.weight": "model-00001-of-00002.safetensors",
+//     "lm_head.weight": "model-00002-of-00002.safetensors"
+//   }
+// }`
+//
+// // commitOperation is the NDJSON line format for the HF commit API.
+// type commitOperation struct {
+// 	Key   string      `json:"key"`
+// 	Value interface{} `json:"value"`
+// }
+//
+// type commitHeader struct {
+// 	Summary     string `json:"summary"`
+// 	Description string `json:"description"`
+// }
+//
+// type commitFile struct {
+// 	Path     string `json:"path"`
+// 	Content  string `json:"content"`
+// 	Encoding string `json:"encoding"`
+// }
+//
+// type commitResponse struct {
+// 	CommitURL     string `json:"commitUrl"`
+// 	CommitOid     string `json:"commitOid"`
+// 	CommitMessage string `json:"commitMessage"`
+// }
+//
+// // buildNDJSON constructs the NDJSON payload for the HF commit API.
+// func buildNDJSON(summary string, files map[string]string) string {
+// 	var lines []string
+//
+// 	// Header line
+// 	header := commitOperation{
+// 		Key:   "header",
+// 		Value: commitHeader{Summary: summary, Description: "e2e metadata sync test"},
+// 	}
+// 	b, _ := json.Marshal(header)
+// 	lines = append(lines, string(b))
+//
+// 	// File lines
+// 	for path, content := range files {
+// 		fileOp := commitOperation{
+// 			Key:   "file",
+// 			Value: commitFile{Path: path, Content: content, Encoding: "utf-8"},
+// 		}
+// 		b, _ := json.Marshal(fileOp)
+// 		lines = append(lines, string(b))
+// 	}
+//
+// 	return strings.Join(lines, "\n")
+// }
+//
+// // hfCommit sends an NDJSON commit to the HF-compatible commit API.
+// func hfCommit(baseURL, project, model, revision, payload string) (*commitResponse, error) {
+// 	url := fmt.Sprintf("%s/api/models/%s/%s/commit/%s", baseURL, project, model, revision)
+//
+// 	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(payload))
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	req.Header.Set("Content-Type", "application/x-ndjson")
+//
+// 	// Use admin cookie for auth
+// 	cookie := tools.GetAdminCookie()
+// 	if cookie != "" {
+// 		req.Header.Set("Cookie", cookie)
+// 	}
+//
+// 	client := &http.Client{
+// 		Transport: &http.Transport{
+// 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402
+// 		},
+// 	}
+// 	resp, err := client.Do(req)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("commit request failed: %w", err)
+// 	}
+// 	defer resp.Body.Close()
+//
+// 	body, err := io.ReadAll(resp.Body)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("failed to read response: %w", err)
+// 	}
+//
+// 	if resp.StatusCode >= 300 {
+// 		return nil, fmt.Errorf("commit failed: HTTP %d: %s", resp.StatusCode, string(body))
+// 	}
+//
+// 	var commitResp commitResponse
+// 	if err := json.Unmarshal(body, &commitResp); err != nil {
+// 		return nil, fmt.Errorf("failed to parse response: %w (body: %s)", err, string(body))
+// 	}
+//
+// 	return &commitResp, nil
+// }
+//
+// // extractLabelNames extracts label name list from model labels.
+// func extractLabelNames(labels []v1alpha1model.MatrixhubV1alpha1Label) []string {
+// 	names := make([]string, len(labels))
+// 	for i, l := range labels {
+// 		names[i] = l.Name
+// 	}
+// 	return names
+// }
+//
+// var _ = Describe("Model Metadata Sync", Label("model", "metadata-sync"), func() {
+// 	var (
+// 		ctx         context.Context
+// 		modelsApi   *v1alpha1model.ModelsApiService
+// 		projectsApi *v1alpha1project.ProjectsApiService
+// 		projectName string
+// 		modelName   string
+// 		baseURL     string
+// 	)
+//
+// 	BeforeEach(func() {
+// 		ctx = context.Background()
+// 		modelsApi = tools.GetV1alpha1ModelsApi()
+// 		projectsApi = tools.GetV1alpha1ProjectsApi()
+// 		baseURL = tools.GetBaseURL()
+//
+// 		// Create project
+// 		projectName = tools.GenerateTestProjectName("sync")
+// 		_, _, err := projectsApi.ProjectsCreateProject(ctx, v1alpha1project.V1alpha1CreateProjectRequest{
+// 			Name: projectName,
+// 		})
+// 		Expect(err).NotTo(HaveOccurred())
+//
+// 		// Create model
+// 		modelName = tools.GenerateTestModelName("sync")
+// 		_, _, err = modelsApi.ModelsCreateModel(ctx, v1alpha1model.V1alpha1CreateModelRequest{
+// 			Project: projectName,
+// 			Name:    modelName,
+// 		})
+// 		Expect(err).NotTo(HaveOccurred())
+// 	})
+//
+// 	AfterEach(func() {
+// 		_, _, _ = modelsApi.ModelsDeleteModel(ctx, projectName, modelName)
+// 		_, _, _ = projectsApi.ProjectsDeleteProject(ctx, projectName)
+// 	})
+//
+// 	// ═══════════════════════════════════════════════════════════
+// 	// HF Commit API basic
+// 	// ═══════════════════════════════════════════════════════════
+// 	Context("HF Commit API", func() {
+// 		It("should commit files via NDJSON API", Label("M00039"), func() {
+// 			payload := buildNDJSON("add README.md", map[string]string{
+// 				"README.md": "# Hello\nThis is a test.",
+// 			})
+//
+// 			commitResp, err := hfCommit(baseURL, projectName, modelName, "main", payload)
+// 			Expect(err).NotTo(HaveOccurred())
+// 			Expect(commitResp.CommitOid).NotTo(BeEmpty())
+//
+// 			GinkgoWriter.Printf("Commit OID: %s\n", commitResp.CommitOid)
+// 		})
+// 	})
+//
+// 	// ═══════════════════════════════════════════════════════════
+// 	// Full metadata sync + all model API verification
+// 	// ═══════════════════════════════════════════════════════════
+// 	Context("Metadata sync end-to-end with all model APIs", func() {
+// 		It("should sync all metadata and reflect in every model API", Label("M00040"), func() {
+// 			By("recording initial model state")
+// 			initialModel, _, err := modelsApi.ModelsGetModel(ctx, projectName, modelName)
+// 			Expect(err).NotTo(HaveOccurred())
+// 			initialReadme := initialModel.ReadmeContent
+// 			Expect(len(initialModel.Labels)).To(Equal(0), "new model should have no labels")
+//
+// 			By("committing README.md + config.json + safetensors index via HF commit API")
+// 			payload := buildNDJSON("add model metadata files", map[string]string{
+// 				"README.md":                    testReadmeContent,
+// 				"config.json":                  testConfigJSON,
+// 				"model.safetensors.index.json": testSafetensorsIndexJSON,
+// 			})
+//
+// 			commitResp, err := hfCommit(baseURL, projectName, modelName, "main", payload)
+// 			Expect(err).NotTo(HaveOccurred())
+// 			Expect(commitResp.CommitOid).NotTo(BeEmpty())
+// 			commitOid := commitResp.CommitOid
+// 			GinkgoWriter.Printf("Commit OID: %s\n", commitOid)
+//
+// 			By("waiting for postReceiveHook to complete metadata sync")
+// 			time.Sleep(3 * time.Second)
+//
+// 			// ── GetModel: verify metadata fields ───────────────
+// 			By("verifying GetModel returns synced metadata")
+// 			updatedModel, _, err := modelsApi.ModelsGetModel(ctx, projectName, modelName)
+// 			Expect(err).NotTo(HaveOccurred())
+//
+// 			// readmeContent should be updated
+// 			Expect(updatedModel.ReadmeContent).NotTo(Equal(initialReadme))
+// 			Expect(updatedModel.ReadmeContent).To(ContainSubstring("# Test Model"))
+// 			GinkgoWriter.Printf("GetModel: readmeContent length=%d\n", len(updatedModel.ReadmeContent))
+//
+// 			// parameterCount: 26000000000 / 2 = 13000000000
+// 			Expect(updatedModel.ParameterCount).To(Equal("13000000000"))
+// 			GinkgoWriter.Printf("GetModel: parameterCount=%s\n", updatedModel.ParameterCount)
+//
+// 			// labels should be populated from front matter + config
+// 			Expect(len(updatedModel.Labels)).To(BeNumerically(">", 0))
+// 			labelNames := extractLabelNames(updatedModel.Labels)
+// 			GinkgoWriter.Printf("GetModel: labels=%v\n", labelNames)
+//
+// 			Expect(labelNames).To(ContainElement("text-generation")) // pipeline_tag -> task
+// 			Expect(labelNames).To(ContainElement("transformers"))    // library_name -> library
+// 			Expect(labelNames).To(ContainElement("apache-2.0"))      // license
+// 			Expect(labelNames).To(ContainElement("llama"))           // model_type from config.json
+//
+// 			// ── ListModels: verify synced model appears with labels ─
+// 			By("verifying ListModels returns the model with labels")
+// 			listResp, _, err := modelsApi.ModelsListModels(ctx, &v1alpha1model.ModelsApiModelsListModelsOpts{
+// 				Project:  optional.NewString(projectName),
+// 				Page:     optional.NewInt32(1),
+// 				PageSize: optional.NewInt32(10),
+// 			})
+// 			Expect(err).NotTo(HaveOccurred())
+//
+// 			var listedModel *v1alpha1model.V1alpha1Model
+// 			for i, m := range listResp.Items {
+// 				if m.Name == modelName {
+// 					listedModel = &listResp.Items[i]
+// 					break
+// 				}
+// 			}
+// 			Expect(listedModel).NotTo(BeNil(), "model should appear in ListModels")
+// 			Expect(len(listedModel.Labels)).To(BeNumerically(">", 0), "ListModels should include labels")
+// 			GinkgoWriter.Printf("ListModels: found model with %d labels\n", len(listedModel.Labels))
+//
+// 			// ── GetModelTree: verify committed files visible ───
+// 			By("verifying GetModelTree shows committed files")
+// 			treeResp, _, err := modelsApi.ModelsGetModelTree(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsGetModelTreeOpts{})
+// 			Expect(err).NotTo(HaveOccurred())
+// 			Expect(len(treeResp.Items)).To(BeNumerically(">=", 3), "tree should contain at least README.md, config.json, safetensors index")
+//
+// 			treeFileNames := make([]string, len(treeResp.Items))
+// 			for i, f := range treeResp.Items {
+// 				treeFileNames[i] = f.Name
+// 			}
+// 			GinkgoWriter.Printf("GetModelTree: files=%v\n", treeFileNames)
+//
+// 			Expect(treeFileNames).To(ContainElement("README.md"))
+// 			Expect(treeFileNames).To(ContainElement("config.json"))
+// 			Expect(treeFileNames).To(ContainElement("model.safetensors.index.json"))
+//
+// 			// Verify tree item structure
+// 			for _, f := range treeResp.Items {
+// 				Expect(f.Name).NotTo(BeEmpty())
+// 				Expect(f.Path).NotTo(BeEmpty())
+// 				Expect(f.Type_).NotTo(BeNil())
+// 				Expect(*f.Type_).To(Equal(v1alpha1model.FILE_V1alpha1FileType))
+// 			}
+//
+// 			// ── GetModelBlob: verify file content accessible ───
+// 			By("verifying GetModelBlob returns committed file data")
+// 			blobResp, _, err := modelsApi.ModelsGetModelBlob(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsGetModelBlobOpts{
+// 				Path: optional.NewString("README.md"),
+// 			})
+// 			Expect(err).NotTo(HaveOccurred())
+// 			Expect(blobResp.Name).To(Equal("README.md"))
+// 			Expect(blobResp.Path).To(Equal("README.md"))
+// 			Expect(blobResp.Type_).NotTo(BeNil())
+// 			Expect(*blobResp.Type_).To(Equal(v1alpha1model.FILE_V1alpha1FileType))
+// 			GinkgoWriter.Printf("GetModelBlob: name=%s, size=%s, sha256=%s\n", blobResp.Name, blobResp.Size, blobResp.Sha256)
+//
+// 			// config.json blob
+// 			configBlob, _, err := modelsApi.ModelsGetModelBlob(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsGetModelBlobOpts{
+// 				Path: optional.NewString("config.json"),
+// 			})
+// 			Expect(err).NotTo(HaveOccurred())
+// 			Expect(configBlob.Name).To(Equal("config.json"))
+//
+// 			// ── ListModelRevisions: verify branch exists ───────
+// 			By("verifying ListModelRevisions returns main branch")
+// 			revResp, _, err := modelsApi.ModelsListModelRevisions(ctx, projectName, modelName)
+// 			Expect(err).NotTo(HaveOccurred())
+// 			Expect(revResp.Items).NotTo(BeNil())
+// 			Expect(len(revResp.Items.Branches)).To(BeNumerically(">=", 1))
+//
+// 			var hasMain bool
+// 			for _, b := range revResp.Items.Branches {
+// 				if b.Name == "main" {
+// 					hasMain = true
+// 					break
+// 				}
+// 			}
+// 			Expect(hasMain).To(BeTrue(), "should have main branch")
+// 			GinkgoWriter.Printf("ListModelRevisions: branches=%d, tags=%d\n",
+// 				len(revResp.Items.Branches), len(revResp.Items.Tags))
+//
+// 			// ── ListModelCommits: verify commit history ────────
+// 			By("verifying ListModelCommits includes the commit")
+// 			commitsResp, _, err := modelsApi.ModelsListModelCommits(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsListModelCommitsOpts{
+// 				Page:     optional.NewInt32(1),
+// 				PageSize: optional.NewInt32(10),
+// 			})
+// 			Expect(err).NotTo(HaveOccurred())
+// 			Expect(len(commitsResp.Items)).To(BeNumerically(">=", 1))
+// 			Expect(commitsResp.Pagination).NotTo(BeNil())
+//
+// 			// Find our commit
+// 			var foundCommit bool
+// 			for _, c := range commitsResp.Items {
+// 				if c.Id == commitOid {
+// 					foundCommit = true
+// 					Expect(c.Message).To(ContainSubstring("add model metadata files"))
+// 					GinkgoWriter.Printf("ListModelCommits: found commit id=%s, message=%s\n", c.Id[:8], c.Message)
+// 					break
+// 				}
+// 			}
+// 			Expect(foundCommit).To(BeTrue(), "commit should appear in ListModelCommits")
+//
+// 			// ── GetModelCommit: verify commit detail ───────────
+// 			By("verifying GetModelCommit returns commit detail")
+// 			commitDetail, _, err := modelsApi.ModelsGetModelCommit(ctx, projectName, modelName, commitOid)
+// 			Expect(err).NotTo(HaveOccurred())
+// 			Expect(commitDetail.Id).To(Equal(commitOid))
+// 			Expect(len(commitDetail.Id)).To(Equal(40), "commit ID should be 40-char SHA-1")
+// 			Expect(commitDetail.Message).To(ContainSubstring("add model metadata files"))
+// 			Expect(commitDetail.AuthorName).NotTo(BeEmpty())
+// 			Expect(commitDetail.AuthorDate).NotTo(BeEmpty())
+// 			GinkgoWriter.Printf("GetModelCommit: id=%s, author=%s\n", commitDetail.Id[:8], commitDetail.AuthorName)
+//
+// 			// ── ListModelTaskLabels: verify global task label ──
+// 			By("verifying ListModelTaskLabels includes synced task label")
+// 			taskResp, _, err := modelsApi.ModelsListModelTaskLabels(ctx)
+// 			Expect(err).NotTo(HaveOccurred())
+// 			var hasTaskLabel bool
+// 			for _, l := range taskResp.Items {
+// 				if l.Name == "text-generation" {
+// 					hasTaskLabel = true
+// 					break
+// 				}
+// 			}
+// 			Expect(hasTaskLabel).To(BeTrue(), "task labels should include 'text-generation'")
+//
+// 			// ── ListModelFrameLabels: verify global library label
+// 			By("verifying ListModelFrameLabels includes synced library label")
+// 			frameResp, _, err := modelsApi.ModelsListModelFrameLabels(ctx)
+// 			Expect(err).NotTo(HaveOccurred())
+// 			var hasFrameLabel bool
+// 			for _, l := range frameResp.Items {
+// 				if l.Name == "transformers" {
+// 					hasFrameLabel = true
+// 					break
+// 				}
+// 			}
+// 			Expect(hasFrameLabel).To(BeTrue(), "library labels should include 'transformers'")
+// 		})
+//
+// 		It("should update metadata when README is replaced with new tags", Label("M00041"), func() {
+// 			By("committing initial README with tags")
+// 			payload1 := buildNDJSON("initial README", map[string]string{
+// 				"README.md": testReadmeContent,
+// 			})
+// 			_, err := hfCommit(baseURL, projectName, modelName, "main", payload1)
+// 			Expect(err).NotTo(HaveOccurred())
+// 			time.Sleep(3 * time.Second)
+//
+// 			model1, _, err := modelsApi.ModelsGetModel(ctx, projectName, modelName)
+// 			Expect(err).NotTo(HaveOccurred())
+// 			labels1 := extractLabelNames(model1.Labels)
+// 			GinkgoWriter.Printf("Labels after first commit: %v\n", labels1)
+// 			Expect(labels1).To(ContainElement("text-generation"))
+// 			Expect(labels1).To(ContainElement("transformers"))
+//
+// 			By("committing updated README with different tags")
+// 			updatedReadme := `---
+// library_name: vllm
+// license: mit
+// pipeline_tag: text-classification
+// language:
+// - en
+// - fr
+// - de
+// tags:
+// - onnx
+// ---
+//
+// # Updated Model
+//
+// This model has been updated.
+// `
+// 			payload2 := buildNDJSON("update README with new tags", map[string]string{
+// 				"README.md": updatedReadme,
+// 			})
+// 			_, err = hfCommit(baseURL, projectName, modelName, "main", payload2)
+// 			Expect(err).NotTo(HaveOccurred())
+// 			time.Sleep(3 * time.Second)
+//
+// 			By("verifying GetModel reflects new labels and readme")
+// 			model2, _, err := modelsApi.ModelsGetModel(ctx, projectName, modelName)
+// 			Expect(err).NotTo(HaveOccurred())
+// 			Expect(model2.ReadmeContent).To(ContainSubstring("# Updated Model"))
+//
+// 			labels2 := extractLabelNames(model2.Labels)
+// 			GinkgoWriter.Printf("Labels after second commit: %v\n", labels2)
+//
+// 			Expect(labels2).To(ContainElement("text-classification"))
+// 			Expect(labels2).To(ContainElement("vllm"))
+// 			Expect(labels2).To(ContainElement("mit"))
+//
+// 			By("verifying GetModelTree shows the same file updated (not duplicated)")
+// 			treeResp, _, err := modelsApi.ModelsGetModelTree(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsGetModelTreeOpts{})
+// 			Expect(err).NotTo(HaveOccurred())
+// 			readmeCount := 0
+// 			for _, f := range treeResp.Items {
+// 				if f.Name == "README.md" {
+// 					readmeCount++
+// 				}
+// 			}
+// 			Expect(readmeCount).To(Equal(1), "README.md should appear once, not duplicated")
+//
+// 			By("verifying ListModelCommits has both commits")
+// 			commitsResp, _, err := modelsApi.ModelsListModelCommits(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsListModelCommitsOpts{
+// 				Page:     optional.NewInt32(1),
+// 				PageSize: optional.NewInt32(10),
+// 			})
+// 			Expect(err).NotTo(HaveOccurred())
+// 			// initial commit (.gitattributes) + 2 metadata commits = at least 3
+// 			Expect(len(commitsResp.Items)).To(BeNumerically(">=", 3))
+// 			GinkgoWriter.Printf("ListModelCommits: %d commits after 2 updates\n", len(commitsResp.Items))
+// 		})
+//
+// 		It("should reflect metadata in ListModels search and label filter", Label("M00042"), func() {
+// 			By("committing metadata files")
+// 			payload := buildNDJSON("add metadata for search test", map[string]string{
+// 				"README.md":   testReadmeContent,
+// 				"config.json": testConfigJSON,
+// 			})
+// 			_, err := hfCommit(baseURL, projectName, modelName, "main", payload)
+// 			Expect(err).NotTo(HaveOccurred())
+// 			time.Sleep(3 * time.Second)
+//
+// 			By("verifying ListModels search finds the model")
+// 			searchResp, _, err := modelsApi.ModelsListModels(ctx, &v1alpha1model.ModelsApiModelsListModelsOpts{
+// 				Project:  optional.NewString(projectName),
+// 				Search:   optional.NewString(modelName),
+// 				Page:     optional.NewInt32(1),
+// 				PageSize: optional.NewInt32(10),
+// 			})
+// 			Expect(err).NotTo(HaveOccurred())
+// 			Expect(len(searchResp.Items)).To(BeNumerically(">=", 1))
+//
+// 			var foundModel *v1alpha1model.V1alpha1Model
+// 			for i, m := range searchResp.Items {
+// 				if m.Name == modelName {
+// 					foundModel = &searchResp.Items[i]
+// 					break
+// 				}
+// 			}
+// 			Expect(foundModel).NotTo(BeNil())
+// 			Expect(len(foundModel.Labels)).To(BeNumerically(">", 0))
+// 			GinkgoWriter.Printf("ListModels search: found model with %d labels\n", len(foundModel.Labels))
+// 		})
+//
+// 		It("should allow GetModelTree and GetModelBlob with revision=main", Label("M00043"), func() {
+// 			By("committing files")
+// 			payload := buildNDJSON("add files for revision test", map[string]string{
+// 				"README.md":   testReadmeContent,
+// 				"config.json": testConfigJSON,
+// 			})
+// 			_, err := hfCommit(baseURL, projectName, modelName, "main", payload)
+// 			Expect(err).NotTo(HaveOccurred())
+// 			time.Sleep(2 * time.Second)
+//
+// 			By("verifying GetModelTree with revision=main")
+// 			treeResp, _, err := modelsApi.ModelsGetModelTree(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsGetModelTreeOpts{
+// 				Revision: optional.NewString("main"),
+// 			})
+// 			Expect(err).NotTo(HaveOccurred())
+// 			Expect(len(treeResp.Items)).To(BeNumerically(">=", 2))
+//
+// 			By("verifying GetModelBlob with revision=main")
+// 			blobResp, _, err := modelsApi.ModelsGetModelBlob(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsGetModelBlobOpts{
+// 				Revision: optional.NewString("main"),
+// 				Path:     optional.NewString("config.json"),
+// 			})
+// 			Expect(err).NotTo(HaveOccurred())
+// 			Expect(blobResp.Name).To(Equal("config.json"))
+// 			Expect(*blobResp.Type_).To(Equal(v1alpha1model.FILE_V1alpha1FileType))
+// 			GinkgoWriter.Printf("GetModelBlob revision=main: name=%s, size=%s\n", blobResp.Name, blobResp.Size)
+// 		})
+//
+// 		It("should allow ListModelCommits with revision=main", Label("M00044"), func() {
+// 			By("committing a file")
+// 			payload := buildNDJSON("add file for commit revision test", map[string]string{
+// 				"README.md": testReadmeContent,
+// 			})
+// 			_, err := hfCommit(baseURL, projectName, modelName, "main", payload)
+// 			Expect(err).NotTo(HaveOccurred())
+// 			time.Sleep(2 * time.Second)
+//
+// 			By("verifying ListModelCommits with revision=main")
+// 			commitsResp, _, err := modelsApi.ModelsListModelCommits(ctx, projectName, modelName, &v1alpha1model.ModelsApiModelsListModelCommitsOpts{
+// 				Revision: optional.NewString("main"),
+// 				Page:     optional.NewInt32(1),
+// 				PageSize: optional.NewInt32(10),
+// 			})
+// 			Expect(err).NotTo(HaveOccurred())
+// 			Expect(len(commitsResp.Items)).To(BeNumerically(">=", 1))
+// 			Expect(commitsResp.Pagination).NotTo(BeNil())
+// 			GinkgoWriter.Printf("ListModelCommits revision=main: %d commits\n", len(commitsResp.Items))
+// 		})
+// 	})
+// })

--- a/test/e2e_apiserver/model/model_test.go
+++ b/test/e2e_apiserver/model/model_test.go
@@ -646,4 +646,360 @@ var _ = Describe("Model", Label("model"), func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
+
+	// ═══════════════════════════════════════════════════════════
+	// 7. Multi-user permission tests
+	// ═══════════════════════════════════════════════════════════
+	Context("Multi-user permission tests", func() {
+		var (
+			viewerCookie    string
+			viewerID        int32
+			editorCookie    string
+			editorID        int32
+			projAdminCookie string
+			projAdminID     int32
+		)
+
+		BeforeEach(func() {
+			password := "Test@123456"
+
+			viewerUsername := tools.GenerateTestUsername("m-viewer")
+			var err error
+			viewerID, viewerCookie, err = tools.CreateUserAndLoginWithID(viewerUsername, password, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			editorUsername := tools.GenerateTestUsername("m-editor")
+			editorID, editorCookie, err = tools.CreateUserAndLoginWithID(editorUsername, password, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			projAdminUsername := tools.GenerateTestUsername("m-padmin")
+			projAdminID, projAdminCookie, err = tools.CreateUserAndLoginWithID(projAdminUsername, password, false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("Project viewer model permissions", func() {
+			var projectName string
+			var modelName string
+
+			BeforeEach(func() {
+				projectName = tools.GenerateTestProjectName("m-viewer-perm")
+				_, _, err := projectsApi.ProjectsCreateProject(ctx, v1alpha1project.V1alpha1CreateProjectRequest{
+					Name: projectName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				memberType := v1alpha1project.USER_V1alpha1MemberType
+				viewerRole := v1alpha1project.VIEWER_V1alpha1ProjectRoleType
+				_, _, err = projectsApi.ProjectsAddProjectMemberWithRole(ctx, projectName, v1alpha1project.ProjectsAddProjectMemberWithRoleBody{
+					MemberId:   viewerID,
+					MemberType: &memberType,
+					Role:       &viewerRole,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				modelName = tools.GenerateTestModelName("viewer-model")
+				_, _, err = modelsApi.ModelsCreateModel(ctx, v1alpha1model.V1alpha1CreateModelRequest{
+					Project: projectName,
+					Name:    modelName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				_, _, _ = projectsApi.ProjectsDeleteProject(ctx, projectName)
+			})
+
+			It("should allow viewer to get model", Label("M00039"), func() {
+				viewerModelsApi := tools.CreateModelClientWithCookie(viewerCookie)
+				getResp, _, err := viewerModelsApi.ModelsGetModel(ctx, projectName, modelName)
+				Expect(err).NotTo(HaveOccurred(), "Viewer should be able to get model")
+				Expect(getResp.Name).To(Equal(modelName))
+			})
+
+			It("should deny viewer from creating model", Label("M00040"), func() {
+				viewerModelsApi := tools.CreateModelClientWithCookie(viewerCookie)
+				_, _, err := viewerModelsApi.ModelsCreateModel(ctx, v1alpha1model.V1alpha1CreateModelRequest{
+					Project: projectName,
+					Name:    tools.GenerateTestModelName("viewer-create"),
+				})
+				Expect(err).To(HaveOccurred(), "Viewer should not be able to create model")
+			})
+
+			It("should deny viewer from deleting model", Label("M00041"), func() {
+				viewerModelsApi := tools.CreateModelClientWithCookie(viewerCookie)
+				_, _, err := viewerModelsApi.ModelsDeleteModel(ctx, projectName, modelName)
+				Expect(err).To(HaveOccurred(), "Viewer should not be able to delete model")
+			})
+		})
+
+		Context("Project editor model permissions", func() {
+			var projectName string
+			var modelName string
+
+			BeforeEach(func() {
+				projectName = tools.GenerateTestProjectName("m-editor-perm")
+				_, _, err := projectsApi.ProjectsCreateProject(ctx, v1alpha1project.V1alpha1CreateProjectRequest{
+					Name: projectName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				memberType := v1alpha1project.USER_V1alpha1MemberType
+				editorRole := v1alpha1project.EDITOR_V1alpha1ProjectRoleType
+				_, _, err = projectsApi.ProjectsAddProjectMemberWithRole(ctx, projectName, v1alpha1project.ProjectsAddProjectMemberWithRoleBody{
+					MemberId:   editorID,
+					MemberType: &memberType,
+					Role:       &editorRole,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				modelName = tools.GenerateTestModelName("editor-model")
+				_, _, err = modelsApi.ModelsCreateModel(ctx, v1alpha1model.V1alpha1CreateModelRequest{
+					Project: projectName,
+					Name:    modelName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				_, _, _ = projectsApi.ProjectsDeleteProject(ctx, projectName)
+			})
+
+			It("should allow editor to get model", Label("M00042"), func() {
+				editorModelsApi := tools.CreateModelClientWithCookie(editorCookie)
+				getResp, _, err := editorModelsApi.ModelsGetModel(ctx, projectName, modelName)
+				Expect(err).NotTo(HaveOccurred(), "Editor should be able to get model")
+				Expect(getResp.Name).To(Equal(modelName))
+			})
+
+			It("should allow editor to create model", Label("M00043"), func() {
+				editorModelsApi := tools.CreateModelClientWithCookie(editorCookie)
+				_, _, err := editorModelsApi.ModelsCreateModel(ctx, v1alpha1model.V1alpha1CreateModelRequest{
+					Project: projectName,
+					Name:    tools.GenerateTestModelName("editor-create"),
+				})
+				Expect(err).NotTo(HaveOccurred(), "Editor should be able to create model")
+			})
+
+			It("should deny editor from deleting model", Label("M00044"), func() {
+				editorModelsApi := tools.CreateModelClientWithCookie(editorCookie)
+				_, _, err := editorModelsApi.ModelsDeleteModel(ctx, projectName, modelName)
+				Expect(err).To(HaveOccurred(), "Editor should not be able to delete model")
+			})
+		})
+
+		Context("Project admin model permissions", func() {
+			var projectName string
+			var modelName string
+
+			BeforeEach(func() {
+				projectName = tools.GenerateTestProjectName("m-padmin-perm")
+				_, _, err := projectsApi.ProjectsCreateProject(ctx, v1alpha1project.V1alpha1CreateProjectRequest{
+					Name: projectName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				memberType := v1alpha1project.USER_V1alpha1MemberType
+				adminRole := v1alpha1project.ADMIN_V1alpha1ProjectRoleType
+				_, _, err = projectsApi.ProjectsAddProjectMemberWithRole(ctx, projectName, v1alpha1project.ProjectsAddProjectMemberWithRoleBody{
+					MemberId:   projAdminID,
+					MemberType: &memberType,
+					Role:       &adminRole,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				modelName = tools.GenerateTestModelName("padmin-model")
+				_, _, err = modelsApi.ModelsCreateModel(ctx, v1alpha1model.V1alpha1CreateModelRequest{
+					Project: projectName,
+					Name:    modelName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				_, _, _ = projectsApi.ProjectsDeleteProject(ctx, projectName)
+			})
+
+			It("should allow project admin to get model", Label("M00045"), func() {
+				projAdminModelsApi := tools.CreateModelClientWithCookie(projAdminCookie)
+				getResp, _, err := projAdminModelsApi.ModelsGetModel(ctx, projectName, modelName)
+				Expect(err).NotTo(HaveOccurred(), "Project admin should be able to get model")
+				Expect(getResp.Name).To(Equal(modelName))
+			})
+
+			It("should allow project admin to create model", Label("M00046"), func() {
+				projAdminModelsApi := tools.CreateModelClientWithCookie(projAdminCookie)
+				_, _, err := projAdminModelsApi.ModelsCreateModel(ctx, v1alpha1model.V1alpha1CreateModelRequest{
+					Project: projectName,
+					Name:    tools.GenerateTestModelName("padmin-create"),
+				})
+				Expect(err).NotTo(HaveOccurred(), "Project admin should be able to create model")
+			})
+
+			It("should allow project admin to delete model", Label("M00047"), func() {
+				projAdminModelsApi := tools.CreateModelClientWithCookie(projAdminCookie)
+				_, _, err := projAdminModelsApi.ModelsDeleteModel(ctx, projectName, modelName)
+				Expect(err).NotTo(HaveOccurred(), "Project admin should be able to delete model")
+			})
+		})
+
+		It("should deny non-member from accessing model in project", Label("M00048"), func() {
+			projectName := tools.GenerateTestProjectName("m-nonmember")
+			_, _, err := projectsApi.ProjectsCreateProject(ctx, v1alpha1project.V1alpha1CreateProjectRequest{
+				Name: projectName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				_, _, _ = projectsApi.ProjectsDeleteProject(ctx, projectName)
+			}()
+
+			modelName := tools.GenerateTestModelName("nonmember")
+			_, _, err = modelsApi.ModelsCreateModel(ctx, v1alpha1model.V1alpha1CreateModelRequest{
+				Project: projectName,
+				Name:    modelName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			viewerModelsApi := tools.CreateModelClientWithCookie(viewerCookie)
+			_, _, err = viewerModelsApi.ModelsGetModel(ctx, projectName, modelName)
+			Expect(err).To(HaveOccurred(), "Non-member should not be able to access model")
+		})
+
+		Context("ListModels permission tests", func() {
+			var publicProjectName string
+			var privateProjectName string
+			var publicModelName string
+			var privateModelName string
+
+			BeforeEach(func() {
+				publicProjectName = tools.GenerateTestProjectName("m-list-public")
+				publicType := v1alpha1project.PUBLIC_V1alpha1ProjectType
+				_, _, err := projectsApi.ProjectsCreateProject(ctx, v1alpha1project.V1alpha1CreateProjectRequest{
+					Name:  publicProjectName,
+					Type_: &publicType,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				publicModelName = tools.GenerateTestModelName("pub-model")
+				_, _, err = modelsApi.ModelsCreateModel(ctx, v1alpha1model.V1alpha1CreateModelRequest{
+					Project: publicProjectName,
+					Name:    publicModelName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				privateProjectName = tools.GenerateTestProjectName("m-list-private")
+				privateType := v1alpha1project.PRIVATE_V1alpha1ProjectType
+				_, _, err = projectsApi.ProjectsCreateProject(ctx, v1alpha1project.V1alpha1CreateProjectRequest{
+					Name:  privateProjectName,
+					Type_: &privateType,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				privateModelName = tools.GenerateTestModelName("priv-model")
+				_, _, err = modelsApi.ModelsCreateModel(ctx, v1alpha1model.V1alpha1CreateModelRequest{
+					Project: privateProjectName,
+					Name:    privateModelName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				_, _, _ = projectsApi.ProjectsDeleteProject(ctx, publicProjectName)
+				_, _, _ = projectsApi.ProjectsDeleteProject(ctx, privateProjectName)
+			})
+
+			It("should show public project models to member", Label("M00049"), func() {
+				memberType := v1alpha1project.USER_V1alpha1MemberType
+				editorRole := v1alpha1project.EDITOR_V1alpha1ProjectRoleType
+				_, _, err := projectsApi.ProjectsAddProjectMemberWithRole(ctx, publicProjectName, v1alpha1project.ProjectsAddProjectMemberWithRoleBody{
+					MemberId:   editorID,
+					MemberType: &memberType,
+					Role:       &editorRole,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				editorModelsApi := tools.CreateModelClientWithCookie(editorCookie)
+				listResp, _, err := editorModelsApi.ModelsListModels(ctx, &v1alpha1model.ModelsApiModelsListModelsOpts{
+					Project:  optional.NewString(publicProjectName),
+					Page:     optional.NewInt32(1),
+					PageSize: optional.NewInt32(50),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				var found bool
+				for _, m := range listResp.Items {
+					if m.Name == publicModelName {
+						found = true
+						break
+					}
+				}
+				Expect(found).To(BeTrue(), "Member should see public project models")
+			})
+
+			It("should show public project models to non-member", Label("M00050"), func() {
+				viewerModelsApi := tools.CreateModelClientWithCookie(viewerCookie)
+				listResp, _, err := viewerModelsApi.ModelsListModels(ctx, &v1alpha1model.ModelsApiModelsListModelsOpts{
+					Project:  optional.NewString(publicProjectName),
+					Page:     optional.NewInt32(1),
+					PageSize: optional.NewInt32(50),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				var found bool
+				for _, m := range listResp.Items {
+					if m.Name == publicModelName {
+						found = true
+						break
+					}
+				}
+				Expect(found).To(BeTrue(), "Non-member should see public project models")
+			})
+
+			It("should show private project models to member", Label("M00051"), func() {
+				memberType := v1alpha1project.USER_V1alpha1MemberType
+				editorRole := v1alpha1project.EDITOR_V1alpha1ProjectRoleType
+				_, _, err := projectsApi.ProjectsAddProjectMemberWithRole(ctx, privateProjectName, v1alpha1project.ProjectsAddProjectMemberWithRoleBody{
+					MemberId:   editorID,
+					MemberType: &memberType,
+					Role:       &editorRole,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				editorModelsApi := tools.CreateModelClientWithCookie(editorCookie)
+				listResp, _, err := editorModelsApi.ModelsListModels(ctx, &v1alpha1model.ModelsApiModelsListModelsOpts{
+					Project:  optional.NewString(privateProjectName),
+					Page:     optional.NewInt32(1),
+					PageSize: optional.NewInt32(50),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				var found bool
+				for _, m := range listResp.Items {
+					if m.Name == privateModelName {
+						found = true
+						break
+					}
+				}
+				Expect(found).To(BeTrue(), "Member should see private project models")
+			})
+
+			It("should not show private project models to non-member", Label("M00052"), func() {
+				viewerModelsApi := tools.CreateModelClientWithCookie(viewerCookie)
+				listResp, _, err := viewerModelsApi.ModelsListModels(ctx, &v1alpha1model.ModelsApiModelsListModelsOpts{
+					Project:  optional.NewString(privateProjectName),
+					Page:     optional.NewInt32(1),
+					PageSize: optional.NewInt32(50),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				var found bool
+				for _, m := range listResp.Items {
+					if m.Name == privateModelName {
+						found = true
+						break
+					}
+				}
+				Expect(found).To(BeFalse(), "Non-member should not see private project models")
+			})
+		})
+	})
 })


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
- Add authz checks to model handler endpoints: GetModel (model.get), CreateModel (model.push), DeleteModel (model.delete), and all git-read endpoints (model.get)
- Fix RegisterModelsHandlerServer → RegisterModelsHandlerFromEndpoint so gRPC interceptors (AuthInterceptor, AuthzInterceptor) actually execute for model requests
- Remove CreateModel from authentication publicMethods to ensure session cookies are parsed and UserIdCtxKey is set in ctx
- Add VerifyProjectPermissionByName to authz service for resolving project name → ID before permission checks
- Add ListModels permission filtering: returns models from projects where user has membership plus all public projects; platform admins see all models; unauthenticated users see only public projects
- Fix authz repo to parse permissions directly from JSON string, bypassing the broken PermissionList.Scan in role.go
- Add multi-user permission e2e tests (M00039-M00052) covering viewer/editor/admin/non-member for get/create/delete/list operations

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #156 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```