### PR TITLE
fix a project name map(local with remote) issue for proxy project

### DIFF
--- a/internal/repo/git_repo.go
+++ b/internal/repo/git_repo.go
@@ -458,7 +458,7 @@ func (g *gitRepo) CloneFromRemote(ctx context.Context, gitRepository *git.GitRep
 		return fmt.Errorf("repository already exists")
 	}
 
-	repoName := repoPrefix(gitRepository.ResourceType) + gitRepository.ProjectName + "/" + gitRepository.ResourceName
+	repoName := repoPrefix(gitRepository.ResourceType) + gitRepository.RemoteProjectName + "/" + gitRepository.RemoteResourceName
 	sourceURL := strings.TrimSuffix(gitRepository.RemoteRegistryURL, "/") + "/" + repoName
 	_, err := repository.InitMirror(ctx, gitPath, sourceURL)
 	if err != nil {
@@ -469,7 +469,7 @@ func (g *gitRepo) CloneFromRemote(ctx context.Context, gitRepository *git.GitRep
 
 func (g *gitRepo) PullFromRemote(ctx context.Context, gitRepository *git.GitRepository) error {
 	gitPath := g.gitPath(gitRepository.ResourceType, gitRepository.ProjectName, gitRepository.ResourceName)
-	repoName := repoPrefix(gitRepository.ResourceType) + gitRepository.ProjectName + "/" + gitRepository.ResourceName
+	repoName := repoPrefix(gitRepository.ResourceType) + gitRepository.RemoteProjectName + "/" + gitRepository.RemoteResourceName
 	sourceURL := strings.TrimSuffix(gitRepository.RemoteRegistryURL, "/") + "/" + repoName
 	if !repository.IsRepository(gitPath) {
 		_, err := repository.InitMirror(ctx, gitPath, sourceURL)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

fix a issue: project/resource name  not correctly map with remote org/resource name for a proxy project

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

 #95

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
fixed now:
<img width="964" height="107" alt="image" src="https://github.com/user-attachments/assets/388d6078-2bc7-4d1e-8df6-9f834c27e441" />
