### PR TITLE
feat: add release CI pipeline with Helm chart publishing and GitHub Release automation

### DIFF
--- a/.github/workflows/build-image-ci.yaml
+++ b/.github/workflows/build-image-ci.yaml
@@ -76,7 +76,7 @@ jobs:
           echo "repo_lower=${REPO_LOWER}" >> $GITHUB_ENV
 
       # ========== main build ==========
-      - name: CI Build matrixhub-apiserver
+      - name: CI Build matrixhub
         uses: docker/build-push-action@v6.15.0
         id: docker_build
         with:

--- a/.github/workflows/call-release-changelog.yaml
+++ b/.github/workflows/call-release-changelog.yaml
@@ -5,9 +5,6 @@ env:
   LABEL_FEATURE: "release/feature-new"
   LABEL_CHANGED: "release/feature-changed"
   LABEL_BUG: "release/bug"
-  DEST_BRANCH: gh-pages
-  DEST_DIRECTORY: 'changelogs/'
-
 on:
   workflow_call:
     inputs:
@@ -82,28 +79,3 @@ jobs:
           path: ${{ env.FILE_PATH }}
           retention-days: 1
           if-no-files-found: error
-
-  update_githubpage:
-    runs-on: ubuntu-latest
-    needs: [generate_changelog]
-    steps:
-      - name: Checkout gh-pages
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.DEST_BRANCH }}
-          fetch-depth: 0
-          persist-credentials: "true"
-
-      - name: Download Artifact
-        uses: actions/download-artifact@v4.2.1
-        with:
-          name: changelog_artifact_${{ needs.generate_changelog.outputs.dest_tag }}
-          path: ${{ env.DEST_DIRECTORY }}
-
-      - name: Commit Changelog
-        run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-          git add .
-          git commit -m "robot update changelog from tag ${{ needs.generate_changelog.outputs.begin_tag }} to tag ${{ needs.generate_changelog.outputs.dest_tag }}" || echo "No changes to commit"
-          git push origin ${{ env.DEST_BRANCH }}

--- a/.github/workflows/call-release-changelog.yaml
+++ b/.github/workflows/call-release-changelog.yaml
@@ -1,0 +1,109 @@
+name: Call Release Changelog
+
+env:
+  SCRIPT_PATH: "./scripts/changelog.sh"
+  LABEL_FEATURE: "release/feature-new"
+  LABEL_CHANGED: "release/feature-changed"
+  LABEL_BUG: "release/bug"
+  DEST_BRANCH: gh-pages
+  DEST_DIRECTORY: 'changelogs/'
+
+on:
+  workflow_call:
+    inputs:
+      dest_tag:
+        required: true
+        type: string
+    outputs:
+      artifact:
+        description: "name of changelog artifact"
+        value: changelog_artifact
+
+permissions: write-all
+
+jobs:
+  generate_changelog:
+    runs-on: ubuntu-latest
+    outputs:
+      dest_tag: ${{ env.dest_tag }}
+      begin_tag: ${{ env.begin_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get Input Tags
+        run: |
+          set -x
+          dest_tag=""
+          if ${{ inputs.dest_tag != '' }} ; then
+              echo "call by workflow_call"
+              dest_tag=${{ inputs.dest_tag }}
+              [ -z "$dest_tag" ] && echo "empty dest_tag" && exit 1
+              if ! git describe --tags --abbrev=0 ${dest_tag} &>/dev/null ; then
+                  echo "error, does not exist dest_tag ${dest_tag} "
+                  exit 1
+              fi
+          else
+              echo "unexpected empty dest_tag"
+              exit 1
+          fi
+          echo "RUN_dest_tag=${dest_tag}" >> $GITHUB_ENV
+
+      - name: Generate Changelog
+        run: |
+          set -x
+          export LABEL_FEATURE=${{ env.LABEL_FEATURE }}
+          export LABEL_CHANGED=${{ env.LABEL_CHANGED }}
+          export LABEL_BUG=${{ env.LABEL_BUG }}
+          export PROJECT_REPO=${{ github.repository }}
+          export GH_TOKEN=${{ github.token }}
+          mkdir changelog
+          ${{ env.SCRIPT_PATH }} ./changelog ${{ env.RUN_dest_tag }} \
+            || { echo "error, failed to generate changelog " ; exit 1 ; }
+          FILE_NAME=` ls changelog `
+          [ -n "$FILE_NAME" ] || { echo "error, failed to find changelog " ; exit 2 ; }
+          #
+          TMP=` echo ${FILE_NAME%.*}`
+          begin_tag=`awk -F'_' '{print $3}' <<< "${TMP}" `
+          dest_tag=`awk -F'_' '{print $5}' <<< "${TMP}" `
+          echo "dest_tag=${dest_tag}" >> $GITHUB_ENV
+          echo "begin_tag=${begin_tag}" >> $GITHUB_ENV
+          FILE_PATH=` echo ${PWD}/changelog/${FILE_NAME} `
+          echo "FILE_PATH=${FILE_PATH}" >> $GITHUB_ENV
+          echo "------------------------------------"
+          cat ${FILE_PATH}
+
+      - name: Upload Changelog
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: changelog_artifact_${{ env.RUN_dest_tag }}
+          path: ${{ env.FILE_PATH }}
+          retention-days: 1
+          if-no-files-found: error
+
+  update_githubpage:
+    runs-on: ubuntu-latest
+    needs: [generate_changelog]
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEST_BRANCH }}
+          fetch-depth: 0
+          persist-credentials: "true"
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4.2.1
+        with:
+          name: changelog_artifact_${{ needs.generate_changelog.outputs.dest_tag }}
+          path: ${{ env.DEST_DIRECTORY }}
+
+      - name: Commit Changelog
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add .
+          git commit -m "robot update changelog from tag ${{ needs.generate_changelog.outputs.begin_tag }} to tag ${{ needs.generate_changelog.outputs.dest_tag }}" || echo "No changes to commit"
+          git push origin ${{ env.DEST_BRANCH }}

--- a/.github/workflows/call-release-chart.yaml
+++ b/.github/workflows/call-release-chart.yaml
@@ -1,8 +1,7 @@
 name: Call Release Charts
 
 # This workflow packages the Helm chart and pushes it to:
-# 1. GitHub Container Registry (OCI) - ghcr.io
-# 2. GitHub Pages (index.yaml for traditional helm repo)
+# GitHub Container Registry (OCI) - ghcr.io
 
 env:
   HELM_VERSION: v3.13.0
@@ -174,64 +173,3 @@ jobs:
           ls -la /tmp/verify/
           echo "Verification successful!"
 
-  # Optional: Also update GitHub Pages for traditional helm repo
-  update-github-pages:
-    runs-on: ubuntu-latest
-    needs: [get-ref, package-chart]
-    if: ${{ needs.get-ref.outputs.submit == 'true' }}
-    permissions:
-      pages: write
-      id-token: write
-      contents: write
-    steps:
-      - name: Get Base Chart URL
-        id: get_base_url
-        run: |
-          name=${{ github.repository }}
-          proj=${name#*/}
-          owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          url=https://${owner}.github.io/${proj}
-          echo "URL=${url}" >> $GITHUB_ENV
-
-      - name: Checkout Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          persist-credentials: "true"
-
-      - name: Setup GitHub Pages Branch
-        run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-
-          # Check if gh-pages branch exists
-          if git ls-remote --heads origin gh-pages | grep -q .; then
-            echo "gh-pages branch exists, checking out..."
-            git checkout gh-pages
-          else
-            echo "gh-pages branch does not exist, creating..."
-            git checkout --orphan gh-pages
-            git rm -rf . || true
-            git commit --allow-empty -m "Initialize gh-pages"
-            git push origin gh-pages
-          fi
-
-      - name: Download Artifact
-        uses: actions/download-artifact@v4.2.1
-        with:
-          name: chart_package_artifact_${{ needs.get-ref.outputs.ref }}
-          path: charts/
-
-      - name: Update Chart Index
-        run: |
-          mkdir -p charts
-          helm repo index ./charts --url ${{ env.URL }}/charts
-          mv ./charts/index.yaml ./index.yaml
-
-      - name: Push to GitHub Pages
-        run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-          git add .
-          git commit -m "Update chart to ${{ needs.get-ref.outputs.ref }}" || echo "No changes to commit"
-          git push origin gh-pages

--- a/.github/workflows/call-release-chart.yaml
+++ b/.github/workflows/call-release-chart.yaml
@@ -1,0 +1,237 @@
+name: Call Release Charts
+
+# This workflow packages the Helm chart and pushes it to:
+# 1. GitHub Container Registry (OCI) - ghcr.io
+# 2. GitHub Pages (index.yaml for traditional helm repo)
+
+env:
+  HELM_VERSION: v3.13.0
+  CHART_NAME: matrixhub
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+      submit:
+        required: true
+        type: string
+    outputs:
+      artifact:
+        description: "Name of chart artifact"
+        value: chart_package_artifact
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag, sha, or branch'
+        required: true
+        default: v0.0.1
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  get-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.get_ref.outputs.ref }}
+      submit: ${{ steps.get_ref.outputs.submit }}
+      chart-version: ${{ steps.get_ref.outputs.chart-version }}
+    steps:
+      - name: Get Ref
+        id: get_ref
+        run: |
+          if [ "${{ inputs.ref }}" != "" ]; then
+            echo "Called by workflow_call"
+            REF="${{ inputs.ref }}"
+            SUBMIT="${{ inputs.submit }}"
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "Called by workflow_dispatch"
+            REF="${{ inputs.ref }}"
+            SUBMIT="true"
+          else
+            echo "Unexpected event: ${{ github.event_name }}"
+            exit 1
+          fi
+          # Extract chart version (remove 'v' prefix)
+          CHART_VERSION=$(echo "${REF}" | sed 's/^v//')
+          echo "ref=${REF}" >> $GITHUB_OUTPUT
+          echo "submit=${SUBMIT}" >> $GITHUB_OUTPUT
+          echo "chart-version=${CHART_VERSION}" >> $GITHUB_OUTPUT
+          echo "Ref: ${REF}"
+          echo "Chart version: ${CHART_VERSION}"
+
+  package-chart:
+    runs-on: ubuntu-latest
+    needs: get-ref
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.get-ref.outputs.ref }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Update Chart Version
+        run: |
+          cd deploy/charts
+          chart_version="${{ needs.get-ref.outputs.chart-version }}"
+          image_ref="${{ needs.get-ref.outputs.ref }}"
+          echo "Updating chart version to: ${chart_version}"
+          echo "Image ref: ${image_ref}"
+
+          # Update version in Chart.yaml
+          sed -i "s/^version:.*/version: ${chart_version}/" matrixhub/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${chart_version}\"/" matrixhub/Chart.yaml
+
+          # Update image tag in values.yaml
+          sed -i "s|tag: \"\"|tag: ${image_ref}|" matrixhub/values.yaml
+
+          echo "Updated Chart.yaml:"
+          cat matrixhub/Chart.yaml
+          echo "Updated values.yaml (image section):"
+          grep -A5 "image:" matrixhub/values.yaml | head -20
+
+      - name: Lint Chart
+        run: |
+          cd deploy/charts
+          helm lint --with-subcharts --values matrixhub/values.yaml matrixhub
+
+      - name: Package Chart
+        run: |
+          cd deploy/charts
+          helm package matrixhub -d .
+          if ! ls *.tgz &>/dev/null; then
+            echo "Failed to generate chart package"
+            exit 1
+          fi
+          mkdir -p tmp
+          mv *.tgz tmp/
+          echo "Packaged chart:"
+          ls -la tmp/
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: chart_package_artifact_${{ needs.get-ref.outputs.ref }}
+          path: deploy/charts/tmp/*
+          retention-days: 7
+          if-no-files-found: error
+
+  push-to-oci:
+    runs-on: ubuntu-latest
+    needs: [get-ref, package-chart]
+    if: needs.get-ref.outputs.submit == 'true'
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v4.2.1
+        with:
+          name: chart_package_artifact_${{ needs.get-ref.outputs.ref }}
+          path: charts/
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Chart to OCI Registry
+        run: |
+          echo "Pushing chart to OCI registry..."
+          chart_file=$(ls charts/*.tgz)
+          echo "Chart file: ${chart_file}"
+
+          # Convert repository owner to lowercase for OCI registry
+          REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "Repository owner (lowercase): ${REPO_OWNER}"
+
+          # Push to ghcr.io as OCI artifact
+          helm push "${chart_file}" oci://ghcr.io/${REPO_OWNER}
+
+          echo "Chart pushed to: oci://ghcr.io/${REPO_OWNER}/${{ env.CHART_NAME }}:${{ needs.get-ref.outputs.chart-version }}"
+          echo ""
+          echo "To install this chart, run:"
+          echo "  helm repo add matrixhub oci://ghcr.io/${REPO_OWNER}"
+          echo "  helm install matrixhub matrixhub/${{ env.CHART_NAME }} --version ${{ needs.get-ref.outputs.chart-version }}"
+
+      - name: Verify OCI Push
+        run: |
+          echo "Verifying chart is available in OCI registry..."
+          REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          mkdir -p /tmp/verify 
+          helm pull oci://ghcr.io/${REPO_OWNER}/${{ env.CHART_NAME }} --version ${{ needs.get-ref.outputs.chart-version }} --destination /tmp/verify
+          ls -la /tmp/verify/
+          echo "Verification successful!"
+
+  # Optional: Also update GitHub Pages for traditional helm repo
+  update-github-pages:
+    runs-on: ubuntu-latest
+    needs: [get-ref, package-chart]
+    if: ${{ needs.get-ref.outputs.submit == 'true' }}
+    permissions:
+      pages: write
+      id-token: write
+      contents: write
+    steps:
+      - name: Get Base Chart URL
+        id: get_base_url
+        run: |
+          name=${{ github.repository }}
+          proj=${name#*/}
+          owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          url=https://${owner}.github.io/${proj}
+          echo "URL=${url}" >> $GITHUB_ENV
+
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: "true"
+
+      - name: Setup GitHub Pages Branch
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+          # Check if gh-pages branch exists
+          if git ls-remote --heads origin gh-pages | grep -q .; then
+            echo "gh-pages branch exists, checking out..."
+            git checkout gh-pages
+          else
+            echo "gh-pages branch does not exist, creating..."
+            git checkout --orphan gh-pages
+            git rm -rf . || true
+            git commit --allow-empty -m "Initialize gh-pages"
+            git push origin gh-pages
+          fi
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4.2.1
+        with:
+          name: chart_package_artifact_${{ needs.get-ref.outputs.ref }}
+          path: charts/
+
+      - name: Update Chart Index
+        run: |
+          mkdir -p charts
+          helm repo index ./charts --url ${{ env.URL }}/charts
+          mv ./charts/index.yaml ./index.yaml
+
+      - name: Push to GitHub Pages
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add .
+          git commit -m "Update chart to ${{ needs.get-ref.outputs.ref }}" || echo "No changes to commit"
+          git push origin gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 # This workflow is triggered by tag push:
 # 1. Builds and pushes container images to ghcr.io
-# 2. Packages Helm chart and pushes to ghcr.io (OCI) and GitHub Pages
+# 2. Packages Helm chart and pushes to ghcr.io (OCI)
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,33 +1,129 @@
-name: Release image
+name: Release
+
+# This workflow is triggered by tag push:
+# 1. Builds and pushes container images to ghcr.io
+# 2. Packages Helm chart and pushes to ghcr.io (OCI) and GitHub Pages
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag'
+        required: true
+        default: v1.0.0
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
+      - 'v[0-9]*.[0-9]*.[0-9]*-rc[0-9]*'
+      - 'v[0-9]*.[0-9]*.[0-9]*-dev[0-9]*'
 
-permissions:
-  contents: read
-  packages: write
+permissions: write-all
 
 jobs:
-  build-and-push:
+  get-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.get_tag.outputs.tag }}
+      is-official-release: ${{ steps.get_tag.outputs.is_official_release }}
+    steps:
+      - name: Get Tag
+        id: get_tag
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "Called by workflow_dispatch"
+            RUN_TAG="${{ github.event.inputs.tag || 'v0.0.1' }}"
+          elif [ "${{ github.event_name }}" == "push" ]; then
+            echo "Called by push tag"
+            RUN_TAG="${GITHUB_REF##*/}"
+          else
+            echo "Unexpected event: ${{ github.event_name }}"
+            exit 1
+          fi
+          echo "Tag: ${RUN_TAG}"
+          echo "tag=${RUN_TAG}" >> $GITHUB_OUTPUT
+
+          # Check if this is an official release (vX.Y.Z without -rc or -dev suffix)
+          if [[ "${RUN_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "is_official_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_official_release=false" >> $GITHUB_OUTPUT
+          fi
+          echo "Is official release: $(cat $GITHUB_OUTPUT | grep is_official_release)"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.get_tag.outputs.tag }}
+
+  build-and-push-image:
+    needs: get-tag
+    uses: ./.github/workflows/call-release-image.yaml
+    with:
+      ref: ${{ needs.get-tag.outputs.tag }}
+    secrets: inherit
+
+  release-chart:
+    needs: [get-tag, build-and-push-image]
+    uses: ./.github/workflows/call-release-chart.yaml
+    with:
+      ref: ${{ needs.get-tag.outputs.tag }}
+      submit: true
+    secrets: inherit
+
+  release-changelog:
+    needs: [build-and-push-image, release-chart, get-tag]
+    uses: ./.github/workflows/call-release-changelog.yaml
+    with:
+      dest_tag: ${{ needs.get-tag.outputs.tag }}
+    secrets: inherit
+
+  create-release:
+    needs: [release-chart, release-changelog, get-tag]
+    if: needs.get-tag.outputs.is-official-release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
+      - name: Download Chart Artifact
+        uses: actions/download-artifact@v4.2.1
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          name: chart_package_artifact_${{ needs.get-tag.outputs.tag }}
+          path: chart-package/
 
-      - name: Push release images
-        run: make image-push
+      - name: Download Changelog Artifact
+        uses: actions/download-artifact@v4.2.1
+        with:
+          name: changelog_artifact_${{ needs.get-tag.outputs.tag }}
+          path: changelog-result/
+
+      - name: Get Downloaded Files
+        id: download_file
+        run: |
+          # ========= chart
+          if ! ls chart-package/*.tgz &>/dev/null ; then
+              echo "error, failed to find any chart "
+              exit 1
+          fi
+          chart_path=$( ls chart-package/*.tgz )
+          echo "chart_path=${chart_path}" >> $GITHUB_ENV
+          # ========== changelog
+          if ! ls changelog-result/*.md &>/dev/null ; then
+              echo "error, failed to find changelog "
+              exit 2
+          fi
+          ls changelog-result/
+          cat changelog-result/*.md
+          changelog_file=$( ls changelog-result/ )
+          changelog_path=./changelog-result/${changelog_file}
+          echo "changelog_path=${changelog_path}" >> $GITHUB_ENV
+          cp ./changelog-result/${changelog_file} ./changelog-result/changelog.md
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1.15.0
+        with:
+          artifacts: "chart-package/*"
+          draft: true
+          allowUpdates: true
+          artifactErrorsFailBuild: true
+          bodyFile: "./changelog-result/changelog.md"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.get-tag.outputs.tag }}
+          name: "Release ${{ needs.get-tag.outputs.tag }}"

--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ help: ## Display this help.
 lint-fix: ## Run golangci-lint with --fix option
 	$(GO_CMD) run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0 run --fix
 
-.PHONY: image-build-apiserver
-image-build-apiserver: ## Build the MatrixHub apiserver image
+.PHONY: image-build
+image-build: ## Build the MatrixHub image
 	$(IMAGE_BUILD_CMD) \
 		-t $(IMAGE_REPO):$(VERSION) \
 		-f deploy/docker/matrixhub/Dockerfile \
@@ -72,13 +72,9 @@ image-build-apiserver: ## Build the MatrixHub apiserver image
 		$(IMAGE_BUILD_EXTRA_OPTS) \
 		.
 
-.PHONY: image-push-apiserver
-image-push-apiserver: ## Build and push the MatrixHub apiserver image
-	$(MAKE) image-build-apiserver PUSH=--push
-
 .PHONY: image-push
-image-push: PUSH=--push
-image-push: image-build
+image-push: ## Build and push the MatrixHub image
+	$(MAKE) image-build PUSH=--push
 
 website/build: website
 	make -C website build

--- a/deploy/charts/Makefile
+++ b/deploy/charts/Makefile
@@ -1,0 +1,46 @@
+# Copyright 2026 The MatrixHub Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CHART_NAME := matrixhub
+CHART_DIR := ./$(CHART_NAME)
+VERSION_REGEX := '[vV]*[0-9]\+\.[0-9]\+\.[0-9]\+.*'
+CHART_FILE := "$(CHART_DIR)/Chart.yaml"
+VALUES_FILE := "$(CHART_DIR)/values.yaml"
+
+# VERSION can be overridden, defaults to git tag
+VERSION ?= $(shell git describe --tags --dirty --always 2>/dev/null || echo "v0.0.1")
+
+.PHONY: all update-versions lint package clean
+
+all: update-versions lint package
+
+## Update version in Chart.yaml and values.yaml
+update-versions:
+	@echo "Updating Chart version to $(VERSION)"
+	@chart_version=$$(echo $(VERSION) | tr -d 'v') ; \
+	sed -i 's/version: "*$(VERSION_REGEX)"*/version: '$$chart_version'/g' $(CHART_FILE); \
+	sed -i 's/appVersion: "*$(VERSION_REGEX)"*/appVersion: "'$$chart_version'"/g' $(CHART_FILE); \
+	sed -i 's/tag: ""/tag: $(VERSION)/g' $(VALUES_FILE)
+
+## Lint the chart
+lint:
+	@helm lint --with-subcharts --values $(CHART_DIR)/values.yaml $(CHART_DIR)
+
+## Package the chart
+package: lint
+	@helm package $(CHART_DIR) -d .
+
+## Clean generated files
+clean:
+	@rm -f *.tgz

--- a/deploy/charts/matrixhub/templates/matrixhub-configmap.yaml
+++ b/deploy/charts/matrixhub/templates/matrixhub-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "matrixhub.fullname" . }}-apiserver-config
+  name: {{ include "matrixhub.fullname" . }}-config
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "matrixhub.labels" . | nindent 4 }}

--- a/deploy/charts/matrixhub/templates/matrixhub-deployment.yaml
+++ b/deploy/charts/matrixhub/templates/matrixhub-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "matrixhub.fullname" . }}-apiserver
+  name: {{ include "matrixhub.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "matrixhub.apiserver.labels" . | nindent 4 }}
@@ -37,14 +37,14 @@ spec:
         {{- end }}
       {{- include "matrixhub.imagePullSecrets" . | nindent 6 }}
       containers:
-        - name: {{ include "matrixhub.fullname" . }}-apiserver
+        - name: {{ include "matrixhub.fullname" . }}
           image: {{ include "matrixhub.image" . }}
           imagePullPolicy: {{ .Values.apiserver.image.pullPolicy }}
           resources:
             {{- toYaml .Values.apiserver.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /etc/matrixhub/config.yaml
-              name: {{ include "matrixhub.fullname" . }}-apiserver-config
+              name: {{ include "matrixhub.fullname" . }}-config
               subPath: config.yaml
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
@@ -72,9 +72,9 @@ spec:
                   name: {{ include "matrixhub.fullname" . }}-secret
                   key: matrixhub.dsn
       volumes:
-        - name: {{ include "matrixhub.fullname" . }}-apiserver-config
+        - name: {{ include "matrixhub.fullname" . }}-config
           configMap:
-            name: {{ include "matrixhub.fullname" . }}-apiserver-config
+            name: {{ include "matrixhub.fullname" . }}-config
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/matrixhub/templates/matrixhub-service.yaml
+++ b/deploy/charts/matrixhub/templates/matrixhub-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "matrixhub.fullname" . }}-apiserver
+  name: {{ include "matrixhub.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "matrixhub.apiserver.labels" . | nindent 4 }}

--- a/deploy/charts/matrixhub/templates/matrixhub-serviceaccount.yaml
+++ b/deploy/charts/matrixhub/templates/matrixhub-serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "matrixhub.fullname" . }}-apiserver
+  name: {{ include "matrixhub.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "matrixhub.apiserver.labels" . | nindent 4 }}

--- a/deploy/charts/matrixhub/values.yaml
+++ b/deploy/charts/matrixhub/values.yaml
@@ -2,7 +2,7 @@ apiserver:
   # -- matrixhub-apiserver deployment labels
   labels:
     # -- matrixhub-apiserver deployment app name
-    app: matrixhub-apiserver
+    app: matrixhub
   # -- target replicas
   replicaCount: 1
   # -- Add matrixhub apiserver pod annotations

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+# Copyright 2022 Authors of spidernet-io
+# SPDX-License-Identifier: Apache-2.0
+
+# usage:
+#  GH_TOKEN=${{ github.token }} LABEL_FEATURE="release/feature-new" LABEL_CHANGED="release/feature-changed" LABEL_BUG="release/bug" PROJECT_REPO="xxx/xxx" changelog.sh  ./ v0.3.6
+#  GH_TOKEN=${{ github.token }} LABEL_FEATURE="release/feature-new" LABEL_CHANGED="release/feature-changed" LABEL_BUG="release/bug" PROJECT_REPO="xxx/xxx" changelog.sh  ./ v0.3.6 v0.3.5
+
+
+CURRENT_DIR_PATH=$(cd `dirname $0`; pwd)
+PROJECT_ROOT_PATH="${CURRENT_DIR_PATH}/.."
+
+set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# optional
+OUTPUT_DIR=${1}
+# required
+DEST_TAG=${2}
+# optional
+START_TAG=${3:-""}
+
+
+LABEL_FEATURE=${LABEL_FEATURE:-"release/feature-new"}
+LABEL_CHANGED=${LABEL_CHANGED:-"release/feature-changed"}
+LABEL_BUG=${LABEL_BUG:-"release/bug"}
+PROJECT_REPO=${PROJECT_REPO:-""}
+[ -n "$PROJECT_REPO" ] || { echo "miss PROJECT_REPO"; exit 1 ; }
+[ -n "${GH_TOKEN}" ] || { echo "error, miss GH_TOKEN"; exit 1 ; }
+
+( cd ${OUTPUT_DIR} ) || { echo "error, OUTPUT_DIR '${OUTPUT_DIR}' is not a valid directory" ; exit 1 ; }
+OUTPUT_DIR=$(cd ${OUTPUT_DIR}; pwd)
+echo "generate changelog to directory ${OUTPUT_DIR}"
+
+# change to root for git cli
+cd ${PROJECT_ROOT_PATH}
+
+#============================
+# Find the previous tag for changelog range
+# If START_TAG is not provided, find the previous official version tag from git
+if [ -z "${START_TAG}" ] ; then
+    echo "-------------- find previous tag"
+    # List all official version tags sorted by version, find the one just before DEST_TAG
+    PREV_TAG=$(git tag --sort=version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -B1 "^${DEST_TAG}$" | head -1)
+    if [ "$PREV_TAG" = "$DEST_TAG" ] || [ -z "$PREV_TAG" ]; then
+        # No previous tag, this is the first release
+        START_TAG=""
+        echo "No previous tag found, this is the first release"
+    else
+        START_TAG="$PREV_TAG"
+        echo "Previous tag: ${START_TAG}"
+    fi
+fi
+
+# Use v0.0.0 as display name for first release (for filename and content)
+DISPLAY_START_TAG="${START_TAG:-v0.0.0}"
+
+echo "-------------- check tags "
+echo "DEST_TAG=${DEST_TAG}"
+echo "START_TAG=${DISPLAY_START_TAG}"
+
+# Get commits in range
+ALL_COMMIT=""
+if [ -z "${START_TAG}" ]; then
+    # First release: all commits up to DEST_TAG
+    ALL_COMMIT=$(git log ${DEST_TAG} --reverse --oneline | awk '{print $1}' | tr '\n' ' ') \
+        || { echo "error, failed to get commits for tag ${DEST_TAG}" ; exit 1 ; }
+else
+    ALL_COMMIT=$(git log ${START_TAG}..${DEST_TAG} --reverse --oneline | awk '{print $1}' | tr '\n' ' ') \
+        || { echo "error, failed to get commits for range ${START_TAG}..${DEST_TAG}" ; exit 1 ; }
+fi
+echo "ALL_COMMIT: ${ALL_COMMIT}"
+
+TOTAL_COUNT="0"
+PR_LIST=""
+#
+FEATURE_PR=""
+CHANGED_PR=""
+FIX_PR=""
+for COMMIT in ${ALL_COMMIT} ; do
+  COMMIT_INFO=` curl --retry 10 -s -H "Accept: application/vnd.github.groot-preview+json" -H "Authorization: Bearer ${GH_TOKEN}" "https://api.github.com/repos/${PROJECT_REPO}/commits/${COMMIT}/pulls" `
+  PR=` jq -r '.[].number' <<< "${COMMIT_INFO}" `
+  [ -n "${PR}" ] || { echo "warning, failed to find PR number for commit ${COMMIT} " ; echo "${COMMIT_INFO}" ; echo "" ; continue ; }
+  if grep " ${PR} " <<< " ${PR_LIST} " &>/dev/null ; then
+    continue
+  else
+    PR_LIST+=" ${PR} "
+  fi
+  (( TOTAL_COUNT+=1 ))
+	INFO=` gh pr view ${PR}  `
+	TITLE=` grep -E "^title:[[:space:]]+" <<< "$INFO" | sed -E 's/title:[[:space:]]+//' `
+	LABELS=` grep -E "^labels:[[:space:]][^\[]" <<< "$INFO" | sed -E 's/labels://' | tr ',' ' ' ` || true
+	#
+	PR_URL="https://github.com/${PROJECT_REPO}/pull/${PR}"
+	#
+	if grep -E "[[:space:]]${LABEL_FEATURE}[[:space:]]" <<< " ${LABELS} " &>/dev/null ; then
+	  echo "get new feature PR ${PR}"
+		FEATURE_PR+="* ${TITLE} : [PR ${PR}](${PR_URL})
+"
+	elif grep -E "[[:space:]]${LABEL_CHANGED}[[:space:]]" <<< " ${LABELS} " &>/dev/null ; then
+	  echo "get changed feature PR ${PR}"
+		CHANGED_PR+="* ${TITLE} : [PR ${PR}](${PR_URL})
+"
+	elif grep -E "[[:space:]]${LABEL_BUG}[[:space:]]" <<< " ${LABELS} " &>/dev/null ; then
+	  echo "get bug fix PR ${PR}"
+		FIX_PR+="* ${TITLE} : [PR ${PR}](${PR_URL})
+"
+	fi
+done
+#---------------------
+echo "generate changelog md"
+FILE_CHANGELOG="${OUTPUT_DIR}/changelog_from_${DISPLAY_START_TAG}_to_${DEST_TAG}.md"
+echo > ${FILE_CHANGELOG}
+echo "# ${DEST_TAG}" >> ${FILE_CHANGELOG}
+echo "Welcome to the ${DEST_TAG} release of MatrixHub!" >> ${FILE_CHANGELOG}
+echo "Compared with version:${DISPLAY_START_TAG}, version:${DEST_TAG} has the following updates." >> ${FILE_CHANGELOG}
+echo "" >> ${FILE_CHANGELOG}
+echo "***" >> ${FILE_CHANGELOG}
+echo "" >> ${FILE_CHANGELOG}
+#
+if [ -n "${FEATURE_PR}" ]; then
+    echo "## New Feature" >> ${FILE_CHANGELOG}
+    echo "" >> ${FILE_CHANGELOG}
+    while read LINE ; do
+      echo "${LINE}" >> ${FILE_CHANGELOG}
+      echo "" >> ${FILE_CHANGELOG}
+    done <<< "${FEATURE_PR}"
+    echo "***" >> ${FILE_CHANGELOG}
+    echo "" >> ${FILE_CHANGELOG}
+fi
+#
+if [ -n "${CHANGED_PR}" ]; then
+    echo "## Changed Feature" >> ${FILE_CHANGELOG}
+    echo "" >> ${FILE_CHANGELOG}
+    while read LINE ; do
+      echo "${LINE}" >> ${FILE_CHANGELOG}
+      echo "" >> ${FILE_CHANGELOG}
+    done <<< "${CHANGED_PR}"
+    echo "***" >> ${FILE_CHANGELOG}
+    echo "" >> ${FILE_CHANGELOG}
+fi
+#
+if [ -n "${FIX_PR}" ]; then
+    echo "## Fix" >> ${FILE_CHANGELOG}
+    echo "" >> ${FILE_CHANGELOG}
+    while read LINE ; do
+      echo "${LINE}" >> ${FILE_CHANGELOG}
+      echo "" >> ${FILE_CHANGELOG}
+    done <<< "${FIX_PR}"
+    echo "***" >> ${FILE_CHANGELOG}
+    echo "" >> ${FILE_CHANGELOG}
+fi
+#
+echo "## Total " >> ${FILE_CHANGELOG}
+echo "" >> ${FILE_CHANGELOG}
+echo "Pull request number: ${TOTAL_COUNT}" >> ${FILE_CHANGELOG}
+echo "" >> ${FILE_CHANGELOG}
+if [ -n "${START_TAG}" ]; then
+    echo "[ Commits ](https://github.com/${PROJECT_REPO}/compare/${START_TAG}...${DEST_TAG})" >> ${FILE_CHANGELOG}
+else
+    echo "[ Commits ](https://github.com/${PROJECT_REPO}/commits/${DEST_TAG})" >> ${FILE_CHANGELOG}
+fi
+echo "--------------------"
+echo "generate changelog to ${FILE_CHANGELOG}"

--- a/scripts/deploy-matrixhub.sh
+++ b/scripts/deploy-matrixhub.sh
@@ -158,7 +158,7 @@ while [ $ELAPSED -lt $TIMEOUT ]; do
     MYSQL_READY=$(kubectl get pods -n matrixhub -l app=matrixhub-mysql -o jsonpath='{.items[0].status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "false")
 
     # Check MatrixHub
-    MATRIXHUB_READY=$(kubectl get pods -n matrixhub -l app=matrixhub-apiserver -o jsonpath='{.items[0].status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "false")
+    MATRIXHUB_READY=$(kubectl get pods -n matrixhub -l app=matrixhub -o jsonpath='{.items[0].status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "false")
 
     if [ "$MYSQL_READY" = "True" ] && [ "$MATRIXHUB_READY" = "True" ]; then
         echo ""
@@ -186,10 +186,10 @@ if [ $ELAPSED -ge $TIMEOUT ]; then
     kubectl get pods -n matrixhub -o wide
     echo ""
     echo "MatrixHub pod logs (init containers):"
-    kubectl logs -n matrixhub -l app=matrixhub-apiserver -c check-db-ready --tail=30 || true
+    kubectl logs -n matrixhub -l app=matrixhub -c check-db-ready --tail=30 || true
     echo ""
     echo "MatrixHub pod logs (main container):"
-    kubectl logs -n matrixhub -l app=matrixhub-apiserver -c matrixhub-apiserver --tail=50 || true
+    kubectl logs -n matrixhub -l app=matrixhub -c matrixhub --tail=50 || true
     echo ""
     echo "MySQL pod logs:"
     kubectl logs -n matrixhub -l app=matrixhub-mysql --tail=50 || true


### PR DESCRIPTION
#### What type of PR is this?
#85 
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

  ## Summary
  - Refactor monolithic release workflow into modular reusable multi-stage pipeline
  - Add Helm chart packaging and publishing via GHCR (OCI) and GitHub Pages
  - Auto-generate changelog from PR labels
  - Auto-create draft GitHub Release for official versions (vX.Y.Z)

  ## Changes
  - `release.yml`: orchestrate tag resolution → build image → release chart → changelog → create release
  - `call-release-chart.yaml`: chart package + push to GHCR and GitHub Pages
  - `call-release-changelog.yaml`: generate changelog based on PR labels (feature-new / feature-changed / bug)
  - `scripts/changelog.sh`: changelog generation script
  - `deploy/charts/Makefile`: chart version update, lint, and package targets
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
# 
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```