### PR TITLE
fix: show model command dialogs

### DIFF
--- a/ui/src/features/models/components/ModelCommandDialog.module.css
+++ b/ui/src/features/models/components/ModelCommandDialog.module.css
@@ -1,0 +1,32 @@
+.codeBlock {
+  position: relative;
+  border: 1px solid var(--mantine-color-gray-2);
+  border-radius: var(--mantine-radius-sm);
+  background: var(--mantine-color-gray-0);
+}
+
+.code {
+  display: block;
+  padding: var(--mantine-spacing-md);
+  padding-right: calc(var(--mantine-spacing-xl) + var(--mantine-spacing-sm));
+  color: var(--mantine-color-gray-9);
+  font-size: var(--mantine-font-size-sm);
+  line-height: var(--mantine-line-height-md);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.copyButton {
+  position: absolute;
+  top: var(--mantine-spacing-xs);
+  right: var(--mantine-spacing-xs);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease;
+}
+
+.codeBlock:hover .copyButton,
+.codeBlock:focus-within .copyButton {
+  opacity: 1;
+  pointer-events: auto;
+}

--- a/ui/src/features/models/components/ModelCommandDialog.module.css
+++ b/ui/src/features/models/components/ModelCommandDialog.module.css
@@ -20,13 +20,5 @@
   position: absolute;
   top: var(--mantine-spacing-xs);
   right: var(--mantine-spacing-xs);
-  opacity: 0;
-  pointer-events: none;
   transition: opacity 120ms ease;
-}
-
-.codeBlock:hover .copyButton,
-.codeBlock:focus-within .copyButton {
-  opacity: 1;
-  pointer-events: auto;
 }

--- a/ui/src/features/models/components/ModelCommandDialog.tsx
+++ b/ui/src/features/models/components/ModelCommandDialog.tsx
@@ -28,6 +28,8 @@ interface CommandCodeBlockProps {
   command: string
 }
 
+const HF_ENDPOINT_PLACEHOLDER = window.location.origin
+
 function buildModelCommand(type: ModelCommandType, modelPath: string, hfEndpoint: string) {
   const commandByType = {
     upload: `hf upload ${modelPath} . .`,
@@ -66,7 +68,7 @@ export function ModelCommandDialog({
   const command = buildModelCommand(
     type,
     modelPath,
-    systemConfigQuery.data?.endpoints?.hfBase ?? '',
+    systemConfigQuery.data?.endpoints?.hfBase || HF_ENDPOINT_PLACEHOLDER,
   )
 
   return (

--- a/ui/src/features/models/components/ModelCommandDialog.tsx
+++ b/ui/src/features/models/components/ModelCommandDialog.tsx
@@ -3,11 +3,13 @@ import {
   Button,
   Code,
   Group,
+  Skeleton,
   Stack,
   Text,
 } from '@mantine/core'
 import { useTranslation } from 'react-i18next'
 
+import { useSystemConfig } from '@/features/system/system.query'
 import { CopyValueButton } from '@/shared/components/CopyValueButton'
 import { ModalWrapper } from '@/shared/components/ModalWrapper'
 
@@ -26,16 +28,14 @@ interface CommandCodeBlockProps {
   command: string
 }
 
-const HF_ENDPOINT_PLACEHOLDER = 'https://example.matrixhub.io'
-
-function buildModelCommand(type: ModelCommandType, modelPath: string) {
+function buildModelCommand(type: ModelCommandType, modelPath: string, hfEndpoint: string) {
   const commandByType = {
     upload: `hf upload ${modelPath} . .`,
     download: `hf download ${modelPath}`,
     use: `vllm serve ${modelPath}`,
   }
 
-  return `export HF_ENDPOINT=${HF_ENDPOINT_PLACEHOLDER}\n${commandByType[type]}`
+  return `export HF_ENDPOINT=${hfEndpoint}\n${commandByType[type]}`
 }
 
 function CommandCodeBlock({ command }: CommandCodeBlockProps) {
@@ -62,7 +62,12 @@ export function ModelCommandDialog({
   onClose,
 }: ModelCommandDialogProps) {
   const { t } = useTranslation()
-  const command = buildModelCommand(type, modelPath)
+  const systemConfigQuery = useSystemConfig()
+  const command = buildModelCommand(
+    type,
+    modelPath,
+    systemConfigQuery.data?.endpoints?.hfBase ?? '',
+  )
 
   return (
     <ModalWrapper
@@ -83,7 +88,9 @@ export function ModelCommandDialog({
           {t(`model.detail.commandDialog.${type}.description`)}
         </Text>
 
-        <CommandCodeBlock command={command} />
+        {systemConfigQuery.isPending
+          ? <Skeleton height={92} radius="sm" />
+          : <CommandCodeBlock command={command} />}
       </Stack>
     </ModalWrapper>
   )

--- a/ui/src/features/models/components/ModelCommandDialog.tsx
+++ b/ui/src/features/models/components/ModelCommandDialog.tsx
@@ -1,0 +1,90 @@
+import {
+  Box,
+  Button,
+  Code,
+  Group,
+  Stack,
+  Text,
+} from '@mantine/core'
+import { useTranslation } from 'react-i18next'
+
+import { CopyValueButton } from '@/shared/components/CopyValueButton'
+import { ModalWrapper } from '@/shared/components/ModalWrapper'
+
+import classes from './ModelCommandDialog.module.css'
+
+export type ModelCommandType = 'upload' | 'download' | 'use'
+
+interface ModelCommandDialogProps {
+  opened: boolean
+  type: ModelCommandType
+  modelPath: string
+  onClose: () => void
+}
+
+interface CommandCodeBlockProps {
+  command: string
+}
+
+const HF_ENDPOINT_PLACEHOLDER = 'https://example.matrixhub.io'
+
+function buildModelCommand(type: ModelCommandType, modelPath: string) {
+  const commandByType = {
+    upload: `hf upload ${modelPath} . .`,
+    download: `hf download ${modelPath}`,
+    use: `vllm serve ${modelPath}`,
+  }
+
+  return `export HF_ENDPOINT=${HF_ENDPOINT_PLACEHOLDER}\n${commandByType[type]}`
+}
+
+function CommandCodeBlock({ command }: CommandCodeBlockProps) {
+  return (
+    <Box className={classes.codeBlock}>
+      <CopyValueButton
+        value={command}
+        timeout={1500}
+        iconClassName={classes.copyButton}
+      >
+      </CopyValueButton>
+
+      <Code block className={classes.code}>
+        {command}
+      </Code>
+    </Box>
+  )
+}
+
+export function ModelCommandDialog({
+  opened,
+  type,
+  modelPath,
+  onClose,
+}: ModelCommandDialogProps) {
+  const { t } = useTranslation()
+  const command = buildModelCommand(type, modelPath)
+
+  return (
+    <ModalWrapper
+      title={t(`model.detail.commandDialog.${type}.title`)}
+      opened={opened}
+      onClose={onClose}
+      size="lg"
+      footer={(
+        <Group justify="flex-end">
+          <Button onClick={onClose}>
+            {t('common.confirm')}
+          </Button>
+        </Group>
+      )}
+    >
+      <Stack gap="md">
+        <Text size="sm" c="dimmed">
+          {t(`model.detail.commandDialog.${type}.description`)}
+        </Text>
+
+        <CommandCodeBlock command={command} />
+      </Stack>
+    </ModalWrapper>
+  )
+}

--- a/ui/src/features/models/pages/ModelDetailPage.tsx
+++ b/ui/src/features/models/pages/ModelDetailPage.tsx
@@ -4,7 +4,11 @@ import {
   Tabs,
 } from '@mantine/core'
 import { ProjectRoleType } from '@matrixhub/api-ts/v1alpha1/role.pb.ts'
-import { IconDownload, IconCloudUpload } from '@tabler/icons-react'
+import {
+  IconCloudUpload,
+  IconDownload,
+  IconTerminal2,
+} from '@tabler/icons-react'
 import {
   Link,
   getRouteApi,
@@ -15,8 +19,10 @@ import { type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useProjectRole } from '@/features/auth/useProjectRole'
+import { ModelCommandDialog, type ModelCommandType } from '@/features/models/components/ModelCommandDialog'
 import { buildModelBadges, buildModelMetaItems } from '@/features/models/models.utils'
 import { ResourceDetailHeader } from '@/shared/components/ResourceDetailHeader'
+import { usePayloadModal } from '@/shared/hooks/usePayloadModal'
 
 interface ModelDetailPageProps {
   children: ReactNode
@@ -38,8 +44,10 @@ export function ModelDetailPage({
   } = useParams()
 
   const { model } = useLoaderData()
+  const commandDialog = usePayloadModal<ModelCommandType>()
   const projectRole = useProjectRole(projectId)
   const hasSettingsRight = projectRole === ProjectRoleType.ROLE_TYPE_PROJECT_ADMIN
+  const modelPath = `${model.project ?? projectId}/${model.name?.trim() || modelId}`
 
   const tabRoutes = linkOptions([
     {
@@ -97,8 +105,33 @@ export function ModelDetailPage({
           metaItems={buildModelMetaItems(model, projectId, i18n.t.bind(i18n))}
           actions={(
             <>
-              <Button color="cyan" fw="normal" variant="light" leftSection={<IconCloudUpload size={16} />}>{t('model.detail.upload')}</Button>
-              <Button color="cyan" fw="normal" variant="light" leftSection={<IconDownload size={16} />}>{t('model.detail.download')}</Button>
+              <Button
+                color="cyan"
+                fw="normal"
+                variant="light"
+                leftSection={<IconCloudUpload size={16} />}
+                onClick={() => commandDialog.open('upload')}
+              >
+                {t('model.detail.upload')}
+              </Button>
+              <Button
+                color="cyan"
+                fw="normal"
+                variant="light"
+                leftSection={<IconDownload size={16} />}
+                onClick={() => commandDialog.open('download')}
+              >
+                {t('model.detail.download')}
+              </Button>
+              <Button
+                color="cyan"
+                fw="normal"
+                variant="light"
+                leftSection={<IconTerminal2 size={16} />}
+                onClick={() => commandDialog.open('use')}
+              >
+                {t('model.detail.use')}
+              </Button>
             </>
           )}
         />
@@ -121,6 +154,14 @@ export function ModelDetailPage({
       </Tabs>
 
       {children}
+      {commandDialog.payload && (
+        <ModelCommandDialog
+          opened={commandDialog.opened}
+          type={commandDialog.payload}
+          modelPath={modelPath}
+          onClose={commandDialog.close}
+        />
+      )}
     </Box>
   )
 }

--- a/ui/src/features/system/system.query.ts
+++ b/ui/src/features/system/system.query.ts
@@ -1,0 +1,20 @@
+import { SystemService } from '@matrixhub/api-ts/v1alpha1/system.pb'
+import { queryOptions, useQuery } from '@tanstack/react-query'
+
+export const systemKeys = {
+  all: ['system'] as const,
+  config: () => [...systemKeys.all, 'config'] as const,
+}
+
+export function systemConfigQueryOptions() {
+  return queryOptions({
+    queryKey: systemKeys.config(),
+    queryFn: () => SystemService.GetSystemConfig({}),
+    staleTime: Infinity,
+    gcTime: Infinity,
+  })
+}
+
+export function useSystemConfig() {
+  return useQuery(systemConfigQueryOptions())
+}

--- a/ui/src/locales/en/model.json
+++ b/ui/src/locales/en/model.json
@@ -18,10 +18,25 @@
   "detail": {
     "upload": "Upload Model Files",
     "download": "Download Model",
+    "use": "Use This Model",
     "desc": "Model Introduction",
     "tree": "Model Files",
     "setting": "Settings",
-    "history": "Commit History"
+    "history": "Commit History",
+    "commandDialog": {
+      "upload": {
+        "title": "Upload Model Files",
+        "description": "Run this command to upload local files to this model."
+      },
+      "download": {
+        "title": "Download Model",
+        "description": "Run this command to download this model."
+      },
+      "use": {
+        "title": "Use This Model",
+        "description": "Run this command to serve this model with vLLM."
+      }
+    }
   },
   "settings": {
     "delete": {

--- a/ui/src/locales/zh/model.json
+++ b/ui/src/locales/zh/model.json
@@ -18,10 +18,25 @@
   "detail": {
     "upload": "上传模型文件",
     "download": "下载模型文件",
+    "use": "使用此模型",
     "desc": "模型介绍",
     "tree": "模型文件",
     "setting": "模型设置",
-    "history": "{{count}} 条提交"
+    "history": "{{count}} 条提交",
+    "commandDialog": {
+      "upload": {
+        "title": "上传模型文件",
+        "description": "运行以下命令将本地文件上传到该模型。"
+      },
+      "download": {
+        "title": "下载模型文件",
+        "description": "运行以下命令下载该模型。"
+      },
+      "use": {
+        "title": "使用此模型",
+        "description": "运行以下命令通过 vLLM 启动该模型。"
+      }
+    }
   },
   "settings": {
     "delete": {

--- a/ui/src/shared/components/CopyValueButton.tsx
+++ b/ui/src/shared/components/CopyValueButton.tsx
@@ -17,6 +17,7 @@ interface CopyValueButtonProps {
   value: string
   timeout?: number
   iconSize?: number
+  iconClassName?: string
   color?: string
   children?: (props: CopyRenderProps) => ReactNode
 }
@@ -25,6 +26,7 @@ export function CopyValueButton({
   value,
   color = 'gray',
   timeout = 1500,
+  iconClassName,
   iconSize = 16,
   children,
 }: CopyValueButtonProps) {
@@ -53,6 +55,8 @@ export function CopyValueButton({
                       variant="subtle"
                       color={color}
                       onClick={copy}
+                      className={iconClassName}
+                      aria-label={copied ? t('shared.copyValueButton.copied') : t('shared.copyValueButton.copy')}
                     >
                       <IconCopy size={iconSize} />
                     </ActionIcon>


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adds model detail command dialogs for uploading model files, downloading models, and using a model with vLLM.

The dialogs show shell commands in highlighted code blocks, support copying the full command text, and keep the copy button visible only while the code area is hovered or focused.

The command endpoint is intentionally displayed as `<MATRIXHUB_ENDPOINT>` because the UI does not currently have a reliable endpoint source.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #435

#### Special notes for your reviewer:

Validation run locally:

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `npx -y react-doctor@latest . --verbose`

`pnpm build` still reports the existing large chunk warning. React Doctor still reports repo-wide pre-existing findings, but no remaining finding points to `ModelCommandDialog`.

Browser smoke reached `/login` without authenticated backend state, so the dialog click flow was not manually exercised in-browser.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Model detail pages now show upload, download, and use commands in copyable highlighted command dialogs.
```
