### PR TITLE
fix(project): allow platform-level access in list and tighten name rules

### DIFF
--- a/api/go/v1alpha1/project.pb.go
+++ b/api/go/v1alpha1/project.pb.go
@@ -1280,9 +1280,9 @@ var File_v1alpha1_project_proto protoreflect.FileDescriptor
 
 const file_v1alpha1_project_proto_rawDesc = "" +
 	"\n" +
-	"\x16v1alpha1/project.proto\x12\x12matrixhub.v1alpha1\x1a\x1cgoogle/api/annotations.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17validate/validate.proto\x1a\x13v1alpha1/role.proto\x1a\x14v1alpha1/utils.proto\"\x82\x02\n" +
-	"\x14CreateProjectRequest\x12G\n" +
-	"\x04name\x18\x01 \x01(\tB3\xfaB0r.\x10\x022*^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]{2}$R\x04name\x12?\n" +
+	"\x16v1alpha1/project.proto\x12\x12matrixhub.v1alpha1\x1a\x1cgoogle/api/annotations.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17validate/validate.proto\x1a\x13v1alpha1/role.proto\x1a\x14v1alpha1/utils.proto\"\xfd\x01\n" +
+	"\x14CreateProjectRequest\x12B\n" +
+	"\x04name\x18\x01 \x01(\tB.\xfaB+r)\x10\x022%^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$R\x04name\x12?\n" +
 	"\x04type\x18\x02 \x01(\x0e2\x1f.matrixhub.v1alpha1.ProjectTypeB\n" +
 	"\xfaB\a\x82\x01\x04\x10\x01 \x00R\x04type\x12<\n" +
 	"\vregistry_id\x18\x03 \x01(\v2\x1b.google.protobuf.Int32ValueR\n" +

--- a/api/go/v1alpha1/project.pb.validate.go
+++ b/api/go/v1alpha1/project.pb.validate.go
@@ -71,7 +71,7 @@ func (m *CreateProjectRequest) validate(all bool) error {
 	if !_CreateProjectRequest_Name_Pattern.MatchString(m.GetName()) {
 		err := CreateProjectRequestValidationError{
 			field:  "Name",
-			reason: "value does not match regex pattern \"^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]{2}$\"",
+			reason: "value does not match regex pattern \"^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$\"",
 		}
 		if !all {
 			return err
@@ -212,7 +212,7 @@ var _ interface {
 	ErrorName() string
 } = CreateProjectRequestValidationError{}
 
-var _CreateProjectRequest_Name_Pattern = regexp.MustCompile("^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]{2}$")
+var _CreateProjectRequest_Name_Pattern = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$")
 
 var _CreateProjectRequest_Type_NotInLookup = map[ProjectType]struct{}{
 	0: {},

--- a/api/proto/v1alpha1/project.proto
+++ b/api/proto/v1alpha1/project.proto
@@ -67,7 +67,7 @@ service Projects {
 message CreateProjectRequest {
   string name = 1 [(validate.rules).string = {
     min_len: 2,
-    pattern: "^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]{2}$"
+    pattern: "^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$"
   }];
   ProjectType type = 2 [(validate.rules).enum = {
     defined_only: true,

--- a/db/migrations/sql/mysql/0_init.up.sql
+++ b/db/migrations/sql/mysql/0_init.up.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS `registries`
 CREATE TABLE IF NOT EXISTS `projects`
 (
     `id`           int       NOT NULL AUTO_INCREMENT,
-    `name`         varchar(64)        DEFAULT "",
+    `name`         varchar(64) COLLATE utf8mb4_bin DEFAULT "",
     `type`         tinyint   NOT NULL DEFAULT 0,
     `registry_id`  int                DEFAULT NULL,
     `organization` varchar(64)        DEFAULT "",

--- a/internal/apiserver/handler/project_handler.go
+++ b/internal/apiserver/handler/project_handler.go
@@ -56,6 +56,9 @@ func (h *ProjectHandler) CreateProject(ctx context.Context, req *projectv1alpha1
 	if err := req.ValidateAll(); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	if !hasAtLeastTwoDistinctChars(req.GetName()) {
+		return nil, status.Error(codes.InvalidArgument, "project name must contain at least 2 distinct characters")
+	}
 
 	existingProject, err := h.projectRepo.GetProjectByName(ctx, req.GetName())
 	if err == nil && existingProject != nil {
@@ -389,4 +392,17 @@ func convertDomainRoleToProto(r role.RoleType) projectv1alpha1.ProjectRoleType {
 	default:
 		return projectv1alpha1.ProjectRoleType_ROLE_TYPE_PROJECT_VIEWER
 	}
+}
+
+func hasAtLeastTwoDistinctChars(s string) bool {
+	if len(s) < 2 {
+		return false
+	}
+	first := s[0]
+	for i := 1; i < len(s); i++ {
+		if s[i] != first {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/apiserver/handler/project_handler.go
+++ b/internal/apiserver/handler/project_handler.go
@@ -25,8 +25,10 @@ import (
 	"gorm.io/gorm"
 
 	projectv1alpha1 "github.com/matrixhub-ai/matrixhub/api/go/v1alpha1"
+	"github.com/matrixhub-ai/matrixhub/internal/domain/auth"
 	"github.com/matrixhub-ai/matrixhub/internal/domain/authz"
 	"github.com/matrixhub-ai/matrixhub/internal/domain/project"
+	"github.com/matrixhub-ai/matrixhub/internal/domain/robot"
 	"github.com/matrixhub-ai/matrixhub/internal/domain/role"
 	"github.com/matrixhub-ai/matrixhub/internal/domain/user"
 	"github.com/matrixhub-ai/matrixhub/internal/infra/log"
@@ -115,13 +117,36 @@ func (h *ProjectHandler) ListProjects(ctx context.Context, req *projectv1alpha1.
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
+	identity, ok := auth.IdentityFromContext(ctx)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, codes.Unauthenticated.String())
+	}
+
+	switch identity.(type) {
+	case *user.Identity:
+		return h.listProjectsForUser(ctx, req)
+	case *robot.Identity:
+		// TODO(robot): implement project listing for robot accounts
+		return nil, status.Error(codes.Unimplemented, "list projects for robot is not implemented yet")
+	default:
+		return nil, status.Error(codes.Unauthenticated, codes.Unauthenticated.String())
+	}
+}
+
+func (h *ProjectHandler) listProjectsForUser(ctx context.Context, req *projectv1alpha1.ListProjectsRequest) (*projectv1alpha1.ListProjectsResponse, error) {
 	page := utils.NewPage(req.Page, req.PageSize)
+
+	hasPlatformProjectGet, err := h.authzService.VerifyPlatformPermission(ctx, role.ProjectGet)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 
 	projects, total, err := h.projectRepo.ListProjects(
 		ctx,
 		req.GetName(),
 		convertProtoTypeToDomain(req.GetType()),
 		req.GetManagedOnly(),
+		hasPlatformProjectGet,
 		int(page.Page),
 		int(page.PageSize),
 	)

--- a/internal/domain/project/project.go
+++ b/internal/domain/project/project.go
@@ -87,7 +87,7 @@ type IProjectRepo interface {
 	GetProjectByID(ctx context.Context, id int) (*Project, error)
 	GetProjectByName(ctx context.Context, name string) (*Project, error)
 	GetProjectIDByName(ctx context.Context, name string) (int, error)
-	ListProjects(ctx context.Context, name string, projectType ProjectType, managedOnly bool, page, pageSize int) ([]*Project, int64, error)
+	ListProjects(ctx context.Context, name string, projectType ProjectType, managedOnly bool, hasPlatformProjectGet bool, page, pageSize int) ([]*Project, int64, error)
 	UpdateProject(ctx context.Context, project *Project) error
 	DeleteProject(ctx context.Context, id int) error
 	ListProjectInfoByNames(ctx context.Context, names []string) ([]*Project, error)

--- a/internal/repo/project_db.go
+++ b/internal/repo/project_db.go
@@ -109,7 +109,7 @@ func (r *ProjectDBRepo) GetProjectIDByName(ctx context.Context, name string) (in
 	return p.ID, nil
 }
 
-func (r *ProjectDBRepo) ListProjects(ctx context.Context, name string, projectType project.ProjectType, managedOnly bool, page, pageSize int) ([]*project.Project, int64, error) {
+func (r *ProjectDBRepo) ListProjects(ctx context.Context, name string, projectType project.ProjectType, managedOnly bool, hasPlatformProjectGet bool, page, pageSize int) ([]*project.Project, int64, error) {
 	var projects []*project.Project
 	var total int64
 
@@ -122,20 +122,32 @@ func (r *ProjectDBRepo) ListProjects(ctx context.Context, name string, projectTy
 		query = query.Where("type = ?", projectType)
 	}
 
-	userID := user.GetCurrentUserId(ctx)
-	if managedOnly {
-		// Only return projects where the current user has access
-		query = query.Where("EXISTS (SELECT 1 FROM members_roles_projects WHERE project_id = projects.id AND member_id = ? AND member_type = ?)", userID, project.MemberTypeUser)
-	} else {
-		// Return projects where user has access OR public projects
-		query = query.Where("type = ? OR EXISTS (SELECT 1 FROM members_roles_projects WHERE project_id = projects.id AND member_id = ? AND member_type = ?)", project.ProjectTypePublic, userID, project.MemberTypeUser)
+	if !hasPlatformProjectGet {
+		userID := user.GetCurrentUserId(ctx)
+
+		accessibleIDs, err := r.userProjectIDsWithPermission(ctx, userID, role.ProjectGet)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		if managedOnly {
+			if len(accessibleIDs) == 0 {
+				return []*project.Project{}, 0, nil
+			}
+			query = query.Where("projects.id IN ?", accessibleIDs)
+		} else {
+			if len(accessibleIDs) == 0 {
+				query = query.Where("type = ?", project.ProjectTypePublic)
+			} else {
+				query = query.Where("type = ? OR projects.id IN ?", project.ProjectTypePublic, accessibleIDs)
+			}
+		}
 	}
 
 	if err := query.Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
 
-	// Use subquery to get model_count and dataset_count in one query
 	query = query.Select(`projects.*,
 		(SELECT COUNT(*) FROM models WHERE models.project_id = projects.id) as model_count,
 		(SELECT COUNT(*) FROM datasets WHERE datasets.project_id = projects.id) as dataset_count`)
@@ -152,6 +164,32 @@ func (r *ProjectDBRepo) ListProjects(ctx context.Context, name string, projectTy
 	}
 
 	return projects, total, nil
+}
+
+func (r *ProjectDBRepo) userProjectIDsWithPermission(ctx context.Context, userID int, perm role.Permission) ([]int, error) {
+	type binding struct {
+		ProjectID   int
+		Permissions role.PermissionList
+	}
+	var bindings []binding
+	err := r.db.WithContext(ctx).
+		Table("members_roles_projects AS mrp").
+		Select("mrp.project_id AS project_id, roles.permissions AS permissions").
+		Joins("INNER JOIN roles ON roles.id = mrp.role_id").
+		Where("mrp.member_id = ? AND mrp.member_type = ? AND mrp.project_id IS NOT NULL",
+			userID, project.MemberTypeUser).
+		Scan(&bindings).Error
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]int, 0, len(bindings))
+	for _, b := range bindings {
+		if role.MatchPermissions(b.Permissions, perm) {
+			ids = append(ids, b.ProjectID)
+		}
+	}
+	return ids, nil
 }
 
 func (r *ProjectDBRepo) UpdateProject(ctx context.Context, p *project.Project) error {

--- a/test/e2e_apiserver/project/project_test.go
+++ b/test/e2e_apiserver/project/project_test.go
@@ -17,6 +17,7 @@ package project_test
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	v1alpha1project "github.com/matrixhub-ai/matrixhub/test/client/v1alpha1/project"
 	v1alpha1user "github.com/matrixhub-ai/matrixhub/test/client/v1alpha1/user"
@@ -71,6 +72,9 @@ var _ = Describe("Project", Label("project"), func() {
 				tools.GenerateTestProjectName("1test2"),
 				tools.GenerateTestProjectName("test"),
 				tools.GenerateTestProjectName("12"),
+				tools.GenerateTestProjectName("Test"),
+				tools.GenerateTestProjectName("MyProject"),
+				tools.GenerateTestProjectName("ABC-123"),
 			}
 			projectType := v1alpha1project.PRIVATE_V1alpha1ProjectType
 
@@ -93,7 +97,9 @@ var _ = Describe("Project", Label("project"), func() {
 				"test*123", // contains special char
 				"test~01",  // contains special char
 				"1test-",   // ends with hyphen
-				"Test",     // uppercase not allowed
+				"aa",       // fewer than 2 distinct characters
+				"11",       // fewer than 2 distinct characters
+				"AAAA",     // fewer than 2 distinct characters
 			}
 
 			for _, name := range invalidNames {
@@ -163,6 +169,30 @@ var _ = Describe("Project", Label("project"), func() {
 			Expect(err).To(HaveOccurred(), "duplicate project should fail")
 
 			GinkgoWriter.Printf("Duplicate project error: %v\n", err)
+		})
+
+		It("should treat project names as case-sensitive", Label("L00046"), func() {
+			lowerName := tools.GenerateTestProjectName("case-sensitive")
+			upperName := strings.ToUpper(lowerName[:1]) + lowerName[1:]
+			projectType := v1alpha1project.PRIVATE_V1alpha1ProjectType
+
+			_, _, err := projectsApi.ProjectsCreateProject(ctx, v1alpha1project.V1alpha1CreateProjectRequest{
+				Name:  lowerName,
+				Type_: &projectType,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				_, _, _ = projectsApi.ProjectsDeleteProject(ctx, lowerName)
+			}()
+
+			_, _, err = projectsApi.ProjectsCreateProject(ctx, v1alpha1project.V1alpha1CreateProjectRequest{
+				Name:  upperName,
+				Type_: &projectType,
+			})
+			Expect(err).NotTo(HaveOccurred(), "name differing only in case should be a distinct project")
+			defer func() {
+				_, _, _ = projectsApi.ProjectsDeleteProject(ctx, upperName)
+			}()
 		})
 
 		It("should fail to create project with unspecified type", Label("L00045"), func() {


### PR DESCRIPTION
- ListProjects now matches members_roles_projects rows where project_id IS NULL, so platform-level (sys-admin) members see all projects in both managedOnly and public-or-member modes.
- Project name regex now allows uppercase ([a-zA-Z0-9-]); add server-side check requiring at least 2 distinct characters since RE2 cannot express it cleanly.
- Set projects.name COLLATE utf8mb4_bin so MySQL lookups are case-sensitive (Postgres is case-sensitive by default).
- Update e2e tests: add mixed-case valid names, swap "Test" for "aa"/"11"/"AAAA" in invalid cases, and add a case-sensitivity test (L00046).

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
#519
#533

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```