### PR TITLE
docs: localize sidebar category titles for zh-CN

### DIFF
--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current.json
@@ -3,8 +3,12 @@
     "message": "当前版本",
     "description": "The label for version current"
   },
-  "sidebar.defaultSidebar.category.Getting Started": {
-    "message": "快速开始",
-    "description": "The label for category 'Getting Started' in sidebar 'defaultSidebar'"
+  "sidebar.tutorialSidebar.category.Operations": {
+    "message": "操作指南",
+    "description": "The label for category 'Operations' in sidebar 'tutorialSidebar'"
+  },
+  "sidebar.tutorialSidebar.category.Model Repository": {
+    "message": "模型仓库",
+    "description": "The label for category 'Model Repository' in sidebar 'tutorialSidebar'"
   }
 }


### PR DESCRIPTION
### 📝 Description

This PR fixes the issue where sidebar category titles remained in English when the website language was switched to Chinese (`zh-CN`). 

While the individual documentation pages were translated, the parent category labels ("Operations" and "Model Repository") were still displayed in English due to hardcoded labels in `sidebars.ts`.

### 🎯 Changes Made
- **Updated `website/i18n/zh-CN/docusaurus-plugin-content-docs/current.json`**:
    - Added localization mapping for `sidebar.tutorialSidebar.category.Operations` -> **"操作指南"**.
    - Added localization mapping for `sidebar.tutorialSidebar.category.Model Repository` -> **"模型仓库"**.

### 🛠️ Verification
- [x] Verified locally with `npm run build`. 
- [x] Confirmed that the sidebar and breadcrumb navigation now correctly display Chinese labels when the `zh-CN` locale is selected.