### PR TITLE
build: pass proxy args into Docker image stages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,10 @@ image-build: ## Build the MatrixHub image
 		-t $(IMAGE_REPO):$(VERSION) \
 		-f deploy/docker/matrixhub/Dockerfile \
 		$(if $(PLATFORMS),--platform=$(PLATFORMS)) \
-		--build-arg GOPROXY=$(GOPROXY) \
-		--build-arg BASE_IMAGE_PREFIX=$(BASE_IMAGE_PREFIX) \
+		--build-arg GOPROXY="$(GOPROXY)" \
+		--build-arg HTTP_PROXY="$(HTTP_PROXY)" \
+		--build-arg HTTPS_PROXY="$(HTTPS_PROXY)" \
+		--build-arg BASE_IMAGE_PREFIX="$(BASE_IMAGE_PREFIX)" \
 		$(PUSH) \
 		$(IMAGE_BUILD_EXTRA_OPTS) \
 		.

--- a/deploy/docker/matrixhub/Dockerfile
+++ b/deploy/docker/matrixhub/Dockerfile
@@ -16,10 +16,11 @@ WORKDIR /workspace
 
 ARG GOPROXY
 ENV GOPROXY=${GOPROXY}
+# HTTP_PROXY/HTTPS_PROXY are predefined Docker build args: declaring them as
+# ARG makes them available as env vars during RUN, without being persisted
+# into the image config.
 ARG HTTP_PROXY
-ENV HTTP_PROXY=${HTTP_PROXY}
 ARG HTTPS_PROXY
-ENV HTTPS_PROXY=${HTTPS_PROXY}
 
 RUN --mount=type=cache,target=/var/cache/apk \
     apk add gcc musl-dev
@@ -40,6 +41,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM ${BASE_IMAGE_PREFIX}/node:${NODE_IMAGE_VERSION} AS ui
 ENV CI=true
 WORKDIR /app/ui
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 COPY ui /app/ui/
 COPY api /app/api/
 RUN corepack enable
@@ -48,6 +51,11 @@ RUN pnpm build
 
 ##########################################
 FROM ${BASE_IMAGE_PREFIX}/library/alpine:${ALPINE_VERSION} AS matrixhub
+
+# Proxy args are declared (but not ENV'd) so networked steps below can use
+# them without persisting proxy settings into the runtime image.
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
 
 RUN --mount=type=cache,target=/var/cache/apk \
     apk add ca-certificates git && \


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
- pass `HTTP_PROXY`, `HTTPS_PROXY`, and `ALL_PROXY` from `make image-build` into Docker build args
- export those proxy variables in the Go builder and UI build stages so dependency downloads can use the local proxy during slow network conditions

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
- verified locally by rebuilding `matrixhub:local` with proxy args and starting MatrixHub successfully

#### Does this PR introduce a user-facing change?
```release-note
NONE
```