### PR TITLE
fix(api): populate CommitterDate and CreatedAt in tree/blob commit 

### DIFF
--- a/internal/repo/git_repo.go
+++ b/internal/repo/git_repo.go
@@ -354,6 +354,8 @@ func (g *gitRepo) GetTree(ctx context.Context, repoType, project, name, revision
 					AuthorDate:     lastCommit.Author().When(),
 					CommitterName:  lastCommit.Committer().Name(),
 					CommitterEmail: lastCommit.Committer().Email(),
+					CommitterDate:  lastCommit.Committer().When(),
+					CreatedAt:      lastCommit.Committer().When(),
 				},
 			})
 		} else {
@@ -370,6 +372,8 @@ func (g *gitRepo) GetTree(ctx context.Context, repoType, project, name, revision
 					AuthorDate:     lastCommit.Author().When(),
 					CommitterName:  lastCommit.Committer().Name(),
 					CommitterEmail: lastCommit.Committer().Email(),
+					CommitterDate:  lastCommit.Committer().When(),
+					CreatedAt:      lastCommit.Committer().When(),
 				},
 			})
 		}
@@ -415,6 +419,8 @@ func (g *gitRepo) GetBlob(ctx context.Context, repoType, project, name, revision
 				AuthorDate:     lastCommit.Author().When(),
 				CommitterName:  lastCommit.Committer().Name(),
 				CommitterEmail: lastCommit.Committer().Email(),
+				CommitterDate:  lastCommit.Committer().When(),
+				CreatedAt:      lastCommit.Committer().When(),
 			},
 		}, nil
 	}
@@ -448,6 +454,8 @@ func (g *gitRepo) GetBlob(ctx context.Context, repoType, project, name, revision
 			AuthorDate:     commit.Author().When(),
 			CommitterName:  commit.Committer().Name(),
 			CommitterEmail: commit.Committer().Email(),
+			CommitterDate:  commit.Committer().When(),
+			CreatedAt:      commit.Committer().When(),
 		},
 	}, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
#### What this PR does / why we need it:

  GetTree and GetBlob were constructing git.Commit structs without setting
  CommitterDate and CreatedAt, causing the API to return zero time
  "0001-01-01T00:00:00Z" for these fields.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #156 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```