### PR TITLE
feat(deploy): add self-hosted runner for internal auto-deploy

### DIFF
--- a/.github/workflows/build-image-latest.yaml
+++ b/.github/workflows/build-image-latest.yaml
@@ -7,11 +7,149 @@ on:
 
 permissions: write-all
 
+env:
+  # Helm v3 uses client-side apply by default — no field manager conflicts
+  HELM_VERSION: v3.18.4
+  CHART_NAME: matrixhub
+
 jobs:
-  call-workflow:
+  # Job 0: Compute version string, used by all downstream jobs
+  # Format: <latest-tag>-<sha> (e.g. 0.0.2-rc.11-1a016ee)
+  compute-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Compute version
+        id: ver
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.1")
+          VERSION="${LATEST_TAG#v}-${SHORT_SHA}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Version: ${VERSION}"
+
+  # Job 1: Build and push image to ghcr.io
+  # Image tag uses 'v' prefix (e.g. v0.0.1-d3e4b1b) to distinguish from chart tag,
+  # since both live in the same OCI repo path (ghcr.io/<owner>/matrixhub).
+  build-image:
+    needs: compute-version
     uses: ./.github/workflows/call-release-image.yaml
     with:
       ref: 'main'
-      tagoverride: 'latest'
-      add_sha_tag: true
+      tagoverride: v${{ needs.compute-version.outputs.version }}
     secrets: inherit
+
+  # Job 2: Package and push Helm chart to ghcr.io as OCI artifact
+  push-chart:
+    needs: compute-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package and push chart
+        run: |
+          cd deploy/charts
+          VERSION="${{ needs.compute-version.outputs.version }}"
+
+          echo "Chart version: ${VERSION}"
+
+          # Chart version = VERSION (no v); appVersion + image tag = vVERSION (matches image)
+          sed -i "s/^version:.*/version: ${VERSION}/" ${{ env.CHART_NAME }}/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"v${VERSION}\"/" ${{ env.CHART_NAME }}/Chart.yaml
+          sed -i "s|tag: \"\"|tag: v${VERSION}|" ${{ env.CHART_NAME }}/values.yaml
+
+          helm lint ${{ env.CHART_NAME }}
+          helm package ${{ env.CHART_NAME }}
+
+          REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          # Chart and image share the same OCI repo, but with different tags:
+          #   image: v${VERSION} (e.g. v0.0.1-d3e4b1b)
+          #   chart: ${VERSION}  (e.g. 0.0.1-d3e4b1b, no 'v' prefix)
+          helm push "${{ env.CHART_NAME }}-${VERSION}.tgz" oci://ghcr.io/${REPO_OWNER}
+
+          echo "Chart pushed: oci://ghcr.io/${REPO_OWNER}/${{ env.CHART_NAME }}:${VERSION}"
+
+  # Job 3: Deploy to internal cluster using the just-built artifacts
+  deploy-internal:
+    needs: [compute-version, build-image, push-chart]
+    runs-on: self-hosted
+    if: success()
+    steps:
+      # Remove any stale helm from /usr/local/bin so setup-helm's version wins in PATH
+      - name: Clean stale helm
+        run: |
+          sudo rm -f /usr/local/bin/helm /usr/bin/helm 2>/dev/null || \
+            rm -f /usr/local/bin/helm /usr/bin/helm 2>/dev/null || true
+          echo "Cleaned. which helm: $(which helm 2>&1 || echo none)"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Verify Helm version
+        run: |
+          which helm
+          helm version --short
+
+      - name: Login to GHCR (avoids broken anonymous auth flow)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" --password-stdin
+
+      - name: Pull chart and deploy
+        run: |
+          VERSION="${{ needs.compute-version.outputs.version }}"
+          # Runner pod has outbound internet; pull chart directly from ghcr.io
+          # (the daocloud mirror does NOT proxy OCI auth properly).
+          # Chart uses unprefixed version tag (image uses v-prefixed) to share OCI repo.
+          CHART_REF="${CHART_REGISTRY:-oci://ghcr.io/matrixhub-ai}/${{ env.CHART_NAME }}"
+          VALUES_FILE="${VALUES_FILE:-/etc/matrixhub/values-internal.yaml}"
+          NAMESPACE="${DEPLOY_NAMESPACE:-matrixhub}"
+
+          echo "Deploying version: ${VERSION}"
+
+          rm -rf /tmp/chart
+          helm pull "${CHART_REF}" --version "${VERSION}" --untar --destination /tmp/chart
+
+          VALS_ARGS=""
+          if [ -f "${VALUES_FILE}" ]; then
+            VALS_ARGS="-f ${VALUES_FILE}"
+            echo "Using values from: ${VALUES_FILE}"
+          fi
+
+          # Image tag has 'v' prefix; chart version doesn't.
+          # Helm v3 uses client-side 3-way merge by default (no --force-conflicts needed)
+          helm upgrade ${{ env.CHART_NAME }} /tmp/chart/${{ env.CHART_NAME }} \
+            -n "${NAMESPACE}" \
+            ${VALS_ARGS} \
+            --set apiserver.image.tag="v${VERSION}" \
+            --wait --timeout 300s
+
+          rm -rf /tmp/chart
+          echo "Deploy complete. Version=${VERSION}"
+
+      - name: Verify deployment
+        run: |
+          NAMESPACE="${DEPLOY_NAMESPACE:-matrixhub}"
+          kubectl -n "${NAMESPACE}" rollout status deployment/matrixhub --timeout=60s
+          echo "---"
+          kubectl -n "${NAMESPACE}" get pods -l app=matrixhub -o wide

--- a/.github/workflows/build-image-latest.yaml
+++ b/.github/workflows/build-image-latest.yaml
@@ -146,10 +146,3 @@ jobs:
 
           rm -rf /tmp/chart
           echo "Deploy complete. Version=${VERSION}"
-
-      - name: Verify deployment
-        run: |
-          NAMESPACE="${DEPLOY_NAMESPACE:-matrixhub}"
-          kubectl -n "${NAMESPACE}" rollout status deployment/matrixhub --timeout=60s
-          echo "---"
-          kubectl -n "${NAMESPACE}" get pods -l app=matrixhub -o wide

--- a/deploy/autoupdate/README.md
+++ b/deploy/autoupdate/README.md
@@ -1,0 +1,58 @@
+# MatrixHub Internal Auto-Deploy
+
+When a PR merges to `main`, GitHub Actions builds the image, then the `deploy-internal` job runs on a self-hosted runner inside the internal K8s cluster to execute `helm upgrade`.
+
+## Architecture
+
+```
+PR merge → GitHub Actions → push image (cloud) → deploy-internal (self-hosted runner in K8s) → helm upgrade
+```
+
+The runner Pod makes an **outbound** HTTPS connection to GitHub (long-poll for jobs). No inbound ports needed.
+
+## Setup
+
+### 1. Create a GitHub PAT
+
+Go to https://github.com/settings/tokens and create a token with `repo` scope (classic) or `Administration` read/write (fine-grained).
+
+### 2. Edit the Secret in runner-deployment.yaml
+
+Replace `ghp_REPLACE_WITH_YOUR_PAT` with your actual token.
+
+### 3. Review values-internal.yaml
+
+The ConfigMap in `runner-deployment.yaml` contains the Helm values for internal deployment. Adjust image registries and storage sizes as needed.
+
+### 4. Deploy
+
+```bash
+kubectl apply -f deploy/autoupdate/runner-deployment.yaml
+```
+
+### 5. Verify runner registered
+
+```bash
+kubectl -n matrixhub logs -l app=github-runner -f
+```
+
+You should see the runner register and start listening. Also check:
+- GitHub repo → Settings → Actions → Runners — the runner should appear as "Idle".
+
+### 6. Test
+
+Merge any PR to `main`. The `deploy-internal` job should appear in the Actions run and execute on the internal runner.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Runner not appearing in GitHub | Check PAT scope, check pod logs for registration errors |
+| `helm upgrade` fails | Check RBAC (ServiceAccount needs ClusterRole), check values |
+| Image pull fails | Verify `ghcr.m.daocloud.io` is accessible from the cluster |
+| Runner shows "offline" | Pod might have restarted — check `kubectl get pods` |
+
+## Files
+
+- `runner-deployment.yaml` — Runner Pod + ServiceAccount + RBAC + Secret + ConfigMap
+- `values-internal.yaml` — Source-of-truth for internal Helm values (also embedded in ConfigMap)

--- a/deploy/autoupdate/README.md
+++ b/deploy/autoupdate/README.md
@@ -5,54 +5,131 @@ When a PR merges to `main`, GitHub Actions builds the image, then the `deploy-in
 ## Architecture
 
 ```
-PR merge → GitHub Actions → push image (cloud) → deploy-internal (self-hosted runner in K8s) → helm upgrade
+PR merge → GitHub Actions → push image + chart (cloud) → deploy-internal (self-hosted runner in K8s) → helm upgrade
 ```
 
-The runner Pod makes an **outbound** HTTPS connection to GitHub (long-poll for jobs). No inbound ports needed.
+The runner pod makes an **outbound** HTTPS connection to GitHub (long-poll for jobs). No inbound ports required.
 
-## Setup
+The runner is **org-level** by default (registered against `matrixhub-ai`), so any repo in the org's runner group can use it.
 
-### 1. Create a GitHub PAT
+## Auth modes
 
-Go to https://github.com/settings/tokens and create a token with `repo` scope (classic) or `Administration` read/write (fine-grained).
+Pick **one** when bootstrapping (see comments in `runner-deployment.yaml`):
 
-### 2. Edit the Secret in runner-deployment.yaml
+| Mode | Pros | Cons | When to use |
+|------|------|------|-------------|
+| **A — Registration token + PVC** | Owner only needs to issue a 1-hour token; no long-lived secret in K8s | Loses identity if PVC is lost — needs a fresh token from the owner | Standard. Recommended starting point. |
+| **B — PAT (admin:org)** | Self-healing across PVC loss; no owner involvement after setup | Long-lived secret stored in K8s; need a bot account with org admin | High-availability or no-bus-factor setups. |
 
-Replace `ghp_REPLACE_WITH_YOUR_PAT` with your actual token.
+The runner's long-term identity is stored in `/runner/.runner` + `.credentials` (lifetime ≈ 6 months, auto-renewed). The PVC `github-runner-data` persists these across pod restarts.
 
-### 3. Review values-internal.yaml
+## Setup — Mode A (registration token + PVC)
 
-The ConfigMap in `runner-deployment.yaml` contains the Helm values for internal deployment. Adjust image registries and storage sizes as needed.
+### 1. Org owner creates a runner group (one-time)
 
-### 4. Deploy
+```
+https://github.com/organizations/matrixhub-ai/settings/actions/runner-groups
+```
+
+- New group → `internal-deploy`
+- Repository access → Selected repositories → `matrixhub`
+
+### 2. Org owner generates a registration token
+
+UI: `Settings → Actions → Runners → New self-hosted runner` shows a token.
+
+Or via API (anyone with `admin:org` scope on a PAT):
+
+```bash
+curl -X POST -H "Authorization: Bearer <admin-pat>" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/orgs/matrixhub-ai/actions/runners/registration-token
+```
+
+The returned `token` is valid for 1 hour.
+
+### 3. Apply the manifests + secret
 
 ```bash
 kubectl apply -f deploy/autoupdate/runner-deployment.yaml
+
+kubectl -n matrixhub-runner create secret generic github-runner-secret \
+  --from-literal=runner-token=AAAA_THE_1H_TOKEN
 ```
 
-### 5. Verify runner registered
+### 4. (Optional) Wipe the secret after registration
+
+The credentials are now in the PVC. The registration token has been consumed and is useless:
 
 ```bash
-kubectl -n matrixhub logs -l app=github-runner -f
+kubectl -n matrixhub-runner delete secret github-runner-secret
 ```
 
-You should see the runner register and start listening. Also check:
-- GitHub repo → Settings → Actions → Runners — the runner should appear as "Idle".
+## Setup — Mode B (PAT)
 
-### 6. Test
+In `runner-deployment.yaml`, swap the env block:
 
-Merge any PR to `main`. The `deploy-internal` job should appear in the Actions run and execute on the internal runner.
+```yaml
+# comment out RUNNER_TOKEN, enable ACCESS_TOKEN
+- name: ACCESS_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: github-runner-secret
+      key: github-pat
+```
+
+Then:
+
+```bash
+kubectl -n matrixhub-runner create secret generic github-runner-secret \
+  --from-literal=github-pat=ghp_xxx
+kubectl apply -f deploy/autoupdate/runner-deployment.yaml
+```
+
+## Verify
+
+```bash
+kubectl -n matrixhub-runner get pods
+kubectl -n matrixhub-runner logs -l app=github-runner --tail=20
+```
+
+Expect:
+```
+√ Connected to GitHub
+Listening for Jobs
+```
+
+And in GitHub:
+```
+https://github.com/organizations/matrixhub-ai/settings/actions/runners
+```
+The runner should appear as **Idle**.
+
+## Test end-to-end
+
+Merge any PR to `main`. The `deploy-internal` job should be dispatched to this runner and complete `helm upgrade` against the internal cluster.
+
+## Customization
+
+| Env var on runner Pod | Default | Effect |
+|-----------------------|---------|--------|
+| `CHART_REGISTRY` | `oci://ghcr.io/matrixhub-ai` | Where to pull the chart from |
+| `DEPLOY_NAMESPACE` | `matrixhub` | Target namespace for `helm upgrade` |
+| `VALUES_FILE` | `/etc/matrixhub/values-internal.yaml` | Helm values file (from ConfigMap) |
+
+Per-environment values live in the `github-runner-values` ConfigMap (also editable post-deploy without changing the workflow).
 
 ## Troubleshooting
 
-| Symptom | Fix |
-|---------|-----|
-| Runner not appearing in GitHub | Check PAT scope, check pod logs for registration errors |
-| `helm upgrade` fails | Check RBAC (ServiceAccount needs ClusterRole), check values |
-| Image pull fails | Verify `ghcr.m.daocloud.io` is accessible from the cluster |
-| Runner shows "offline" | Pod might have restarted — check `kubectl get pods` |
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Pod CrashLoop, "401 Unauthorized" | Owner deleted the runner from GitHub UI, or PVC was reset | Wipe PVC + new registration token + re-bootstrap |
+| Pod CrashLoop, "Token is expired" (mode A, first start) | Took > 1 hour to apply | Get a fresh token, recreate secret, restart pod |
+| `helm upgrade` fails RBAC | Cluster RBAC blocks ClusterRole binding | Adjust the ClusterRole in `runner-deployment.yaml` |
+| `helm pull` 403 | Auth flow broken | Check `helm registry login` step in workflow has access to a working GITHUB_TOKEN |
+| Runner appears offline | Pod evicted / node down | `kubectl describe pod` and check events |
 
 ## Files
 
-- `runner-deployment.yaml` — Runner Pod + ServiceAccount + RBAC + Secret + ConfigMap
-- `values-internal.yaml` — Source-of-truth for internal Helm values (also embedded in ConfigMap)
+- `runner-deployment.yaml` — Namespace + SA + ClusterRoleBinding + PVC + ConfigMap + Deployment
+- `values-internal.yaml` — Source-of-truth for internal Helm values (also embedded in the ConfigMap above)

--- a/deploy/autoupdate/runner-deployment.yaml
+++ b/deploy/autoupdate/runner-deployment.yaml
@@ -1,17 +1,35 @@
 # GitHub Actions Self-Hosted Runner for MatrixHub auto-deploy
 #
-# Prerequisites:
-#   1. Create a GitHub Personal Access Token (PAT) with "repo" scope
-#      or a fine-grained token with "Administration" read/write on the repo
-#   2. Create the secret manually:
-#      kubectl -n matrixhub-runner create secret generic github-runner-secret \
-#        --from-literal=github-pat=ghp_YOUR_TOKEN_HERE
-#   3. kubectl apply -f runner-deployment.yaml
+# This deploys an org-level (or repo-level) self-hosted runner inside an
+# internal K8s cluster. The runner makes outbound HTTPS long-poll
+# connections to github.com — no inbound ports, no webhook receiver.
 #
-# The runner registers itself with GitHub on startup (outbound HTTPS only,
-# no inbound ports needed). When build-image-latest.yaml triggers the
-# deploy-internal job (runs-on: self-hosted), it executes helm upgrade
-# inside this pod.
+# Two auth modes (pick ONE — see comments in the Deployment env block):
+#
+#   A) Registration token (one-time, persisted via PVC)
+#      - Owner generates an org-level registration token (UI or API).
+#      - Token is valid for 1 hour; runner uses it once to register.
+#      - Runner credentials (.runner, .credentials, ~6-month lifetime) are
+#        written to the mounted PVC. Pod restarts reuse those credentials
+#        without needing a new registration token.
+#      - Set RUNNER_TOKEN secret key; leave ACCESS_TOKEN unset.
+#
+#   B) Long-lived PAT (admin:org on org-level, or admin on repo-level)
+#      - Bot account creates a PAT and stores it in the secret.
+#      - Runner mints a fresh registration token on each startup.
+#      - More resilient (no PVC dependency) but PAT is a long-term secret.
+#      - Set ACCESS_TOKEN secret key; leave RUNNER_TOKEN unset.
+#
+# Bootstrap:
+#   kubectl apply -f runner-deployment.yaml
+#
+#   # mode A (registration token):
+#   kubectl -n matrixhub-runner create secret generic github-runner-secret \
+#     --from-literal=runner-token=AAAAxxxx_1HOUR_TOKEN
+#
+#   # mode B (PAT):
+#   kubectl -n matrixhub-runner create secret generic github-runner-secret \
+#     --from-literal=github-pat=ghp_xxxx
 ---
 apiVersion: v1
 kind: Namespace
@@ -54,8 +72,8 @@ metadata:
   name: github-runner-values
   namespace: matrixhub-runner
 data:
-  # Internal network values override for helm upgrade
-  # Customize these for your environment
+  # Internal-network helm values override.
+  # Customize these for your environment.
   values-internal.yaml: |
     apiserver:
       image:
@@ -74,6 +92,20 @@ data:
       persistence:
         size: 8Gi
 ---
+# PVC for runner credentials (.runner, .credentials, .credentials_rsaparams).
+# These files have ~6-month lifetime and let the runner reconnect across
+# pod restarts without needing a new registration token.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: github-runner-data
+  namespace: matrixhub-runner
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 5Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -83,6 +115,10 @@ metadata:
     app: github-runner
 spec:
   replicas: 1
+  # Recreate (not RollingUpdate) — two pods cannot share the same PVC,
+  # and only one runner should own the credentials at a time.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: github-runner
@@ -96,13 +132,33 @@ spec:
         - name: runner
           image: docker.m.daocloud.io/myoung34/github-runner:latest
           env:
-            - name: REPO_URL
-              value: "https://github.com/OWNER/REPO"
-            - name: ACCESS_TOKEN
+            # ---- Target scope (pick ONE) ----
+            # Org-level (recommended — runner can serve any repo in the org's runner group)
+            - name: ORG_NAME
+              value: "matrixhub-ai"
+            - name: RUNNER_GROUP
+              value: "internal-deploy"
+            # Repo-level (uncomment & comment-out ORG_NAME above if needed)
+            # - name: REPO_URL
+            #   value: "https://github.com/matrixhub-ai/matrixhub"
+
+            # ---- Auth (pick ONE — see header comments) ----
+            # Mode A: registration token (one-time, persisted via PVC)
+            - name: RUNNER_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: github-runner-secret
-                  key: github-pat
+                  key: runner-token
+                  optional: true
+            # Mode B: long-lived PAT (uncomment to use)
+            # - name: ACCESS_TOKEN
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: github-runner-secret
+            #       key: github-pat
+            #       optional: true
+
+            # ---- Runner config ----
             - name: RUNNER_NAME
               valueFrom:
                 fieldRef:
@@ -110,17 +166,26 @@ spec:
             - name: LABELS
               value: "self-hosted,linux,internal"
             - name: RUNNER_WORKDIR
-              value: "/home/runner/_work"
+              value: "/runner/_work"
             - name: DISABLE_AUTO_UPDATE
               value: "true"
-            # Chart registry — runner pod has outbound internet (it talks to github.com),
-            # so pull chart directly from ghcr.io. Override per-fork as needed.
+            # Non-ephemeral so registration survives pod restarts (when PVC persists)
+            - name: EPHEMERAL
+              value: "false"
+            # Don't deregister on shutdown — credentials would be invalidated
+            - name: RUNNER_SCOPE
+              value: "org"
+
+            # ---- Deploy-job environment (read by build-image-latest.yaml) ----
+            # Chart pulled directly from ghcr.io (runner has outbound internet;
+            # the daocloud mirror doesn't proxy OCI bearer auth correctly).
             - name: CHART_REGISTRY
               value: "oci://ghcr.io/matrixhub-ai"
-            # Target namespace for helm upgrade
             - name: DEPLOY_NAMESPACE
               value: "matrixhub"
           volumeMounts:
+            - name: runner-data
+              mountPath: /runner
             - name: values
               mountPath: /etc/matrixhub
               readOnly: true
@@ -132,6 +197,9 @@ spec:
               cpu: "2"
               memory: 2Gi
       volumes:
+        - name: runner-data
+          persistentVolumeClaim:
+            claimName: github-runner-data
         - name: values
           configMap:
             name: github-runner-values

--- a/deploy/autoupdate/runner-deployment.yaml
+++ b/deploy/autoupdate/runner-deployment.yaml
@@ -1,0 +1,137 @@
+# GitHub Actions Self-Hosted Runner for MatrixHub auto-deploy
+#
+# Prerequisites:
+#   1. Create a GitHub Personal Access Token (PAT) with "repo" scope
+#      or a fine-grained token with "Administration" read/write on the repo
+#   2. Create the secret manually:
+#      kubectl -n matrixhub-runner create secret generic github-runner-secret \
+#        --from-literal=github-pat=ghp_YOUR_TOKEN_HERE
+#   3. kubectl apply -f runner-deployment.yaml
+#
+# The runner registers itself with GitHub on startup (outbound HTTPS only,
+# no inbound ports needed). When build-image-latest.yaml triggers the
+# deploy-internal job (runs-on: self-hosted), it executes helm upgrade
+# inside this pod.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: matrixhub-runner
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: github-runner
+  namespace: matrixhub-runner
+---
+# Runner needs cluster-wide permissions to run helm upgrade
+# (Helm manages Deployments, Services, ConfigMaps, Secrets, etc.)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: matrixhub-github-runner
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: matrixhub-github-runner
+subjects:
+  - kind: ServiceAccount
+    name: github-runner
+    namespace: matrixhub-runner
+roleRef:
+  kind: ClusterRole
+  name: matrixhub-github-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: github-runner-values
+  namespace: matrixhub-runner
+data:
+  # Internal network values override for helm upgrade
+  # Customize these for your environment
+  values-internal.yaml: |
+    apiserver:
+      image:
+        registry: ghcr.m.daocloud.io
+        repository: matrixhub-ai/matrixhub
+        tag: "latest"
+        pullPolicy: Always
+      service:
+        type: NodePort
+      storage:
+        mode: pvc
+        pvc:
+          size: 60Gi
+    mysql:
+      registry: docker.m.daocloud.io
+      persistence:
+        size: 8Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: github-runner
+  namespace: matrixhub-runner
+  labels:
+    app: github-runner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: github-runner
+  template:
+    metadata:
+      labels:
+        app: github-runner
+    spec:
+      serviceAccountName: github-runner
+      containers:
+        - name: runner
+          image: docker.m.daocloud.io/myoung34/github-runner:latest
+          env:
+            - name: REPO_URL
+              value: "https://github.com/OWNER/REPO"
+            - name: ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: github-runner-secret
+                  key: github-pat
+            - name: RUNNER_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: LABELS
+              value: "self-hosted,linux,internal"
+            - name: RUNNER_WORKDIR
+              value: "/home/runner/_work"
+            - name: DISABLE_AUTO_UPDATE
+              value: "true"
+            # Chart registry — runner pod has outbound internet (it talks to github.com),
+            # so pull chart directly from ghcr.io. Override per-fork as needed.
+            - name: CHART_REGISTRY
+              value: "oci://ghcr.io/matrixhub-ai"
+            # Target namespace for helm upgrade
+            - name: DEPLOY_NAMESPACE
+              value: "matrixhub"
+          volumeMounts:
+            - name: values
+              mountPath: /etc/matrixhub
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+      volumes:
+        - name: values
+          configMap:
+            name: github-runner-values

--- a/deploy/autoupdate/runner-deployment.yaml
+++ b/deploy/autoupdate/runner-deployment.yaml
@@ -169,10 +169,21 @@ spec:
               value: "/runner/_work"
             - name: DISABLE_AUTO_UPDATE
               value: "true"
-            # Non-ephemeral so registration survives pod restarts (when PVC persists)
-            - name: EPHEMERAL
-              value: "false"
-            # Don't deregister on shutdown — credentials would be invalidated
+            # Credential persistence: copy /actions-runner/.runner etc to this
+            # directory on shutdown, restore from it on startup. Together with
+            # the PVC mounted below, this lets pod restarts skip ./config.sh
+            # entirely — no new registration token needed.
+            - name: CONFIGURED_ACTIONS_RUNNER_FILES_DIR
+              value: "/runner"
+            # Required when CONFIGURED_ACTIONS_RUNNER_FILES_DIR is set,
+            # otherwise the entrypoint exits with an error. Disabling auto-
+            # deregistration means runner identity stays valid on GitHub side
+            # across pod restarts.
+            - name: DISABLE_AUTOMATIC_DEREGISTRATION
+              value: "true"
+            # NOTE: do NOT set EPHEMERAL here. The entrypoint uses `[ -n "$EPHEMERAL" ]`
+            # which is true for any non-empty value (including "false"), so setting
+            # EPHEMERAL=false would actually enable ephemeral mode. Leave unset.
             - name: RUNNER_SCOPE
               value: "org"
 

--- a/deploy/autoupdate/values-internal.yaml
+++ b/deploy/autoupdate/values-internal.yaml
@@ -1,0 +1,22 @@
+# Internal network Helm values for MatrixHub
+# Used by the self-hosted runner during helm upgrade
+#
+# This file is mounted into the runner pod via ConfigMap
+# and also kept here as the source of truth.
+apiserver:
+  image:
+    registry: ghcr.m.daocloud.io
+    repository: matrixhub-ai/matrixhub
+    tag: "latest"
+    pullPolicy: Always
+  service:
+    type: NodePort
+  storage:
+    mode: pvc
+    pvc:
+      size: 60Gi
+
+mysql:
+  registry: docker.m.daocloud.io
+  persistence:
+    size: 8Gi

--- a/deploy/charts/matrixhub/templates/matrixhub-deployment.yaml
+++ b/deploy/charts/matrixhub/templates/matrixhub-deployment.yaml
@@ -8,8 +8,12 @@ metadata:
 spec:
   replicas: {{ .Values.apiserver.replicaCount }}
   selector:
+    # IMPORTANT: only use stable labels (selectorLabels) here.
+    # spec.selector.matchLabels is IMMUTABLE in K8s — including dynamic
+    # labels like helm.sh/chart or app.kubernetes.io/version will break
+    # every upgrade with "field is immutable" error.
     matchLabels:
-      {{- include "matrixhub.apiserver.labels" . | nindent 6 }}
+      {{- include "matrixhub.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.apiserver.podAnnotations }}

--- a/deploy/charts/matrixhub/templates/matrixhub-service.yaml
+++ b/deploy/charts/matrixhub/templates/matrixhub-service.yaml
@@ -22,4 +22,5 @@ spec:
       nodePort: null
       {{- end }}
   selector:
-    {{- include "matrixhub.apiserver.labels" . | nindent 4 }}
+    # Only stable labels — must match Deployment's spec.selector.matchLabels
+    {{- include "matrixhub.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
## Summary

Adds a fully automated path from `merge to main` → running build inside an internal K8s cluster, without exposing any inbound ports.

A GitHub Actions self-hosted runner is deployed as a K8s pod **inside** the cluster. It establishes outbound long-poll connections to `github.com` for jobs. When `build-image-latest.yaml` runs, the new `deploy-internal` job is dispatched to that runner, which pulls the just-built Helm chart and runs `helm upgrade`.

## Flow

```
PR merge to main
    │
    ├─ Job: compute-version       → e.g. 0.0.1-<sha>
    ├─ Job: build-image           → push image to ghcr.io with tag v<version>
    ├─ Job: push-chart            → push chart OCI artifact to ghcr.io with tag <version>
    └─ Job: deploy-internal       (runs-on: self-hosted)
           ├─ helm registry login ghcr.io   (using GITHUB_TOKEN)
           ├─ helm pull <chart> --version <version>
           └─ helm upgrade matrixhub <chart> --set apiserver.image.tag=v<version>
```

## Why this design

- **No inbound exposure**: the runner pod only makes outbound HTTPS calls. No webhook receiver, no VPN tunneling, no exposed ingress on the internal side.
- **Always deploys the just-built artifact**: the deploy job pulls the chart that was produced by `push-chart` in the same workflow run, not the source tree. Image and chart versions are always in sync.
- **Per-environment customization**: the runner pod's env vars (`CHART_REGISTRY`, `VALUES_FILE`, `DEPLOY_NAMESPACE`) override defaults — each environment can point at its own values file (mounted from a ConfigMap) and namespace without changing the workflow.

## Files

| Path | Purpose |
|------|---------|
| `.github/workflows/build-image-latest.yaml` | Adds `compute-version`, `push-chart`, `deploy-internal` jobs alongside the existing image build |
| `deploy/autoupdate/runner-deployment.yaml` | K8s manifests for the runner pod (Namespace, ServiceAccount, ClusterRole, ClusterRoleBinding, Secret reference, ConfigMap, Deployment) |
| `deploy/autoupdate/values-internal.yaml` | Source-of-truth Helm values used by the runner (also embedded in the ConfigMap) |
| `deploy/autoupdate/README.md` | Setup instructions |
| `deploy/charts/matrixhub/templates/matrixhub-deployment.yaml` | (bug fix, prerequisite) use stable selectorLabels in `spec.selector.matchLabels` |
| `deploy/charts/matrixhub/templates/matrixhub-service.yaml` | (bug fix, prerequisite) same selector fix for Service |

## Design notes

- **Tag conventions** (image and chart share the same OCI repo path on ghcr.io):
  - image tag = `v<version>` (e.g. `v0.0.1-d3e4b1b`)
  - chart tag = `<version>` (e.g. `0.0.1-d3e4b1b`)
  - The `v` prefix on the image ensures they never overwrite each other.
- **Auth**: the runner uses `helm registry login` with `${{ secrets.GITHUB_TOKEN }}` before `helm pull`. ghcr.io's anonymous token endpoint returns HTTP 403 for the scopes Helm sends by default, so anonymous pull does not work.
- **Mirror caveat**: chart is pulled from `ghcr.io` directly, not the `ghcr.m.daocloud.io` mirror, because the mirror does not proxy OCI bearer auth correctly. The image still goes through the mirror via `values-internal.yaml` because application pods may not have outbound internet.
- **Helm version**: pinned to `v3.18.4` (azure/setup-helm@v4 default).
- **Chart selector fix**: bundled in this PR because every `helm upgrade` would otherwise fail with `spec.selector: Invalid value: ... field is immutable` — that fix is a hard prerequisite for the auto-deploy to function.

## Setup (one-time per cluster)

```bash
# 1. Create a GitHub PAT with `repo` scope, then:
kubectl create namespace matrixhub-runner
kubectl -n matrixhub-runner create secret generic github-runner-secret \
  --from-literal=github-pat=ghp_xxx

# 2. Edit deploy/autoupdate/runner-deployment.yaml:
#    - set REPO_URL env to your fork/upstream URL
#    - adjust the ConfigMap values for your environment

# 3. Apply
kubectl apply -f deploy/autoupdate/runner-deployment.yaml
```

The runner should appear as "Idle" under `Settings → Actions → Runners` in the repo within ~30s.

## Test plan

- [x] Runner pod registers and appears as Idle on the GitHub repo
- [x] `compute-version`, `build-image`, `push-chart` jobs succeed on the cloud runner
- [x] `deploy-internal` job is dispatched to the self-hosted runner
- [x] `helm pull` succeeds against ghcr.io with the runner-injected `GITHUB_TOKEN`
- [x] `helm upgrade` completes; rollout finishes; new pod is running with the expected image tag
- [ ] Run a second `merge to main` and confirm the new version is auto-deployed end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)