### PR TITLE
[Docs] Update GitHub organization links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ _As contributors and maintainers of this project, and in the interest of fosteri
 ## Before You Start
 
 - Read the [Code of Conduct](CODE_OF_CONDUCT.md).
-- Check open [issues](https://github.com/matrixhub/matrixhub/issues) and [pull requests](https://github.com/matrixhub/matrixhub/pulls) to avoid duplicate work.
+- Check open [issues](https://github.com/matrixhub-ai/matrixhub/issues) and [pull requests](https://github.com/matrixhub-ai/matrixhub/pulls) to avoid duplicate work.
 
 ## Local Development
 

--- a/website/src/pages/community.tsx
+++ b/website/src/pages/community.tsx
@@ -9,7 +9,7 @@ const sections = [
     description:
       'Star and follow the MatrixHub repository for updates, issues, and releases.',
     linkText: 'Visit Repository →',
-    href: 'https://github.com/matrixhub',
+    href: 'https://github.com/matrixhub-ai',
   },
   {
     emoji: '🤝',


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Updates GitHub links in `CONTRIBUTING.md` and the community page to point at the `matrixhub-ai` organization.

#### Which issue(s) this PR fixes:

N/A - no issue.

#### Special notes for your reviewer:

N/A - link-only update.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
