### PR TITLE
[Fix] Align localized blog slugs

### DIFF
--- a/website/i18n/zh-CN/docusaurus-plugin-content-blog/2026-04-27-deepseek-v4-distribution.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-blog/2026-04-27-deepseek-v4-distribution.md
@@ -1,4 +1,5 @@
 ---
+slug: /deepseek-v4-distribution
 title: DeepSeek v4 跑不起来？99% 的人都卡在分发
 description: 为什么企业环境里的 DeepSeek 落地经常卡在分发层，以及 MatrixHub 能解决什么问题。
 ---

--- a/website/i18n/zh-CN/docusaurus-plugin-content-blog/2026-04-27-examples.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-blog/2026-04-27-examples.md
@@ -1,4 +1,5 @@
 ---
+slug: /examples
 title: 示例
 description: MatrixHub 在企业内网里的实际使用示例，重点展示模型缓存和分发加速效果。
 ---


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Aligns zh-CN blog post slugs with their English counterparts so Docusaurus generates matching localized blog URLs and the locale dropdown does not point to missing pages.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

Verified with `npm run build` in `website`. The build now emits both `/blog/<slug>` and `/zh-CN/blog/<slug>` for the affected posts.

#### Does this PR introduce a user-facing change?

```release-note
Fixed Chinese blog language-switch links for localized MatrixHub website posts.
```