### PR TITLE
fix(authz): merge platform and project permissions for project scope

### DIFF
--- a/internal/domain/authz/authz_service.go
+++ b/internal/domain/authz/authz_service.go
@@ -104,11 +104,17 @@ func (s *AuthzService) getPermissions(ctx context.Context, identity auth.Identit
 }
 
 func (s *AuthzService) getUserPermissions(ctx context.Context, id *user.Identity, projectId int) ([]role.Permission, error) {
-	if projectId == 0 {
-		return s.authzRepo.GetUserPlatformPermissions(ctx, id.GetID())
+	platformPerms, err := s.authzRepo.GetUserPlatformPermissions(ctx, id.GetID())
+	if err != nil {
+		return nil, err
 	}
 
-	return s.authzRepo.GetUserProjectPermissions(ctx, id.GetID(), projectId)
+	projectPerms, err := s.authzRepo.GetUserProjectPermissions(ctx, id.GetID(), projectId)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(platformPerms, projectPerms...), nil
 }
 
 // getRobotPermissions resolves permissions for a robot account.


### PR DESCRIPTION
## What

`getUserPermissions` returned only **one** permission set:
- `projectId == 0` → platform permissions only
- otherwise → project permissions only

A user scoped to a project therefore lost their platform-level permissions, breaking authz checks that depend on both.

## Fix
 #660
Fetch both platform and project permissions and return their union.
