### PR TITLE
feat(ui): add replication executions page with column filter support

### DIFF
--- a/ui/agents/rules/implementation.md
+++ b/ui/agents/rules/implementation.md
@@ -102,7 +102,8 @@ See `tanstack-integration.md` for the complete error handling strategy.
 - If the required wrapper does not exist yet, create or extend the project table wrapper first, then use that wrapper in the page
 - Put stable shared table wrappers under `src/shared/components/data-table/` unless the project later adopts a different shared location
 - Centralize shared table styling and behavior in the wrapper, including pagination, loading states, empty states, row actions, selection behavior, and similar concerns
-- For route-backed list pages that use the shared table wrapper, keep query/search params, pagination navigation, refresh triggers, and row-selection state in the page layer or a shared hook such as `src/shared/hooks/useRouteListState.ts`; the shared hook expects the search object to have `page` / `query` fields and derives selected row ids and current-page selected records from `records` + `getRecordId`; feature table components should stay focused on columns, cells, and feature-specific toolbar/actions
+- The shared `DataTable` wrapper owns default MRT filter behavior and styling; feature tables should only opt specific columns in with `enableColumnFilter: true` and the needed column filter props
+- For route-backed list pages, keep search params, pagination, refresh, selection, and any route-synchronized column-filter state in the page layer or a shared hook such as `src/shared/hooks/useRouteListState.ts`
 - Do not introduce a different table abstraction or second table library for the same class of UI without agreement
 
 ## Feature Page Splitting Guidelines

--- a/ui/src/features/admin/components/admin-page-header.tsx
+++ b/ui/src/features/admin/components/admin-page-header.tsx
@@ -1,4 +1,5 @@
 import {
+  Breadcrumbs,
   Group,
   Text,
   Title,
@@ -22,21 +23,41 @@ interface AdminPageHeaderProps {
   items: [AdminPageHeaderItem, ...AdminPageHeaderItem[]]
 }
 
+const headerItemStyles = [
+  {
+    fw: 600,
+    fz: rem(18),
+    c: 'inherit',
+  },
+  {
+    fw: 600,
+    fz: rem(14),
+    c: 'inherit',
+  },
+  {
+    fw: 400,
+    fz: rem(14),
+    c: 'inherit',
+  },
+] as const
+
 function HeaderItem({
   item,
-  primary = false,
+  index,
 }: {
   item: AdminPageHeaderItem
-  primary?: boolean
+  index: number
 }) {
+  const style = headerItemStyles[index] ?? headerItemStyles[headerItemStyles.length - 1]
+  const isPrimary = index === 0
+
   if (item.linkProps) {
     return (
       <AnchorLink
-        c="inherit"
+        c={style.c}
         underline="hover"
-        fw={600}
-        lh={primary ? rem(28) : rem(24)}
-        fz={primary ? rem(18) : rem(18)}
+        fw={style.fw}
+        fz={style.fz}
         {...item.linkProps}
       >
         {item.label}
@@ -44,12 +65,13 @@ function HeaderItem({
     )
   }
 
-  if (primary) {
+  if (isPrimary) {
     return (
       <Title
-        size={rem(18)}
-        fw={600}
+        size={style.fz}
+        fw={style.fw}
         lh={rem(28)}
+        c={style.c}
       >
         {item.label}
       </Title>
@@ -58,9 +80,9 @@ function HeaderItem({
 
   return (
     <Text
-      fw={600}
-      lh={rem(24)}
-      fz={rem(18)}
+      c={style.c}
+      fw={style.fw}
+      fz={style.fz}
     >
       {item.label}
     </Text>
@@ -72,8 +94,6 @@ export function AdminPageHeader({
   icon: Icon,
   items,
 }: AdminPageHeaderProps) {
-  const [primaryItem, ...secondaryItems] = items
-
   return (
     <Group
       px={28}
@@ -92,13 +112,18 @@ export function AdminPageHeader({
           size={rem(28)}
           style={{ flexShrink: 0 }}
         />
-        <HeaderItem item={primaryItem} primary />
-        {secondaryItems.map(item => (
-          <Group key={item.label?.toString()} gap={10} wrap="nowrap" align="center">
-            <Text c="gray.6" fw={500}>/</Text>
-            <HeaderItem item={item} />
-          </Group>
-        ))}
+        <Breadcrumbs
+          separator="/"
+          separatorMargin="xs"
+        >
+          {items.map((item, index) => (
+            <HeaderItem
+              key={item.label?.toString() ?? index}
+              item={item}
+              index={index}
+            />
+          ))}
+        </Breadcrumbs>
       </Group>
 
       {actions && (

--- a/ui/src/features/admin/components/admin-page-header.tsx
+++ b/ui/src/features/admin/components/admin-page-header.tsx
@@ -1,0 +1,115 @@
+import {
+  Group,
+  Text,
+  Title,
+  rem,
+} from '@mantine/core'
+
+import AnchorLink from '@/shared/components/AnchorLink'
+
+import type { TablerIcon } from '@tabler/icons-react'
+import type { LinkComponentProps } from '@tanstack/react-router'
+import type { ReactNode } from 'react'
+
+export interface AdminPageHeaderItem {
+  label: ReactNode
+  linkProps?: LinkComponentProps
+}
+
+interface AdminPageHeaderProps {
+  actions?: ReactNode
+  icon: TablerIcon
+  items: [AdminPageHeaderItem, ...AdminPageHeaderItem[]]
+}
+
+function HeaderItem({
+  item,
+  primary = false,
+}: {
+  item: AdminPageHeaderItem
+  primary?: boolean
+}) {
+  if (item.linkProps) {
+    return (
+      <AnchorLink
+        c="inherit"
+        underline="hover"
+        fw={600}
+        lh={primary ? rem(28) : rem(24)}
+        fz={primary ? rem(18) : rem(18)}
+        {...item.linkProps}
+      >
+        {item.label}
+      </AnchorLink>
+    )
+  }
+
+  if (primary) {
+    return (
+      <Title
+        size={rem(18)}
+        fw={600}
+        lh={rem(28)}
+      >
+        {item.label}
+      </Title>
+    )
+  }
+
+  return (
+    <Text
+      fw={600}
+      lh={rem(24)}
+      fz={rem(18)}
+    >
+      {item.label}
+    </Text>
+  )
+}
+
+export function AdminPageHeader({
+  actions,
+  icon: Icon,
+  items,
+}: AdminPageHeaderProps) {
+  const [primaryItem, ...secondaryItems] = items
+
+  return (
+    <Group
+      px={28}
+      py="lg"
+      justify="space-between"
+      wrap="nowrap"
+      mih={72}
+      align="center"
+    >
+      <Group
+        gap={10}
+        wrap="nowrap"
+        align="center"
+      >
+        <Icon
+          size={rem(28)}
+          style={{ flexShrink: 0 }}
+        />
+        <HeaderItem item={primaryItem} primary />
+        {secondaryItems.map(item => (
+          <Group key={item.label?.toString()} gap={10} wrap="nowrap" align="center">
+            <Text c="gray.6" fw={500}>/</Text>
+            <HeaderItem item={item} />
+          </Group>
+        ))}
+      </Group>
+
+      {actions && (
+        <Group
+          gap="sm"
+          wrap="nowrap"
+          align="center"
+        >
+          {actions}
+        </Group>
+      )}
+    </Group>
+  )
+}

--- a/ui/src/features/admin/components/admin-page-layout.tsx
+++ b/ui/src/features/admin/components/admin-page-layout.tsx
@@ -1,47 +1,16 @@
-import {
-  Box,
-  Group,
-  Title,
-  rem,
-} from '@mantine/core'
+import { Box } from '@mantine/core'
 
-import type { TablerIcon } from '@tabler/icons-react'
 import type { ReactNode } from 'react'
 
 interface AdminPageLayoutProps {
   children?: ReactNode
-  icon: TablerIcon
-  title: string
 }
 
 export function AdminPageLayout({
   children,
-  icon: Icon,
-  title,
 }: AdminPageLayoutProps) {
   return (
     <Box component="section">
-      {/* FIXME:Text/title (Gray/90) */}
-      <Group
-        px={28}
-        py="lg"
-        gap={10}
-        wrap="nowrap"
-        mih={72}
-        align="center"
-      >
-        <Icon
-          size={rem(28)}
-          style={{ flexShrink: 0 }}
-        />
-        <Title
-          size={rem(18)}
-          fw={600}
-          lh={rem(28)}
-        >
-          {title}
-        </Title>
-      </Group>
       <Box px="xl">
         {children}
       </Box>

--- a/ui/src/features/admin/components/admin-page-layout.tsx
+++ b/ui/src/features/admin/components/admin-page-layout.tsx
@@ -10,10 +10,8 @@ export function AdminPageLayout({
   children,
 }: AdminPageLayoutProps) {
   return (
-    <Box component="section">
-      <Box px="xl">
-        {children}
-      </Box>
+    <Box component="section" px="xl">
+      {children}
     </Box>
   )
 }

--- a/ui/src/features/admin/replications/components/ReplicationsTable.tsx
+++ b/ui/src/features/admin/replications/components/ReplicationsTable.tsx
@@ -1,9 +1,11 @@
 import {
+  Anchor,
   Badge,
   Group,
   Text,
 } from '@mantine/core'
 import { SyncPolicyType } from '@matrixhub/api-ts/v1alpha1/sync_policy.pb'
+import { Link } from '@tanstack/react-router'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -31,10 +33,31 @@ type ReplicationsTableProps = Omit<DataTableProps<SyncPolicyItem>, 'columns'>
 const EMPTY_VALUE = '-'
 
 function ReplicationNameCell({ row }: ReplicationCellProps) {
+  const name = row.original.name
+  const replicationId = row.original.id
+
+  if (replicationId == null) {
+    return (
+      <Text fw={500}>
+        {name ?? EMPTY_VALUE}
+      </Text>
+    )
+  }
+
   return (
-    <Text fw={500}>
-      {row.original.name ?? EMPTY_VALUE}
-    </Text>
+    <Anchor
+      fw={500}
+      underline="never"
+      renderRoot={props => (
+        <Link
+          {...props}
+          to="/admin/replications/$replicationId/executions"
+          params={{ replicationId: String(replicationId) }}
+        />
+      )}
+    >
+      {name ?? EMPTY_VALUE}
+    </Anchor>
   )
 }
 

--- a/ui/src/features/admin/replications/executions/components/ReplicationExecutionsTable.tsx
+++ b/ui/src/features/admin/replications/executions/components/ReplicationExecutionsTable.tsx
@@ -1,0 +1,221 @@
+import { Text } from '@mantine/core'
+import {
+  SyncTaskStatus,
+  TriggerType,
+  type SyncTask,
+} from '@matrixhub/api-ts/v1alpha1/sync_policy.pb'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { DataTable, type DataTableProps } from '@/shared/components/DataTable'
+import { StatusIndicator } from '@/shared/components/StatusIndicator'
+import { formatDateTime } from '@/shared/utils/date'
+
+import { StopReplicationExecutionAction } from './StopReplicationExecutionAction'
+import { replicationExecutionStatusFilterValues } from '../executions.schema'
+import {
+  formatReplicationExecutionDuration,
+  getReplicationExecutionRowId,
+} from '../executions.utils'
+
+import type { MRT_ColumnDef } from 'mantine-react-table'
+
+type ExecutionCellProps = Parameters<NonNullable<MRT_ColumnDef<SyncTask>['Cell']>>[0]
+
+function formatReplicationExecutionSuccessRate(task: SyncTask) {
+  const totalItems = task.totalItems == null ? 0 : Number(task.totalItems)
+  const successfulItems = task.successfulItems == null ? 0 : Number(task.successfulItems)
+
+  if (!Number.isFinite(totalItems) || totalItems <= 0) {
+    return '-'
+  }
+
+  const successRate = ((Number.isFinite(successfulItems) ? successfulItems : 0) / totalItems) * 100
+
+  return `${Number(successRate.toFixed(2))}%`
+}
+
+function formatReplicationExecutionTotalItems(task: SyncTask) {
+  const totalItems = task.totalItems == null ? 0 : Number(task.totalItems)
+
+  if (!Number.isFinite(totalItems)) {
+    return '-'
+  }
+
+  return new Intl.NumberFormat().format(totalItems)
+}
+
+type ReplicationExecutionsTableProps = Omit<
+  DataTableProps<SyncTask>,
+  'columns' | 'renderToolbar'
+> & {
+  syncPolicyId: number
+}
+
+function ExecutionTaskCell({ row }: ExecutionCellProps) {
+  if (row.original.id == null) {
+    return <Text fw={600}>-</Text>
+  }
+
+  return <Text fw={600}>{row.original.id}</Text>
+}
+
+function ExecutionStatusCell({ row }: ExecutionCellProps) {
+  const { t } = useTranslation()
+  const status = row.original.status
+
+  if (status === SyncTaskStatus.SYNC_TASK_STATUS_RUNNING) {
+    return (
+      <StatusIndicator
+        type="info"
+        label={t('routes.admin.replications.executions.status.running')}
+      />
+    )
+  }
+
+  if (status === SyncTaskStatus.SYNC_TASK_STATUS_STOPPED) {
+    return (
+      <StatusIndicator
+        type="warning"
+        label={t('routes.admin.replications.executions.status.stopped')}
+      />
+    )
+  }
+
+  if (status === SyncTaskStatus.SYNC_TASK_STATUS_SUCCEEDED) {
+    return (
+      <StatusIndicator
+        type="success"
+        label={t('routes.admin.replications.executions.status.succeeded')}
+      />
+    )
+  }
+
+  if (status === SyncTaskStatus.SYNC_TASK_STATUS_FAILED) {
+    return (
+      <StatusIndicator
+        type="danger"
+        label={t('routes.admin.replications.executions.status.failed')}
+      />
+    )
+  }
+
+  return (
+    <StatusIndicator
+      label={t('routes.admin.replications.executions.status.unknown')}
+    />
+  )
+}
+
+function ExecutionActionsCell({
+  row,
+  table,
+}: ExecutionCellProps) {
+  const syncPolicyId = (
+    table.options.meta as { syncPolicyId?: number } | undefined
+  )?.syncPolicyId
+
+  if (syncPolicyId == null) {
+    return <Text size="sm">-</Text>
+  }
+
+  return (
+    <StopReplicationExecutionAction
+      syncPolicyId={syncPolicyId}
+      task={row.original}
+      disabled={row.original.id == null}
+    />
+  )
+}
+
+export function ReplicationExecutionsTable({
+  syncPolicyId,
+  onRefresh,
+  fetching = false,
+  tableOptions,
+  ...props
+}: ReplicationExecutionsTableProps) {
+  const { t } = useTranslation()
+  const columns = useMemo<MRT_ColumnDef<SyncTask>[]>(() => [
+    {
+      id: 'taskId',
+      header: t('routes.admin.replications.executions.table.taskId'),
+      Cell: ExecutionTaskCell,
+      size: 130,
+    },
+    {
+      accessorKey: 'status',
+      header: t('routes.admin.replications.executions.table.status'),
+      Cell: ExecutionStatusCell,
+      enableColumnFilter: true,
+      filterFn: 'equals',
+      filterVariant: 'select',
+      mantineFilterSelectProps: {
+        data: replicationExecutionStatusFilterValues.map(value => ({
+          value,
+          label: t(`routes.admin.replications.executions.status.${value.replace('SYNC_TASK_STATUS_', '').toLowerCase()}`),
+        })),
+        placeholder: t('routes.admin.replications.executions.filters.status'),
+      },
+      size: 110,
+    },
+    {
+      id: 'triggerType',
+      header: t('routes.admin.replications.executions.table.triggerType'),
+      accessorFn: row => (
+        row.triggerType === TriggerType.TRIGGER_TYPE_SCHEDULED
+          ? t('routes.admin.replications.trigger.scheduled')
+          : t('routes.admin.replications.trigger.manual')
+      ),
+      size: 110,
+    },
+    {
+      id: 'startedTimestamp',
+      header: t('routes.admin.replications.executions.table.startedAt'),
+      accessorFn: row => formatDateTime(row.startedTimestamp, 'YYYY/M/D HH:mm'),
+      size: 150,
+    },
+    {
+      id: 'duration',
+      header: t('routes.admin.replications.executions.table.duration'),
+      accessorFn: row => formatReplicationExecutionDuration(row),
+      size: 150,
+    },
+    {
+      id: 'successRate',
+      header: t('routes.admin.replications.executions.table.successRate'),
+      accessorFn: row => formatReplicationExecutionSuccessRate(row),
+      size: 120,
+    },
+    {
+      id: 'totalItems',
+      header: t('routes.admin.replications.executions.table.totalItems'),
+      accessorFn: row => formatReplicationExecutionTotalItems(row),
+      size: 100,
+    },
+    {
+      id: 'actions',
+      header: t('routes.admin.replications.executions.table.actions'),
+      Cell: ExecutionActionsCell,
+      size: 126,
+    },
+  ], [t])
+
+  return (
+    <DataTable
+      {...props}
+      columns={columns}
+      emptyTitle={t('routes.admin.replications.executions.table.empty')}
+      fetching={fetching}
+      getRowId={getReplicationExecutionRowId}
+      onRefresh={onRefresh}
+      tableOptions={{
+        ...tableOptions,
+        meta: {
+          ...(tableOptions?.meta as object | undefined),
+          syncPolicyId,
+        },
+      }}
+    />
+  )
+}

--- a/ui/src/features/admin/replications/executions/components/ReplicationExecutionsTable.tsx
+++ b/ui/src/features/admin/replications/executions/components/ReplicationExecutionsTable.tsx
@@ -53,11 +53,7 @@ type ReplicationExecutionsTableProps = Omit<
 }
 
 function ExecutionTaskCell({ row }: ExecutionCellProps) {
-  if (row.original.id == null) {
-    return <Text fw={600}>-</Text>
-  }
-
-  return <Text fw={600}>{row.original.id}</Text>
+  return <Text fw={600}>{row.original.id ?? '-'}</Text>
 }
 
 function ExecutionStatusCell({ row }: ExecutionCellProps) {

--- a/ui/src/features/admin/replications/executions/components/StopReplicationExecutionAction.tsx
+++ b/ui/src/features/admin/replications/executions/components/StopReplicationExecutionAction.tsx
@@ -1,0 +1,48 @@
+import { Button } from '@mantine/core'
+import {
+  SyncTaskStatus,
+  type SyncTask,
+} from '@matrixhub/api-ts/v1alpha1/sync_policy.pb'
+import { useMutation } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+
+import { stopReplicationExecutionMutationOptions } from '../executions.mutation'
+
+interface StopReplicationExecutionActionProps {
+  syncPolicyId: number
+  task: SyncTask
+  disabled?: boolean
+}
+
+export function StopReplicationExecutionAction({
+  syncPolicyId,
+  task,
+  disabled,
+}: StopReplicationExecutionActionProps) {
+  const { t } = useTranslation()
+  const mutation = useMutation(stopReplicationExecutionMutationOptions(syncPolicyId))
+  const canStop = task.status === SyncTaskStatus.SYNC_TASK_STATUS_RUNNING
+
+  const handleStop = async () => {
+    if (task.id == null) {
+      return
+    }
+
+    await mutation.mutateAsync({ syncTaskId: task.id })
+  }
+
+  return (
+    <Button
+      variant="transparent"
+      size="compact-sm"
+      color="blue"
+      disabled={disabled || !canStop || mutation.isPending}
+      loading={mutation.isPending}
+      onClick={() => {
+        void handleStop()
+      }}
+    >
+      {t('routes.admin.replications.executions.actions.stop')}
+    </Button>
+  )
+}

--- a/ui/src/features/admin/replications/executions/executions.mutation.ts
+++ b/ui/src/features/admin/replications/executions/executions.mutation.ts
@@ -1,0 +1,33 @@
+import {
+  type StopSyncTaskRequest,
+  SyncPolicy,
+} from '@matrixhub/api-ts/v1alpha1/sync_policy.pb'
+import { mutationOptions } from '@tanstack/react-query'
+
+import i18n from '@/i18n'
+
+import { adminReplicationExecutionKeys } from './executions.query'
+
+import type { NotificationMeta } from '@/types/tanstack-query'
+
+function requireSyncTaskId(id?: number) {
+  if (id == null) {
+    throw new Error(i18n.t('routes.admin.replications.executions.errors.missingSyncTaskId'))
+  }
+
+  return id
+}
+
+export function stopReplicationExecutionMutationOptions(syncPolicyId: number) {
+  return mutationOptions({
+    mutationFn: ({ syncTaskId }: StopSyncTaskRequest) => SyncPolicy.StopSyncTask({
+      syncPolicyId,
+      syncTaskId: requireSyncTaskId(syncTaskId),
+    }),
+    meta: {
+      successMessage: i18n.t('routes.admin.replications.executions.notifications.stopSuccess'),
+      errorMessage: i18n.t('routes.admin.replications.executions.notifications.stopError'),
+      invalidates: [adminReplicationExecutionKeys.lists(syncPolicyId)],
+    } satisfies NotificationMeta,
+  })
+}

--- a/ui/src/features/admin/replications/executions/executions.query.ts
+++ b/ui/src/features/admin/replications/executions/executions.query.ts
@@ -1,4 +1,7 @@
-import { SyncPolicy } from '@matrixhub/api-ts/v1alpha1/sync_policy.pb'
+import {
+  type ListSyncTasksRequest,
+  SyncPolicy,
+} from '@matrixhub/api-ts/v1alpha1/sync_policy.pb'
 import {
   keepPreviousData,
   queryOptions,
@@ -7,29 +10,29 @@ import {
 
 import { DEFAULT_PAGE_SIZE } from '@/utils/constants'
 
-import { type ReplicationExecutionsSearch } from './executions.schema'
+type ReplicationExecutionsListParams = Pick<ListSyncTasksRequest, 'page' | 'status'>
 
 export const adminReplicationExecutionKeys = {
   all: ['admin', 'replications', 'executions'] as const,
   lists: (syncPolicyId: number) => [...adminReplicationExecutionKeys.all, syncPolicyId, 'list'] as const,
-  list: (syncPolicyId: number, search: ReplicationExecutionsSearch) => [
+  list: (syncPolicyId: number, params: ReplicationExecutionsListParams) => [
     ...adminReplicationExecutionKeys.lists(syncPolicyId),
-    search,
+    params,
   ] as const,
 }
 
 export function replicationExecutionsQueryOptions(
   syncPolicyId: number,
-  search: ReplicationExecutionsSearch,
+  params: ReplicationExecutionsListParams,
 ) {
   return queryOptions({
-    queryKey: adminReplicationExecutionKeys.list(syncPolicyId, search),
+    queryKey: adminReplicationExecutionKeys.list(syncPolicyId, params),
     queryFn: async () => {
       const response = await SyncPolicy.ListSyncTasks({
         syncPolicyId,
-        page: search.page,
+        page: params.page,
         pageSize: DEFAULT_PAGE_SIZE,
-        status: search.status,
+        status: params.status,
       })
 
       return {
@@ -42,10 +45,10 @@ export function replicationExecutionsQueryOptions(
 
 export function useReplicationExecutions(
   syncPolicyId: number,
-  search: ReplicationExecutionsSearch,
+  params: ReplicationExecutionsListParams,
 ) {
   return useQuery({
-    ...replicationExecutionsQueryOptions(syncPolicyId, search),
+    ...replicationExecutionsQueryOptions(syncPolicyId, params),
     placeholderData: keepPreviousData,
   })
 }

--- a/ui/src/features/admin/replications/executions/executions.query.ts
+++ b/ui/src/features/admin/replications/executions/executions.query.ts
@@ -1,0 +1,51 @@
+import { SyncPolicy } from '@matrixhub/api-ts/v1alpha1/sync_policy.pb'
+import {
+  keepPreviousData,
+  queryOptions,
+  useQuery,
+} from '@tanstack/react-query'
+
+import { DEFAULT_PAGE_SIZE } from '@/utils/constants'
+
+import { type ReplicationExecutionsSearch } from './executions.schema'
+
+export const adminReplicationExecutionKeys = {
+  all: ['admin', 'replications', 'executions'] as const,
+  lists: (syncPolicyId: number) => [...adminReplicationExecutionKeys.all, syncPolicyId, 'list'] as const,
+  list: (syncPolicyId: number, search: ReplicationExecutionsSearch) => [
+    ...adminReplicationExecutionKeys.lists(syncPolicyId),
+    search,
+  ] as const,
+}
+
+export function replicationExecutionsQueryOptions(
+  syncPolicyId: number,
+  search: ReplicationExecutionsSearch,
+) {
+  return queryOptions({
+    queryKey: adminReplicationExecutionKeys.list(syncPolicyId, search),
+    queryFn: async () => {
+      const response = await SyncPolicy.ListSyncTasks({
+        syncPolicyId,
+        page: search.page,
+        pageSize: DEFAULT_PAGE_SIZE,
+        status: search.status,
+      })
+
+      return {
+        executions: response.syncTasks ?? [],
+        pagination: response.pagination,
+      }
+    },
+  })
+}
+
+export function useReplicationExecutions(
+  syncPolicyId: number,
+  search: ReplicationExecutionsSearch,
+) {
+  return useQuery({
+    ...replicationExecutionsQueryOptions(syncPolicyId, search),
+    placeholderData: keepPreviousData,
+  })
+}

--- a/ui/src/features/admin/replications/executions/executions.schema.ts
+++ b/ui/src/features/admin/replications/executions/executions.schema.ts
@@ -1,0 +1,33 @@
+import { SyncTaskStatus } from '@matrixhub/api-ts/v1alpha1/sync_policy.pb'
+import { z } from 'zod'
+
+import { DEFAULT_PAGE } from '@/utils/constants'
+
+export const replicationExecutionStatusFilterValues = [
+  SyncTaskStatus.SYNC_TASK_STATUS_RUNNING,
+  SyncTaskStatus.SYNC_TASK_STATUS_STOPPED,
+  SyncTaskStatus.SYNC_TASK_STATUS_SUCCEEDED,
+  SyncTaskStatus.SYNC_TASK_STATUS_FAILED,
+] as const
+
+export type ReplicationExecutionStatusFilterValue
+  = typeof replicationExecutionStatusFilterValues[number]
+
+export const replicationExecutionsSearchDefaults = {
+  page: DEFAULT_PAGE,
+  status: undefined as ReplicationExecutionStatusFilterValue | undefined,
+}
+
+export const replicationExecutionsSearchSchema = z.object({
+  page: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(replicationExecutionsSearchDefaults.page)
+    .catch(replicationExecutionsSearchDefaults.page),
+  status: z.enum(replicationExecutionStatusFilterValues)
+    .optional()
+    .catch(replicationExecutionsSearchDefaults.status),
+})
+
+export type ReplicationExecutionsSearch = z.infer<typeof replicationExecutionsSearchSchema>

--- a/ui/src/features/admin/replications/executions/executions.schema.ts
+++ b/ui/src/features/admin/replications/executions/executions.schema.ts
@@ -29,5 +29,3 @@ export const replicationExecutionsSearchSchema = z.object({
     .optional()
     .catch(replicationExecutionsSearchDefaults.status),
 })
-
-export type ReplicationExecutionsSearch = z.infer<typeof replicationExecutionsSearchSchema>

--- a/ui/src/features/admin/replications/executions/executions.utils.ts
+++ b/ui/src/features/admin/replications/executions/executions.utils.ts
@@ -1,0 +1,67 @@
+import {
+  SyncTaskStatus,
+  type SyncTask,
+} from '@matrixhub/api-ts/v1alpha1/sync_policy.pb'
+
+import i18n from '@/i18n'
+import { toMilliseconds } from '@/shared/utils/date'
+
+const SECOND_IN_MS = 1000
+const MINUTE_IN_MS = 60 * SECOND_IN_MS
+const HOUR_IN_MS = 60 * MINUTE_IN_MS
+
+export function getReplicationExecutionRowId(task: SyncTask) {
+  return String(task.id ?? `${task.startedTimestamp ?? '0'}-${task.status ?? 'unknown'}`)
+}
+
+export function parseReplicationId(replicationId: string) {
+  const value = Number(replicationId)
+
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(i18n.t('routes.admin.replications.executions.errors.invalidSyncPolicyId'))
+  }
+
+  return value
+}
+
+export function formatReplicationExecutionDuration(task: SyncTask) {
+  const startedAt = task.startedTimestamp == null
+    ? undefined
+    : toMilliseconds(task.startedTimestamp)
+  const completedAt = task.completedTimestamp == null
+    ? undefined
+    : toMilliseconds(task.completedTimestamp)
+  const endedAt = completedAt ?? (
+    task.status === SyncTaskStatus.SYNC_TASK_STATUS_RUNNING
+      ? Date.now()
+      : undefined
+  )
+
+  if (startedAt == null || endedAt == null || endedAt < startedAt) {
+    return '-'
+  }
+
+  const durationMs = Math.max(0, endedAt - startedAt)
+
+  if (durationMs < SECOND_IN_MS) {
+    return `${Math.round(durationMs)} ms`
+  }
+
+  if (durationMs < MINUTE_IN_MS) {
+    const seconds = durationMs / SECOND_IN_MS
+
+    return Number.isInteger(seconds) ? `${seconds} s` : `${seconds.toFixed(1)} s`
+  }
+
+  if (durationMs < HOUR_IN_MS) {
+    const minutes = Math.floor(durationMs / MINUTE_IN_MS)
+    const seconds = Math.floor((durationMs % MINUTE_IN_MS) / SECOND_IN_MS)
+
+    return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`
+  }
+
+  const hours = Math.floor(durationMs / HOUR_IN_MS)
+  const minutes = Math.floor((durationMs % HOUR_IN_MS) / MINUTE_IN_MS)
+
+  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`
+}

--- a/ui/src/features/admin/replications/executions/executions.utils.ts
+++ b/ui/src/features/admin/replications/executions/executions.utils.ts
@@ -2,13 +2,10 @@ import {
   SyncTaskStatus,
   type SyncTask,
 } from '@matrixhub/api-ts/v1alpha1/sync_policy.pb'
+import dayjs from 'dayjs'
 
 import i18n from '@/i18n'
 import { toMilliseconds } from '@/shared/utils/date'
-
-const SECOND_IN_MS = 1000
-const MINUTE_IN_MS = 60 * SECOND_IN_MS
-const HOUR_IN_MS = 60 * MINUTE_IN_MS
 
 export function getReplicationExecutionRowId(task: SyncTask) {
   return String(task.id ?? `${task.startedTimestamp ?? '0'}-${task.status ?? 'unknown'}`)
@@ -31,37 +28,16 @@ export function formatReplicationExecutionDuration(task: SyncTask) {
   const completedAt = task.completedTimestamp == null
     ? undefined
     : toMilliseconds(task.completedTimestamp)
+
   const endedAt = completedAt ?? (
     task.status === SyncTaskStatus.SYNC_TASK_STATUS_RUNNING
       ? Date.now()
       : undefined
   )
 
-  if (startedAt == null || endedAt == null || endedAt < startedAt) {
+  if (startedAt == null || endedAt == null || endedAt <= startedAt) {
     return '-'
   }
 
-  const durationMs = Math.max(0, endedAt - startedAt)
-
-  if (durationMs < SECOND_IN_MS) {
-    return `${Math.round(durationMs)} ms`
-  }
-
-  if (durationMs < MINUTE_IN_MS) {
-    const seconds = durationMs / SECOND_IN_MS
-
-    return Number.isInteger(seconds) ? `${seconds} s` : `${seconds.toFixed(1)} s`
-  }
-
-  if (durationMs < HOUR_IN_MS) {
-    const minutes = Math.floor(durationMs / MINUTE_IN_MS)
-    const seconds = Math.floor((durationMs % MINUTE_IN_MS) / SECOND_IN_MS)
-
-    return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`
-  }
-
-  const hours = Math.floor(durationMs / HOUR_IN_MS)
-  const minutes = Math.floor((durationMs % HOUR_IN_MS) / MINUTE_IN_MS)
-
-  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`
+  return dayjs(endedAt).from(startedAt, true)
 }

--- a/ui/src/features/admin/replications/executions/pages/ReplicationExecutionsPage.tsx
+++ b/ui/src/features/admin/replications/executions/pages/ReplicationExecutionsPage.tsx
@@ -1,0 +1,96 @@
+import {
+  Anchor,
+  Breadcrumbs,
+  Text,
+} from '@mantine/core'
+import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
+import { getRouteApi, Link } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
+
+import { useRouteListState } from '@/shared/hooks/useRouteListState'
+import { DEFAULT_PAGE } from '@/utils/constants'
+
+import { replicationDetailQueryOptions } from '../../replications.query'
+import { getReplicationDisplayName } from '../../replications.utils'
+import { ReplicationExecutionsTable } from '../components/ReplicationExecutionsTable'
+import {
+  adminReplicationExecutionKeys,
+  useReplicationExecutions,
+} from '../executions.query'
+import { parseReplicationId } from '../executions.utils'
+
+const replicationExecutionsRouteApi = getRouteApi('/(auth)/admin/replications_/$replicationId/executions')
+
+export function ReplicationExecutionsPage() {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const navigate = replicationExecutionsRouteApi.useNavigate()
+  const search = replicationExecutionsRouteApi.useSearch()
+  const { replicationId } = replicationExecutionsRouteApi.useParams()
+  const syncPolicyId = parseReplicationId(replicationId)
+  const { data: syncPolicy } = useSuspenseQuery(replicationDetailQueryOptions(syncPolicyId))
+  const {
+    data,
+    isLoading,
+    isFetching,
+  } = useReplicationExecutions(syncPolicyId, search)
+  const executions = data?.executions ?? []
+  const pagination = data?.pagination
+
+  const refreshExecutions = () => queryClient.invalidateQueries({
+    queryKey: adminReplicationExecutionKeys.lists(syncPolicyId),
+  })
+
+  const {
+    onRefresh,
+    onPageChange,
+    routeColumnFilterTableOptions,
+  } = useRouteListState({
+    search,
+    navigate,
+    records: executions,
+    getRecordId: task => String(task.id ?? '-'),
+    refresh: refreshExecutions,
+    columnFilterSync: [
+      {
+        columnId: 'status',
+        searchKey: 'status',
+      },
+    ],
+  })
+
+  return (
+    <>
+      <Breadcrumbs separator="/" separatorMargin="xs" mb="md">
+        <Anchor
+          underline="never"
+          renderRoot={props => (
+            <Link
+              {...props}
+              to="/admin/replications"
+            />
+          )}
+        >
+          {t('admin.replications')}
+        </Anchor>
+        <Text size="sm" fw={500}>
+          {t('routes.admin.replications.executions.breadcrumb', {
+            name: getReplicationDisplayName(syncPolicy),
+          })}
+        </Text>
+      </Breadcrumbs>
+
+      <ReplicationExecutionsTable
+        syncPolicyId={syncPolicyId}
+        data={executions}
+        pagination={pagination}
+        loading={isLoading}
+        fetching={isFetching}
+        page={search.page ?? DEFAULT_PAGE}
+        onRefresh={onRefresh}
+        onPageChange={onPageChange}
+        tableOptions={routeColumnFilterTableOptions}
+      />
+    </>
+  )
+}

--- a/ui/src/features/admin/replications/executions/pages/ReplicationExecutionsPage.tsx
+++ b/ui/src/features/admin/replications/executions/pages/ReplicationExecutionsPage.tsx
@@ -1,17 +1,9 @@
-import {
-  Anchor,
-  Breadcrumbs,
-  Text,
-} from '@mantine/core'
-import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
-import { getRouteApi, Link } from '@tanstack/react-router'
-import { useTranslation } from 'react-i18next'
+import { useQueryClient } from '@tanstack/react-query'
+import { getRouteApi } from '@tanstack/react-router'
 
 import { useRouteListState } from '@/shared/hooks/useRouteListState'
 import { DEFAULT_PAGE } from '@/utils/constants'
 
-import { replicationDetailQueryOptions } from '../../replications.query'
-import { getReplicationDisplayName } from '../../replications.utils'
 import { ReplicationExecutionsTable } from '../components/ReplicationExecutionsTable'
 import {
   adminReplicationExecutionKeys,
@@ -22,13 +14,11 @@ import { parseReplicationId } from '../executions.utils'
 const replicationExecutionsRouteApi = getRouteApi('/(auth)/admin/replications_/$replicationId/executions')
 
 export function ReplicationExecutionsPage() {
-  const { t } = useTranslation()
   const queryClient = useQueryClient()
   const navigate = replicationExecutionsRouteApi.useNavigate()
   const search = replicationExecutionsRouteApi.useSearch()
   const { replicationId } = replicationExecutionsRouteApi.useParams()
   const syncPolicyId = parseReplicationId(replicationId)
-  const { data: syncPolicy } = useSuspenseQuery(replicationDetailQueryOptions(syncPolicyId))
   const {
     data,
     isLoading,
@@ -60,37 +50,16 @@ export function ReplicationExecutionsPage() {
   })
 
   return (
-    <>
-      <Breadcrumbs separator="/" separatorMargin="xs" mb="md">
-        <Anchor
-          underline="never"
-          renderRoot={props => (
-            <Link
-              {...props}
-              to="/admin/replications"
-            />
-          )}
-        >
-          {t('admin.replications')}
-        </Anchor>
-        <Text size="sm" fw={500}>
-          {t('routes.admin.replications.executions.breadcrumb', {
-            name: getReplicationDisplayName(syncPolicy),
-          })}
-        </Text>
-      </Breadcrumbs>
-
-      <ReplicationExecutionsTable
-        syncPolicyId={syncPolicyId}
-        data={executions}
-        pagination={pagination}
-        loading={isLoading}
-        fetching={isFetching}
-        page={search.page ?? DEFAULT_PAGE}
-        onRefresh={onRefresh}
-        onPageChange={onPageChange}
-        tableOptions={routeColumnFilterTableOptions}
-      />
-    </>
+    <ReplicationExecutionsTable
+      syncPolicyId={syncPolicyId}
+      data={executions}
+      pagination={pagination}
+      loading={isLoading}
+      fetching={isFetching}
+      page={search.page ?? DEFAULT_PAGE}
+      onRefresh={onRefresh}
+      onPageChange={onPageChange}
+      tableOptions={routeColumnFilterTableOptions}
+    />
   )
 }

--- a/ui/src/features/admin/replications/replications.query.ts
+++ b/ui/src/features/admin/replications/replications.query.ts
@@ -5,6 +5,8 @@ import {
   useQuery,
 } from '@tanstack/react-query'
 
+import i18n from '@/i18n'
+
 import {
   DEFAULT_REPLICATIONS_PAGE_SIZE,
   type ReplicationsSearch,
@@ -14,6 +16,8 @@ export const adminReplicationKeys = {
   all: ['admin', 'replications'] as const,
   lists: () => [...adminReplicationKeys.all, 'list'] as const,
   list: (search: ReplicationsSearch) => [...adminReplicationKeys.lists(), search] as const,
+  details: () => [...adminReplicationKeys.all, 'detail'] as const,
+  detail: (syncPolicyId: number) => [...adminReplicationKeys.details(), syncPolicyId] as const,
 }
 
 export function replicationsQueryOptions(search: ReplicationsSearch) {
@@ -30,6 +34,21 @@ export function replicationsQueryOptions(search: ReplicationsSearch) {
         replications: response.syncPolicies ?? [],
         pagination: response.pagination,
       }
+    },
+  })
+}
+
+export function replicationDetailQueryOptions(syncPolicyId: number) {
+  return queryOptions({
+    queryKey: adminReplicationKeys.detail(syncPolicyId),
+    queryFn: async () => {
+      const response = await SyncPolicy.GetSyncPolicy({ syncPolicyId })
+
+      if (!response.syncPolicy) {
+        throw new Error(i18n.t('routes.admin.replications.executions.errors.syncPolicyNotFound'))
+      }
+
+      return response.syncPolicy
     },
   })
 }

--- a/ui/src/locales/en/routes/admin.replications.json
+++ b/ui/src/locales/en/routes/admin.replications.json
@@ -94,5 +94,42 @@
   },
   "errors": {
     "missingSyncPolicyId": "Sync policy ID is required"
+  },
+  "executions": {
+    "breadcrumb": "Sync Rule: {{name}}",
+    "searchPlaceholder": "Search by task ID",
+    "filters": {
+      "status": "Status"
+    },
+    "table": {
+      "taskId": "Task",
+      "status": "Status",
+      "triggerType": "Trigger Mode",
+      "startedAt": "Created At",
+      "duration": "Duration",
+      "successRate": "Success Rate",
+      "totalItems": "Total",
+      "actions": "Actions",
+      "empty": "No sync tasks found"
+    },
+    "status": {
+      "running": "Running",
+      "stopped": "Stopped",
+      "succeeded": "Succeeded",
+      "failed": "Failed",
+      "unknown": "Unknown"
+    },
+    "actions": {
+      "stop": "Stop Task"
+    },
+    "notifications": {
+      "stopSuccess": "Sync task stopped successfully",
+      "stopError": "Failed to stop sync task"
+    },
+    "errors": {
+      "invalidSyncPolicyId": "Invalid sync policy ID",
+      "missingSyncTaskId": "Sync task ID is required",
+      "syncPolicyNotFound": "Sync rule not found"
+    }
   }
 }

--- a/ui/src/locales/zh/routes/admin.replications.json
+++ b/ui/src/locales/zh/routes/admin.replications.json
@@ -94,5 +94,42 @@
   },
   "errors": {
     "missingSyncPolicyId": "同步策略ID不能为空"
+  },
+  "executions": {
+    "breadcrumb": "同步规则：{{name}}",
+    "searchPlaceholder": "输入任务 ID 搜索",
+    "filters": {
+      "status": "状态"
+    },
+    "table": {
+      "taskId": "任务",
+      "status": "状态",
+      "triggerType": "触发模式",
+      "startedAt": "创建时间",
+      "duration": "持续时间",
+      "successRate": "成功百分比",
+      "totalItems": "总数",
+      "actions": "操作",
+      "empty": "暂无同步任务数据"
+    },
+    "status": {
+      "running": "进行中",
+      "stopped": "已停止",
+      "succeeded": "成功",
+      "failed": "失败",
+      "unknown": "未知"
+    },
+    "actions": {
+      "stop": "停止任务"
+    },
+    "notifications": {
+      "stopSuccess": "同步任务已停止",
+      "stopError": "停止同步任务失败"
+    },
+    "errors": {
+      "invalidSyncPolicyId": "无效的同步策略 ID",
+      "missingSyncTaskId": "同步任务 ID 不能为空",
+      "syncPolicyNotFound": "同步规则不存在"
+    }
   }
 }

--- a/ui/src/routes/(auth)/admin/registries.tsx
+++ b/ui/src/routes/(auth)/admin/registries.tsx
@@ -2,6 +2,7 @@ import { IconBuildingWarehouse as AdminRegistriesIcon } from '@tabler/icons-reac
 import { createFileRoute, stripSearchParams } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 
+import { AdminPageHeader } from '@/features/admin/components/admin-page-header'
 import { AdminPageLayout } from '@/features/admin/components/admin-page-layout'
 import { RegistriesPage } from '@/features/admin/registries/pages/RegistriesPage'
 import { registriesQueryOptions } from '@/features/admin/registries/registries.query'
@@ -28,11 +29,14 @@ function RouteComponent() {
   const { t } = useTranslation()
 
   return (
-    <AdminPageLayout
-      icon={AdminRegistriesIcon}
-      title={t('admin.registries')}
-    >
-      <RegistriesPage />
-    </AdminPageLayout>
+    <>
+      <AdminPageHeader
+        icon={AdminRegistriesIcon}
+        items={[{ label: t('admin.registries') }]}
+      />
+      <AdminPageLayout>
+        <RegistriesPage />
+      </AdminPageLayout>
+    </>
   )
 }

--- a/ui/src/routes/(auth)/admin/replications.tsx
+++ b/ui/src/routes/(auth)/admin/replications.tsx
@@ -2,6 +2,7 @@ import { IconAffiliate } from '@tabler/icons-react'
 import { createFileRoute, stripSearchParams } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 
+import { AdminPageHeader } from '@/features/admin/components/admin-page-header'
 import { AdminPageLayout } from '@/features/admin/components/admin-page-layout'
 import { ReplicationsPage } from '@/features/admin/replications/pages/ReplicationsPage'
 import { replicationsQueryOptions } from '@/features/admin/replications/replications.query'
@@ -28,11 +29,14 @@ function RouteComponent() {
   const { t } = useTranslation()
 
   return (
-    <AdminPageLayout
-      icon={IconAffiliate}
-      title={t('admin.replications')}
-    >
-      <ReplicationsPage />
-    </AdminPageLayout>
+    <>
+      <AdminPageHeader
+        icon={IconAffiliate}
+        items={[{ label: t('admin.replications') }]}
+      />
+      <AdminPageLayout>
+        <ReplicationsPage />
+      </AdminPageLayout>
+    </>
   )
 }

--- a/ui/src/routes/(auth)/admin/replications_.$replicationId.executions.tsx
+++ b/ui/src/routes/(auth)/admin/replications_.$replicationId.executions.tsx
@@ -1,7 +1,9 @@
 import { IconAffiliate } from '@tabler/icons-react'
+import { useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute, stripSearchParams } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 
+import { AdminPageHeader } from '@/features/admin/components/admin-page-header'
 import { AdminPageLayout } from '@/features/admin/components/admin-page-layout'
 import { replicationExecutionsQueryOptions } from '@/features/admin/replications/executions/executions.query'
 import {
@@ -11,6 +13,7 @@ import {
 import { parseReplicationId } from '@/features/admin/replications/executions/executions.utils'
 import { ReplicationExecutionsPage } from '@/features/admin/replications/executions/pages/ReplicationExecutionsPage'
 import { replicationDetailQueryOptions } from '@/features/admin/replications/replications.query'
+import { getReplicationDisplayName } from '@/features/admin/replications/replications.utils'
 
 export const Route = createFileRoute(
   '/(auth)/admin/replications_/$replicationId/executions',
@@ -21,29 +24,43 @@ export const Route = createFileRoute(
   },
   loaderDeps: ({ search }) => ({ search }),
   loader: async ({
-    context: { queryClient },
+    context,
     deps: { search },
     params: { replicationId },
   }) => {
     const syncPolicyId = parseReplicationId(replicationId)
 
-    await Promise.allSettled([
-      queryClient.ensureQueryData(replicationDetailQueryOptions(syncPolicyId)),
-      queryClient.ensureQueryData(replicationExecutionsQueryOptions(syncPolicyId, search)),
-    ])
+    await context.queryClient.ensureQueryData(replicationDetailQueryOptions(syncPolicyId))
+    context.queryClient.prefetchQuery(replicationExecutionsQueryOptions(syncPolicyId, search))
   },
   component: RouteComponent,
 })
 
 function RouteComponent() {
   const { t } = useTranslation()
+  const { replicationId } = Route.useParams()
+  const syncPolicyId = parseReplicationId(replicationId)
+  const { data: syncPolicy } = useSuspenseQuery(replicationDetailQueryOptions(syncPolicyId))
 
   return (
-    <AdminPageLayout
-      icon={IconAffiliate}
-      title={t('admin.replications')}
-    >
-      <ReplicationExecutionsPage />
-    </AdminPageLayout>
+    <>
+      <AdminPageHeader
+        icon={IconAffiliate}
+        items={[
+          {
+            label: t('admin.replications'),
+            linkProps: { to: '/admin/replications' },
+          },
+          {
+            label: t('routes.admin.replications.executions.breadcrumb', {
+              name: getReplicationDisplayName(syncPolicy),
+            }),
+          },
+        ]}
+      />
+      <AdminPageLayout>
+        <ReplicationExecutionsPage />
+      </AdminPageLayout>
+    </>
   )
 }

--- a/ui/src/routes/(auth)/admin/replications_.$replicationId.executions.tsx
+++ b/ui/src/routes/(auth)/admin/replications_.$replicationId.executions.tsx
@@ -1,22 +1,49 @@
-import { Title } from '@mantine/core'
-import { createFileRoute } from '@tanstack/react-router'
+import { IconAffiliate } from '@tabler/icons-react'
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
+
+import { AdminPageLayout } from '@/features/admin/components/admin-page-layout'
+import { replicationExecutionsQueryOptions } from '@/features/admin/replications/executions/executions.query'
+import {
+  replicationExecutionsSearchDefaults,
+  replicationExecutionsSearchSchema,
+} from '@/features/admin/replications/executions/executions.schema'
+import { parseReplicationId } from '@/features/admin/replications/executions/executions.utils'
+import { ReplicationExecutionsPage } from '@/features/admin/replications/executions/pages/ReplicationExecutionsPage'
+import { replicationDetailQueryOptions } from '@/features/admin/replications/replications.query'
 
 export const Route = createFileRoute(
   '/(auth)/admin/replications_/$replicationId/executions',
 )({
+  validateSearch: replicationExecutionsSearchSchema,
+  search: {
+    middlewares: [stripSearchParams(replicationExecutionsSearchDefaults)],
+  },
+  loaderDeps: ({ search }) => ({ search }),
+  loader: async ({
+    context: { queryClient },
+    deps: { search },
+    params: { replicationId },
+  }) => {
+    const syncPolicyId = parseReplicationId(replicationId)
+
+    await Promise.allSettled([
+      queryClient.ensureQueryData(replicationDetailQueryOptions(syncPolicyId)),
+      queryClient.ensureQueryData(replicationExecutionsQueryOptions(syncPolicyId, search)),
+    ])
+  },
   component: RouteComponent,
 })
 
 function RouteComponent() {
-  const { replicationId } = Route.useParams()
+  const { t } = useTranslation()
 
   return (
-    <div>
-      <Title order={3}>
-        Executions for Replication
-        {' '}
-        {replicationId}
-      </Title>
-    </div>
+    <AdminPageLayout
+      icon={IconAffiliate}
+      title={t('admin.replications')}
+    >
+      <ReplicationExecutionsPage />
+    </AdminPageLayout>
   )
 }

--- a/ui/src/routes/(auth)/admin/users.tsx
+++ b/ui/src/routes/(auth)/admin/users.tsx
@@ -2,6 +2,7 @@ import { IconUsers as AdminUsersIcon } from '@tabler/icons-react'
 import { createFileRoute, stripSearchParams } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 
+import { AdminPageHeader } from '@/features/admin/components/admin-page-header'
 import { AdminPageLayout } from '@/features/admin/components/admin-page-layout'
 import { UsersPage } from '@/features/admin/users/pages/UsersPage'
 import { usersQueryOptions } from '@/features/admin/users/users.query'
@@ -28,11 +29,14 @@ function RouteComponent() {
   const { t } = useTranslation()
 
   return (
-    <AdminPageLayout
-      icon={AdminUsersIcon}
-      title={t('admin.users')}
-    >
-      <UsersPage />
-    </AdminPageLayout>
+    <>
+      <AdminPageHeader
+        icon={AdminUsersIcon}
+        items={[{ label: t('admin.users') }]}
+      />
+      <AdminPageLayout>
+        <UsersPage />
+      </AdminPageLayout>
+    </>
   )
 }

--- a/ui/src/shared/components/DataTable.tsx
+++ b/ui/src/shared/components/DataTable.tsx
@@ -14,6 +14,7 @@ import { useDebouncedCallback, useDebouncedValue } from '@mantine/hooks'
 import { IconRefresh, IconTrash } from '@tabler/icons-react'
 import { MantineReactTable } from 'mantine-react-table'
 import 'mantine-react-table/styles.css'
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Pagination } from './Pagination'
@@ -170,9 +171,66 @@ function resolveTableOptionProps<TArgs extends object, TProps extends object>(
     : props
 }
 
-// -- DataTable --
+// Build a value→label map from the static `data` of a select-filter column so
+// the active-filter tooltip shows the human-readable label instead of the raw
+// value. Skipped when `mantineFilterSelectProps` is a function (we can't inspect
+// it without table args) or `data` is missing/grouped.
+function deriveSelectFilterLabelMap<TData extends MRT_RowData>(
+  column: MRT_ColumnDef<TData>,
+): Map<string, string> | undefined {
+  const filterProps = column.mantineFilterSelectProps
 
-const emptyRowsFallback = () => null
+  if (!filterProps || typeof filterProps === 'function') {
+    return undefined
+  }
+
+  const data = (filterProps as { data?: unknown }).data
+
+  if (!Array.isArray(data) || data.length === 0) {
+    return undefined
+  }
+
+  const labelByValue = new Map<string, string>()
+
+  for (const item of data) {
+    if (typeof item === 'string') {
+      labelByValue.set(item, item)
+    } else if (item && typeof item === 'object' && 'value' in item) {
+      const value = String((item as { value: unknown }).value ?? '')
+      const label = (item as { label?: unknown }).label
+
+      labelByValue.set(value, typeof label === 'string' ? label : value)
+    }
+  }
+
+  return labelByValue.size > 0 ? labelByValue : undefined
+}
+
+function withFilterTooltipLabels<TData extends MRT_RowData>(
+  columns: MRT_ColumnDef<TData>[],
+): MRT_ColumnDef<TData>[] {
+  return columns.map((column) => {
+    if (column.filterTooltipValueFn) {
+      return column
+    }
+    const labelByValue = deriveSelectFilterLabelMap(column)
+
+    if (!labelByValue) {
+      return column
+    }
+
+    return {
+      ...column,
+      filterTooltipValueFn: (value: unknown) => {
+        const key = String(value ?? '')
+
+        return labelByValue.get(key) ?? key
+      },
+    }
+  })
+}
+
+// -- DataTable --
 
 export function DataTable<TData extends MRT_RowData>({
   data,
@@ -205,7 +263,7 @@ export function DataTable<TData extends MRT_RowData>({
   // Loading
   loading = false,
   fetching = false,
-  renderEmptyRowsFallback = emptyRowsFallback,
+  renderEmptyRowsFallback,
   // Header
   hideTableHead = false,
   // Display column overrides
@@ -227,6 +285,8 @@ export function DataTable<TData extends MRT_RowData>({
     state: extraState,
     ...restTableOptions
   } = tableOptions ?? {}
+
+  const enhancedColumns = useMemo(() => withFilterTooltipLabels(columns), [columns])
 
   const [debouncedLoading] = useDebouncedValue(loading, 300)
 
@@ -252,10 +312,6 @@ export function DataTable<TData extends MRT_RowData>({
         <Box mb="sm">
           <SearchToolbar
             {...searchToolbarProps}
-            toolbarProps={{
-              mb: 'md',
-              ...searchToolbarProps?.toolbarProps,
-            }}
             searchPlaceholder={showSearch ? searchPlaceholderText : undefined}
             searchValue={searchValue}
             onSearchChange={onSearchChange}
@@ -305,7 +361,22 @@ export function DataTable<TData extends MRT_RowData>({
   // Empty state
   const hasEmptyTitle = hasContent(emptyTitle)
   const hasEmptyDescription = hasContent(emptyDescription)
-  const showEmptyState = data.length === 0 && !loading && (hasEmptyTitle || hasEmptyDescription)
+  const hasCustomEmptyState = hasEmptyTitle || hasEmptyDescription
+  const renderDefaultEmptyRowsFallback = hasCustomEmptyState
+    ? () => (
+        <Center py="xl" w="100%">
+          <Stack align="center" gap="xs">
+            {hasEmptyTitle && <Text fw={500}>{emptyTitle}</Text>}
+            {hasEmptyDescription && (
+              <Text size="sm" c="dimmed">
+                {emptyDescription}
+              </Text>
+            )}
+          </Stack>
+        </Center>
+      )
+    : () => null
+  const effectiveRenderEmptyRowsFallback = renderEmptyRowsFallback ?? renderDefaultEmptyRowsFallback
 
   // Pagination
   const totalPages = pagination?.pages
@@ -320,7 +391,7 @@ export function DataTable<TData extends MRT_RowData>({
       {toolbar}
 
       <MantineReactTable
-        columns={columns}
+        columns={enhancedColumns}
         data={data}
         enableBottomToolbar={false}
         enableTopToolbar={false}
@@ -343,14 +414,13 @@ export function DataTable<TData extends MRT_RowData>({
         // Selection
         enableRowSelection={enableRowSelection}
         enableSelectAll={enableSelectAll}
-        layoutMode="grid"
         onRowSelectionChange={onRowSelectionChange}
         getRowId={getRowId}
         // Row actions
         enableRowActions={enableRowActions}
         renderRowActions={renderRowActions}
         positionActionsColumn={positionActionsColumn}
-        renderEmptyRowsFallback={renderEmptyRowsFallback}
+        renderEmptyRowsFallback={effectiveRenderEmptyRowsFallback}
         localization={{ noRecordsToDisplay: '' }}
         // Display column overrides
         displayColumnDefOptions={{
@@ -424,19 +494,6 @@ export function DataTable<TData extends MRT_RowData>({
           bg: row.getIsSelected() ? 'var(--mantine-color-cyan-light)' : undefined,
         })}
       />
-
-      {showEmptyState && (
-        <Center py="xl">
-          <Stack align="center" gap="xs">
-            {hasEmptyTitle && <Text fw={500}>{emptyTitle}</Text>}
-            {hasEmptyDescription && (
-              <Text size="sm" c="dimmed">
-                {emptyDescription}
-              </Text>
-            )}
-          </Stack>
-        </Center>
-      )}
 
       {onPageChange && (
         <Pagination

--- a/ui/src/shared/components/DataTable.tsx
+++ b/ui/src/shared/components/DataTable.tsx
@@ -13,6 +13,7 @@ import {
 import { useDebouncedCallback, useDebouncedValue } from '@mantine/hooks'
 import { IconRefresh, IconTrash } from '@tabler/icons-react'
 import { MantineReactTable } from 'mantine-react-table'
+import 'mantine-react-table/styles.css'
 import { useTranslation } from 'react-i18next'
 
 import { Pagination } from './Pagination'
@@ -156,6 +157,19 @@ function mergeTableOptionProps<TData extends MRT_RowData, TProps extends object>
   }
 }
 
+function resolveTableOptionProps<TArgs extends object, TProps extends object>(
+  props: TProps | ((args: TArgs) => TProps) | undefined,
+  args: TArgs,
+) {
+  if (!props) {
+    return undefined
+  }
+
+  return typeof props === 'function'
+    ? props(args)
+    : props
+}
+
 // -- DataTable --
 
 const emptyRowsFallback = () => null
@@ -201,7 +215,12 @@ export function DataTable<TData extends MRT_RowData>({
 }: DataTableProps<TData>) {
   const { t } = useTranslation()
   const {
+    columnFilterDisplayMode = 'popover',
+    defaultColumn,
+    enableColumnFilters = true,
     initialState,
+    mantineFilterSelectProps,
+    mantineFilterTextInputProps,
     mantinePaperProps,
     mantineTableContainerProps,
     mantineTableProps,
@@ -233,6 +252,10 @@ export function DataTable<TData extends MRT_RowData>({
         <Box mb="sm">
           <SearchToolbar
             {...searchToolbarProps}
+            toolbarProps={{
+              mb: 'md',
+              ...searchToolbarProps?.toolbarProps,
+            }}
             searchPlaceholder={showSearch ? searchPlaceholderText : undefined}
             searchValue={searchValue}
             onSearchChange={onSearchChange}
@@ -309,9 +332,14 @@ export function DataTable<TData extends MRT_RowData>({
         enableGlobalFilterModes={false}
         enableHiding={false}
         enablePagination={false}
-        enableColumnFilters={false}
+        enableColumnFilters={enableColumnFilters}
         enableSorting={false}
         enableTableHead={!hideTableHead}
+        columnFilterDisplayMode={columnFilterDisplayMode}
+        defaultColumn={{
+          enableColumnFilter: false,
+          ...defaultColumn,
+        }}
         // Selection
         enableRowSelection={enableRowSelection}
         enableSelectAll={enableSelectAll}
@@ -341,6 +369,14 @@ export function DataTable<TData extends MRT_RowData>({
           ...initialState,
         }}
         state={tableState}
+        mantineFilterSelectProps={args => ({
+          clearable: true,
+          comboboxProps: { withinPortal: false },
+          ...resolveTableOptionProps(mantineFilterSelectProps, args),
+        })}
+        mantineFilterTextInputProps={args => ({
+          ...resolveTableOptionProps(mantineFilterTextInputProps, args),
+        })}
         mantinePaperProps={mergeTableOptionProps<TData, PaperProps>(
           {
             radius: 0,

--- a/ui/src/shared/components/StatusIndicator.tsx
+++ b/ui/src/shared/components/StatusIndicator.tsx
@@ -1,0 +1,49 @@
+import {
+  Box,
+  Group,
+  Text,
+  type TextProps,
+} from '@mantine/core'
+
+import type { ReactNode } from 'react'
+
+export type StatusIndicatorType = 'danger' | 'info' | 'neutral' | 'success' | 'warning'
+
+export interface StatusIndicatorProps {
+  label: ReactNode
+  type?: StatusIndicatorType
+  dotSize?: number
+  textProps?: TextProps
+}
+
+const statusIndicatorColors: Record<StatusIndicatorType, string> = {
+  danger: 'var(--mantine-color-error)',
+  info: 'var(--mantine-primary-color-filled)',
+  neutral: 'var(--mantine-color-dimmed)',
+  success: 'var(--mantine-color-green-filled)',
+  warning: 'var(--mantine-color-yellow-filled)',
+}
+
+export function StatusIndicator({
+  label,
+  type = 'neutral',
+  dotSize = 10,
+  textProps,
+}: StatusIndicatorProps) {
+  return (
+    <Group gap={6} wrap="nowrap">
+      <Box
+        h={dotSize}
+        w={dotSize}
+        bg={statusIndicatorColors[type]}
+        style={{
+          borderRadius: '50%',
+          flexShrink: 0,
+        }}
+      />
+      <Text size="sm" {...textProps}>
+        {label}
+      </Text>
+    </Group>
+  )
+}

--- a/ui/src/shared/hooks/useRouteListState.ts
+++ b/ui/src/shared/hooks/useRouteListState.ts
@@ -3,11 +3,25 @@ import {
   useState,
 } from 'react'
 
-import type { MRT_RowSelectionState } from 'mantine-react-table'
+import { DEFAULT_PAGE } from '@/utils/constants'
+
+import type {
+  MRT_ColumnFiltersState,
+  MRT_RowSelectionState,
+  MRT_TableOptions,
+  MRT_Updater,
+} from 'mantine-react-table'
 
 interface RouteListSearchState {
   page?: number
   query?: string
+}
+
+interface RouteColumnFilterSyncConfig<TSearch extends RouteListSearchState> {
+  columnId: string
+  searchKey: keyof TSearch
+  toColumnFilterValue?: (value: TSearch[keyof TSearch]) => unknown
+  toSearchValue?: (value: unknown) => TSearch[keyof TSearch]
 }
 
 interface UseRouteListStateOptions<TSearch extends RouteListSearchState, TRecord> {
@@ -21,9 +35,8 @@ interface UseRouteListStateOptions<TSearch extends RouteListSearchState, TRecord
   refresh?: () => unknown
   defaultPage?: number
   normalizeQuery?: (value: string) => string | undefined
+  columnFilterSync?: RouteColumnFilterSyncConfig<TSearch>[]
 }
-
-const DEFAULT_PAGE = 1
 
 function defaultNormalizeQuery(value: string) {
   const nextQuery = value.trim()
@@ -39,6 +52,7 @@ export function useRouteListState<TSearch extends RouteListSearchState, TRecord>
   refresh,
   defaultPage = DEFAULT_PAGE,
   normalizeQuery = defaultNormalizeQuery,
+  columnFilterSync,
 }: UseRouteListStateOptions<TSearch, TRecord>) {
   const [rowSelection, setRowSelection] = useState<MRT_RowSelectionState>({})
 
@@ -61,6 +75,19 @@ export function useRouteListState<TSearch extends RouteListSearchState, TRecord>
 
   const selectedCount = selectedRowIds.length
   const currentQuery = normalizeQuery(search.query ?? '')
+  const columnFilters: MRT_ColumnFiltersState = (columnFilterSync ?? []).flatMap((filter) => {
+    const rawValue = search[filter.searchKey]
+    const value = filter.toColumnFilterValue
+      ? filter.toColumnFilterValue(rawValue)
+      : rawValue
+
+    return value == null || value === ''
+      ? []
+      : [{
+          id: filter.columnId,
+          value,
+        }]
+  })
 
   const onSearchChange = (value: string) => {
     const nextQuery = normalizeQuery(value)
@@ -101,6 +128,61 @@ export function useRouteListState<TSearch extends RouteListSearchState, TRecord>
     })
   }
 
+  const onColumnFiltersChange = (updater: MRT_Updater<MRT_ColumnFiltersState>) => {
+    if (!columnFilterSync?.length) {
+      return
+    }
+
+    const nextColumnFilters = typeof updater === 'function'
+      ? updater(columnFilters)
+      : updater
+
+    const nextSearchPatch = {} as Partial<TSearch>
+    let hasChanges = false
+
+    for (const filter of columnFilterSync) {
+      const rawValue = nextColumnFilters.find(
+        columnFilter => columnFilter.id === filter.columnId,
+      )?.value
+      const nextValue = filter.toSearchValue
+        ? filter.toSearchValue(rawValue)
+        : rawValue as TSearch[keyof TSearch]
+
+      if (nextValue !== search[filter.searchKey]) {
+        hasChanges = true
+      }
+
+      nextSearchPatch[filter.searchKey] = nextValue
+    }
+
+    if (!hasChanges) {
+      return
+    }
+
+    clearRowSelection()
+    startTransition(() => {
+      void navigate({
+        replace: true,
+        search: prev => ({
+          ...prev,
+          page: defaultPage,
+          ...nextSearchPatch,
+        }),
+      })
+    })
+  }
+
+  const routeColumnFilterTableOptions: Pick<
+    MRT_TableOptions<object>,
+    'manualFiltering' | 'onColumnFiltersChange' | 'state'
+  > | undefined = columnFilterSync?.length
+    ? {
+        manualFiltering: true,
+        onColumnFiltersChange,
+        state: { columnFilters },
+      }
+    : undefined
+
   return {
     rowSelection,
     setRowSelection,
@@ -111,5 +193,6 @@ export function useRouteListState<TSearch extends RouteListSearchState, TRecord>
     onSearchChange,
     onRefresh,
     onPageChange,
+    routeColumnFilterTableOptions,
   }
 }

--- a/ui/src/shared/utils/date.ts
+++ b/ui/src/shared/utils/date.ts
@@ -19,7 +19,7 @@ function isProtobufTimestamp(value: DateValue): value is ProtobufTimestampLike {
   return typeof value === 'object' && value !== null && ('seconds' in value || 'nanos' in value)
 }
 
-function toMilliseconds(value: TimestampValue) {
+export function toMilliseconds(value: TimestampValue) {
   const dateNum = Number(value)
 
   if (Number.isNaN(dateNum)) {

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -1,3 +1,4 @@
+export const DEFAULT_PAGE = 1
 export const DEFAULT_PAGE_SIZE = 10
 
 export const DEFAULT_PROJECTS_PAGE_SIZE = 10


### PR DESCRIPTION
## Summary
- add a replication executions page at `/admin/replications/$id/executions`
- add per-column filter support to the shared `DataTable`