### PR TITLE
chore(ui): pin pnpm 10

### DIFF
--- a/ui/agents/stack.md
+++ b/ui/agents/stack.md
@@ -6,7 +6,7 @@ Technology choices, global wirings, and day-to-day commands. Everything here is 
 
 ## Stack
 
-- `pnpm` — package manager
+- `pnpm 10.x` — package manager (`package.json` pins the Corepack version)
 - `Vite` — dev server / build
 - `React 19`
 - `TypeScript`

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,11 @@
   "name": "matrixhub-ui",
   "private": true,
   "version": "0.0.0",
+  "packageManager": "pnpm@10.17.0",
   "type": "module",
+  "engines": {
+    "pnpm": ">=10 <11"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Pins the UI package manager metadata to `pnpm@10.17.0` for Corepack-based environments.
- Adds an `engines.pnpm` constraint for `>=10 <11`.
- Updates the UI stack docs to state the pnpm 10.x baseline.

This keeps local, CI, and image build environments aligned on pnpm 10.x.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Validated locally:

- `pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm --version` returned `10.17.0`
- `pnpm lint`
- `pnpm typecheck`
- commit hook `npx lint-staged`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
