### PR TITLE
feat(ui-admin-replication): update replication form and list display

### DIFF
--- a/ui/src/features/admin/replications/components/ReplicationFormModal.tsx
+++ b/ui/src/features/admin/replications/components/ReplicationFormModal.tsx
@@ -346,7 +346,7 @@ export function ReplicationFormModal({
                       tooltipProps={{ w: 280 }}
                     />
                   )}
-                  disabled
+                  disabled={mode === 'edit'}
                 />
               </Group>
             </RadioGroup>
@@ -392,6 +392,7 @@ export function ReplicationFormModal({
               {field => (
                 <TextInput
                   {...inlineFieldProps}
+                  withAsterisk
                   aria-label={t('routes.admin.replications.form.resourceName')}
                   leftSection={renderInlineFieldSection(
                     t('routes.admin.replications.form.resourceName'),
@@ -400,6 +401,7 @@ export function ReplicationFormModal({
                   value={field.state.value}
                   onChange={event => field.handleChange(event.currentTarget.value)}
                   onBlur={field.handleBlur}
+                  error={fieldError(field)}
                 />
               )}
             </form.Field>
@@ -428,6 +430,7 @@ export function ReplicationFormModal({
             {field => (
               <Select
                 label={t('routes.admin.replications.form.targetRegistry')}
+                withAsterisk
                 data={registryOptions}
                 value={field.state.value ? String(field.state.value) : null}
                 onChange={value => field.handleChange(value ? Number(value) : 0)}

--- a/ui/src/features/admin/replications/components/ReplicationFormModal.tsx
+++ b/ui/src/features/admin/replications/components/ReplicationFormModal.tsx
@@ -321,13 +321,13 @@ export function ReplicationFormModal({
             <RadioGroup
               label={t('routes.admin.replications.form.syncRule')}
               withAsterisk
-              value={String(field.state.value)}
+              value={field.state.value}
               onChange={value => field.handleChange(value as ReplicationFormValues['policyType'])}
               onBlur={field.handleBlur}
             >
               <Group mt="xs">
                 <Radio
-                  value={String(SyncPolicyType.SYNC_POLICY_TYPE_PULL_BASE)}
+                  value={SyncPolicyType.SYNC_POLICY_TYPE_PULL_BASE}
                   label={(
                     <FieldHintLabel
                       label={t('routes.admin.replications.form.pull')}
@@ -338,7 +338,7 @@ export function ReplicationFormModal({
                   disabled={mode === 'edit'}
                 />
                 <Radio
-                  value={String(SyncPolicyType.SYNC_POLICY_TYPE_PUSH_BASE)}
+                  value={SyncPolicyType.SYNC_POLICY_TYPE_PUSH_BASE}
                   label={(
                     <FieldHintLabel
                       label={t('routes.admin.replications.form.push')}

--- a/ui/src/features/admin/replications/components/ReplicationsTable.tsx
+++ b/ui/src/features/admin/replications/components/ReplicationsTable.tsx
@@ -12,6 +12,7 @@ import { DataTable, type DataTableProps } from '@/shared/components/DataTable'
 import { DeleteReplicationAction } from './DeleteReplicationAction'
 import { EditReplicationAction } from './EditReplicationAction'
 import { SyncReplicationAction } from './SyncReplicationAction'
+import { ToggleReplicationAction } from './ToggleReplicationAction'
 import {
   formatReplicationBandwidth,
   getReplicationRowId,
@@ -54,23 +55,12 @@ function ReplicationActionsCell({
   row,
 }: ReplicationActionCellProps) {
   const isDisabled = row.original.id == null
-  // const isDisabledToggle = row.original.isDisabled
-  // const toggleLabel = isDisabledToggle
-  //   ? t('routes.admin.replications.actions.enable')
-  //   : t('routes.admin.replications.actions.disable')
 
   return (
     <Group gap={4} wrap="nowrap">
       <EditReplicationAction syncPolicy={row.original} disabled={isDisabled} />
       <SyncReplicationAction syncPolicy={row.original} disabled={isDisabled} />
-      {/* <Button
-        variant="transparent"
-        size="compact-sm"
-        color="blue"
-        disabled={isDisabled}
-      >
-        {toggleLabel}
-      </Button> */}
+      <ToggleReplicationAction syncPolicy={row.original} disabled={isDisabled} />
       <DeleteReplicationAction syncPolicy={row.original} disabled={isDisabled} />
     </Group>
   )
@@ -81,12 +71,15 @@ function getRegistryLabel(registry?: Registry) {
 }
 
 function formatLocation(parts: (string | undefined)[]) {
-  const location = parts
-    .map(part => part?.trim())
-    .filter((part): part is string => Boolean(part))
-    .join(' : ')
+  const normalized = parts.map(part => part?.trim() || '')
 
-  return location || EMPTY_VALUE
+  if (normalized.every(part => !part)) {
+    return EMPTY_VALUE
+  }
+
+  return normalized
+    .map(part => part || EMPTY_VALUE)
+    .join(' : ')
 }
 
 function getReplicationSource(item: SyncPolicyItem, localLabel: string) {

--- a/ui/src/features/admin/replications/components/ToggleReplicationAction.tsx
+++ b/ui/src/features/admin/replications/components/ToggleReplicationAction.tsx
@@ -1,0 +1,49 @@
+import { Button } from '@mantine/core'
+import { useMutation } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+
+import { switchReplicationMutationOptions } from '../replications.mutation'
+
+import type { SyncPolicyItem } from '@matrixhub/api-ts/v1alpha1/sync_policy.pb'
+
+interface ToggleReplicationActionProps {
+  syncPolicy: SyncPolicyItem
+  disabled?: boolean
+}
+
+export function ToggleReplicationAction({
+  syncPolicy,
+  disabled,
+}: ToggleReplicationActionProps) {
+  const { t } = useTranslation()
+  const mutation = useMutation(switchReplicationMutationOptions())
+  const nextIsDisabled = !syncPolicy.isDisabled
+
+  const handleToggle = async () => {
+    if (syncPolicy.id == null) {
+      return
+    }
+
+    await mutation.mutateAsync({
+      syncPolicyId: syncPolicy.id,
+      isDisabled: nextIsDisabled,
+    })
+  }
+
+  return (
+    <Button
+      variant="transparent"
+      size="compact-sm"
+      color="blue"
+      disabled={disabled || mutation.isPending}
+      loading={mutation.isPending}
+      onClick={() => {
+        void handleToggle()
+      }}
+    >
+      {syncPolicy.isDisabled
+        ? t('routes.admin.replications.actions.enable')
+        : t('routes.admin.replications.actions.disable')}
+    </Button>
+  )
+}

--- a/ui/src/features/admin/replications/replications.mutation.ts
+++ b/ui/src/features/admin/replications/replications.mutation.ts
@@ -5,6 +5,7 @@ import {
   type DeleteSyncPolicyRequest,
   SyncPolicy,
   type UpdateSyncPolicyRequest,
+  type UpdateSyncPolicySwitchRequest,
 } from '@matrixhub/api-ts/v1alpha1/sync_policy.pb'
 import { mutationOptions } from '@tanstack/react-query'
 
@@ -69,6 +70,23 @@ export function syncReplicationMutationOptions() {
     meta: {
       successMessage: i18n.t('routes.admin.replications.notifications.syncSuccess'),
       errorMessage: i18n.t('routes.admin.replications.notifications.syncError'),
+    } satisfies NotificationMeta,
+  })
+}
+
+export function switchReplicationMutationOptions() {
+  return mutationOptions({
+    mutationFn: ({
+      syncPolicyId, isDisabled,
+    }: UpdateSyncPolicySwitchRequest) =>
+      SyncPolicy.UpdateSyncPolicySwitch({
+        syncPolicyId: requireSyncPolicyId(syncPolicyId),
+        isDisabled,
+      }),
+    meta: {
+      successMessage: i18n.t('routes.admin.replications.notifications.switchSuccess'),
+      errorMessage: i18n.t('routes.admin.replications.notifications.switchError'),
+      invalidates: [adminReplicationKeys.lists()],
     } satisfies NotificationMeta,
   })
 }

--- a/ui/src/features/admin/replications/replications.schema.ts
+++ b/ui/src/features/admin/replications/replications.schema.ts
@@ -57,7 +57,9 @@ function replicationFormBaseSchema() {
     bandwidth: z.string().trim().optional(),
     bandwidthUnit: z.enum(replicationBandwidthUnitValues),
     isOverwrite: z.boolean(),
-    resourceName: z.string().trim().optional(),
+    // Phase 1 backend contract only requires resourceName to be present.
+    // Keep validation limited to "required" for now and defer pattern checks.
+    resourceName: z.string().trim().min(1, t('routes.admin.replications.validation.resourceNameRequired')),
     resourceTypes: z.array(z.enum(replicationResourceTypeValues)),
     sourceRegistryId: z.number(),
     targetProjectName: z.string().trim().optional(),
@@ -75,7 +77,10 @@ export function createReplicationFormSchema() {
       })
     }
 
-    if (!data.sourceRegistryId || data.sourceRegistryId < 1) {
+    if (
+      data.policyType === SyncPolicyType.SYNC_POLICY_TYPE_PULL_BASE
+      && (!data.sourceRegistryId || data.sourceRegistryId < 1)
+    ) {
       ctx.addIssue({
         code: 'custom',
         message: t('routes.admin.replications.validation.sourceRegistryRequired'),

--- a/ui/src/locales/en/routes/admin.replications.json
+++ b/ui/src/locales/en/routes/admin.replications.json
@@ -75,6 +75,7 @@
     "isOverwriteHint": "If a resource with the same name already exists, controls whether the target resource should be overwritten."
   },
   "validation": {
+    "resourceNameRequired": "Resource name is required",
     "resourceTypesRequired": "At least one resource type is required",
     "sourceRegistryRequired": "Source registry is required",
     "targetRegistryRequired": "Target registry is required"
@@ -84,6 +85,8 @@
     "createError": "Failed to create sync rule",
     "updateSuccess": "Sync rule updated successfully",
     "updateError": "Failed to update sync rule",
+    "switchSuccess": "Sync rule status updated successfully",
+    "switchError": "Failed to update sync rule status",
     "deleteSuccess": "Sync rule deleted successfully",
     "deleteError": "Failed to delete sync rule",
     "syncSuccess": "Sync task started successfully",

--- a/ui/src/locales/zh/routes/admin.replications.json
+++ b/ui/src/locales/zh/routes/admin.replications.json
@@ -75,6 +75,7 @@
     "isOverwriteHint": "如果存在相同名称的资源，指定是否覆盖目标上的资源。"
   },
   "validation": {
+    "resourceNameRequired": "请输入资源名称",
     "resourceTypesRequired": "至少需要选择一个资源类型",
     "sourceRegistryRequired": "请选择源仓库",
     "targetRegistryRequired": "请选择目标仓库"
@@ -84,6 +85,8 @@
     "createError": "同步规则创建失败",
     "updateSuccess": "同步规则更新成功",
     "updateError": "同步规则更新失败",
+    "switchSuccess": "同步规则状态更新成功",
+    "switchError": "同步规则状态更新失败",
     "deleteSuccess": "同步规则删除成功",
     "deleteError": "同步规则删除失败",
     "syncSuccess": "同步任务已启动",


### PR DESCRIPTION
 ## Summary
  - enable `push` option in replication create form

  ## Notes
  - `push` create/edit API is not ready yet, so the frontend support is only prepared at the UI/form level
  - enable/disable API is not ready yet, so the list action is only scaffolded and should not be considered complete backend-integrated behavior
  - scheduled trigger mode still needs product/design confirmation on the interaction flow; this part will be added later

  ## Scope
  - replications form validation and interaction cleanup
  - preliminary action wiring structure for future API integration