### PR TITLE
feat(project): permission-based filter for ListProjects API

### DIFF
--- a/api/go/v1alpha1/project.pb.go
+++ b/api/go/v1alpha1/project.pb.go
@@ -74,6 +74,64 @@ func (ProjectType) EnumDescriptor() ([]byte, []int) {
 	return file_v1alpha1_project_proto_rawDescGZIP(), []int{0}
 }
 
+// ProjectPermissionFilter controls which projects are returned based on user permissions.
+// Wire values are backward compatible with the old bool managed_only field (false=0, true=1).
+type ProjectPermissionFilter int32
+
+const (
+	// Default: returns accessible projects + public projects (compatible with old managed_only=false)
+	ProjectPermissionFilter_PERMISSION_FILTER_UNSPECIFIED ProjectPermissionFilter = 0
+	// Returns only explicitly authorized projects, excluding public (compatible with old managed_only=true)
+	ProjectPermissionFilter_PERMISSION_FILTER_MANAGED_ONLY ProjectPermissionFilter = 1
+	// Returns only projects where user has write permission (model.push or dataset.push)
+	ProjectPermissionFilter_PERMISSION_FILTER_CAN_WRITE ProjectPermissionFilter = 2
+	// Returns projects where user has read permission + public projects
+	ProjectPermissionFilter_PERMISSION_FILTER_CAN_READ ProjectPermissionFilter = 3
+)
+
+// Enum value maps for ProjectPermissionFilter.
+var (
+	ProjectPermissionFilter_name = map[int32]string{
+		0: "PERMISSION_FILTER_UNSPECIFIED",
+		1: "PERMISSION_FILTER_MANAGED_ONLY",
+		2: "PERMISSION_FILTER_CAN_WRITE",
+		3: "PERMISSION_FILTER_CAN_READ",
+	}
+	ProjectPermissionFilter_value = map[string]int32{
+		"PERMISSION_FILTER_UNSPECIFIED":  0,
+		"PERMISSION_FILTER_MANAGED_ONLY": 1,
+		"PERMISSION_FILTER_CAN_WRITE":    2,
+		"PERMISSION_FILTER_CAN_READ":     3,
+	}
+)
+
+func (x ProjectPermissionFilter) Enum() *ProjectPermissionFilter {
+	p := new(ProjectPermissionFilter)
+	*p = x
+	return p
+}
+
+func (x ProjectPermissionFilter) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ProjectPermissionFilter) Descriptor() protoreflect.EnumDescriptor {
+	return file_v1alpha1_project_proto_enumTypes[1].Descriptor()
+}
+
+func (ProjectPermissionFilter) Type() protoreflect.EnumType {
+	return &file_v1alpha1_project_proto_enumTypes[1]
+}
+
+func (x ProjectPermissionFilter) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ProjectPermissionFilter.Descriptor instead.
+func (ProjectPermissionFilter) EnumDescriptor() ([]byte, []int) {
+	return file_v1alpha1_project_proto_rawDescGZIP(), []int{1}
+}
+
 type MemberType int32
 
 const (
@@ -104,11 +162,11 @@ func (x MemberType) String() string {
 }
 
 func (MemberType) Descriptor() protoreflect.EnumDescriptor {
-	return file_v1alpha1_project_proto_enumTypes[1].Descriptor()
+	return file_v1alpha1_project_proto_enumTypes[2].Descriptor()
 }
 
 func (MemberType) Type() protoreflect.EnumType {
-	return &file_v1alpha1_project_proto_enumTypes[1]
+	return &file_v1alpha1_project_proto_enumTypes[2]
 }
 
 func (x MemberType) Number() protoreflect.EnumNumber {
@@ -117,7 +175,7 @@ func (x MemberType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use MemberType.Descriptor instead.
 func (MemberType) EnumDescriptor() ([]byte, []int) {
-	return file_v1alpha1_project_proto_rawDescGZIP(), []int{1}
+	return file_v1alpha1_project_proto_rawDescGZIP(), []int{2}
 }
 
 type CreateProjectRequest struct {
@@ -225,14 +283,14 @@ func (*CreateProjectResponse) Descriptor() ([]byte, []int) {
 }
 
 type ListProjectsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Type          ProjectType            `protobuf:"varint,2,opt,name=type,proto3,enum=matrixhub.v1alpha1.ProjectType" json:"type,omitempty"`
-	ManagedOnly   bool                   `protobuf:"varint,3,opt,name=managed_only,json=managedOnly,proto3" json:"managed_only,omitempty"`
-	Page          int32                  `protobuf:"varint,4,opt,name=page,proto3" json:"page,omitempty"`
-	PageSize      int32                  `protobuf:"varint,5,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state            protoimpl.MessageState  `protogen:"open.v1"`
+	Name             string                  `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Type             ProjectType             `protobuf:"varint,2,opt,name=type,proto3,enum=matrixhub.v1alpha1.ProjectType" json:"type,omitempty"`
+	PermissionFilter ProjectPermissionFilter `protobuf:"varint,3,opt,name=permission_filter,json=permissionFilter,proto3,enum=matrixhub.v1alpha1.ProjectPermissionFilter" json:"permission_filter,omitempty"`
+	Page             int32                   `protobuf:"varint,4,opt,name=page,proto3" json:"page,omitempty"`
+	PageSize         int32                   `protobuf:"varint,5,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *ListProjectsRequest) Reset() {
@@ -279,11 +337,11 @@ func (x *ListProjectsRequest) GetType() ProjectType {
 	return ProjectType_PROJECT_TYPE_UNSPECIFIED
 }
 
-func (x *ListProjectsRequest) GetManagedOnly() bool {
+func (x *ListProjectsRequest) GetPermissionFilter() ProjectPermissionFilter {
 	if x != nil {
-		return x.ManagedOnly
+		return x.PermissionFilter
 	}
-	return false
+	return ProjectPermissionFilter_PERMISSION_FILTER_UNSPECIFIED
 }
 
 func (x *ListProjectsRequest) GetPage() int32 {
@@ -1288,11 +1346,11 @@ const file_v1alpha1_project_proto_rawDesc = "" +
 	"\vregistry_id\x18\x03 \x01(\v2\x1b.google.protobuf.Int32ValueR\n" +
 	"registryId\x12\"\n" +
 	"\forganization\x18\x04 \x01(\tR\forganization\"\x17\n" +
-	"\x15CreateProjectResponse\"\xb2\x01\n" +
+	"\x15CreateProjectResponse\"\xe9\x01\n" +
 	"\x13ListProjectsRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x123\n" +
-	"\x04type\x18\x02 \x01(\x0e2\x1f.matrixhub.v1alpha1.ProjectTypeR\x04type\x12!\n" +
-	"\fmanaged_only\x18\x03 \x01(\bR\vmanagedOnly\x12\x12\n" +
+	"\x04type\x18\x02 \x01(\x0e2\x1f.matrixhub.v1alpha1.ProjectTypeR\x04type\x12X\n" +
+	"\x11permission_filter\x18\x03 \x01(\x0e2+.matrixhub.v1alpha1.ProjectPermissionFilterR\x10permissionFilter\x12\x12\n" +
 	"\x04page\x18\x04 \x01(\x05R\x04page\x12\x1b\n" +
 	"\tpage_size\x18\x05 \x01(\x05R\bpageSize\"\x8f\x01\n" +
 	"\x14ListProjectsResponse\x127\n" +
@@ -1371,7 +1429,12 @@ const file_v1alpha1_project_proto_rawDesc = "" +
 	"\vProjectType\x12\x1c\n" +
 	"\x18PROJECT_TYPE_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14PROJECT_TYPE_PRIVATE\x10\x01\x12\x17\n" +
-	"\x13PROJECT_TYPE_PUBLIC\x10\x02*9\n" +
+	"\x13PROJECT_TYPE_PUBLIC\x10\x02*\xa1\x01\n" +
+	"\x17ProjectPermissionFilter\x12!\n" +
+	"\x1dPERMISSION_FILTER_UNSPECIFIED\x10\x00\x12\"\n" +
+	"\x1ePERMISSION_FILTER_MANAGED_ONLY\x10\x01\x12\x1f\n" +
+	"\x1bPERMISSION_FILTER_CAN_WRITE\x10\x02\x12\x1e\n" +
+	"\x1aPERMISSION_FILTER_CAN_READ\x10\x03*9\n" +
 	"\n" +
 	"MemberType\x12\x14\n" +
 	"\x10MEMBER_TYPE_USER\x10\x00\x12\x15\n" +
@@ -1400,81 +1463,83 @@ func file_v1alpha1_project_proto_rawDescGZIP() []byte {
 	return file_v1alpha1_project_proto_rawDescData
 }
 
-var file_v1alpha1_project_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_v1alpha1_project_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
 var file_v1alpha1_project_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_v1alpha1_project_proto_goTypes = []any{
 	(ProjectType)(0),                         // 0: matrixhub.v1alpha1.ProjectType
-	(MemberType)(0),                          // 1: matrixhub.v1alpha1.MemberType
-	(*CreateProjectRequest)(nil),             // 2: matrixhub.v1alpha1.CreateProjectRequest
-	(*CreateProjectResponse)(nil),            // 3: matrixhub.v1alpha1.CreateProjectResponse
-	(*ListProjectsRequest)(nil),              // 4: matrixhub.v1alpha1.ListProjectsRequest
-	(*ListProjectsResponse)(nil),             // 5: matrixhub.v1alpha1.ListProjectsResponse
-	(*GetProjectRequest)(nil),                // 6: matrixhub.v1alpha1.GetProjectRequest
-	(*GetProjectResponse)(nil),               // 7: matrixhub.v1alpha1.GetProjectResponse
-	(*DeleteProjectRequest)(nil),             // 8: matrixhub.v1alpha1.DeleteProjectRequest
-	(*DeleteProjectResponse)(nil),            // 9: matrixhub.v1alpha1.DeleteProjectResponse
-	(*UpdateProjectRequest)(nil),             // 10: matrixhub.v1alpha1.UpdateProjectRequest
-	(*UpdateProjectResponse)(nil),            // 11: matrixhub.v1alpha1.UpdateProjectResponse
-	(*Project)(nil),                          // 12: matrixhub.v1alpha1.Project
-	(*ListProjectMembersRequest)(nil),        // 13: matrixhub.v1alpha1.ListProjectMembersRequest
-	(*ListProjectMembersResponse)(nil),       // 14: matrixhub.v1alpha1.ListProjectMembersResponse
-	(*ProjectMember)(nil),                    // 15: matrixhub.v1alpha1.ProjectMember
-	(*AddProjectMemberWithRoleRequest)(nil),  // 16: matrixhub.v1alpha1.AddProjectMemberWithRoleRequest
-	(*AddProjectMemberWithRoleResponse)(nil), // 17: matrixhub.v1alpha1.AddProjectMemberWithRoleResponse
-	(*RemoveProjectMembersRequest)(nil),      // 18: matrixhub.v1alpha1.RemoveProjectMembersRequest
-	(*MemberToRemove)(nil),                   // 19: matrixhub.v1alpha1.MemberToRemove
-	(*RemoveProjectMembersResponse)(nil),     // 20: matrixhub.v1alpha1.RemoveProjectMembersResponse
-	(*UpdateProjectMemberRoleRequest)(nil),   // 21: matrixhub.v1alpha1.UpdateProjectMemberRoleRequest
-	(*UpdateProjectMemberRoleResponse)(nil),  // 22: matrixhub.v1alpha1.UpdateProjectMemberRoleResponse
-	(*wrapperspb.Int32Value)(nil),            // 23: google.protobuf.Int32Value
-	(*Pagination)(nil),                       // 24: matrixhub.v1alpha1.Pagination
-	(*timestamppb.Timestamp)(nil),            // 25: google.protobuf.Timestamp
-	(ProjectRoleType)(0),                     // 26: matrixhub.v1alpha1.ProjectRoleType
+	(ProjectPermissionFilter)(0),             // 1: matrixhub.v1alpha1.ProjectPermissionFilter
+	(MemberType)(0),                          // 2: matrixhub.v1alpha1.MemberType
+	(*CreateProjectRequest)(nil),             // 3: matrixhub.v1alpha1.CreateProjectRequest
+	(*CreateProjectResponse)(nil),            // 4: matrixhub.v1alpha1.CreateProjectResponse
+	(*ListProjectsRequest)(nil),              // 5: matrixhub.v1alpha1.ListProjectsRequest
+	(*ListProjectsResponse)(nil),             // 6: matrixhub.v1alpha1.ListProjectsResponse
+	(*GetProjectRequest)(nil),                // 7: matrixhub.v1alpha1.GetProjectRequest
+	(*GetProjectResponse)(nil),               // 8: matrixhub.v1alpha1.GetProjectResponse
+	(*DeleteProjectRequest)(nil),             // 9: matrixhub.v1alpha1.DeleteProjectRequest
+	(*DeleteProjectResponse)(nil),            // 10: matrixhub.v1alpha1.DeleteProjectResponse
+	(*UpdateProjectRequest)(nil),             // 11: matrixhub.v1alpha1.UpdateProjectRequest
+	(*UpdateProjectResponse)(nil),            // 12: matrixhub.v1alpha1.UpdateProjectResponse
+	(*Project)(nil),                          // 13: matrixhub.v1alpha1.Project
+	(*ListProjectMembersRequest)(nil),        // 14: matrixhub.v1alpha1.ListProjectMembersRequest
+	(*ListProjectMembersResponse)(nil),       // 15: matrixhub.v1alpha1.ListProjectMembersResponse
+	(*ProjectMember)(nil),                    // 16: matrixhub.v1alpha1.ProjectMember
+	(*AddProjectMemberWithRoleRequest)(nil),  // 17: matrixhub.v1alpha1.AddProjectMemberWithRoleRequest
+	(*AddProjectMemberWithRoleResponse)(nil), // 18: matrixhub.v1alpha1.AddProjectMemberWithRoleResponse
+	(*RemoveProjectMembersRequest)(nil),      // 19: matrixhub.v1alpha1.RemoveProjectMembersRequest
+	(*MemberToRemove)(nil),                   // 20: matrixhub.v1alpha1.MemberToRemove
+	(*RemoveProjectMembersResponse)(nil),     // 21: matrixhub.v1alpha1.RemoveProjectMembersResponse
+	(*UpdateProjectMemberRoleRequest)(nil),   // 22: matrixhub.v1alpha1.UpdateProjectMemberRoleRequest
+	(*UpdateProjectMemberRoleResponse)(nil),  // 23: matrixhub.v1alpha1.UpdateProjectMemberRoleResponse
+	(*wrapperspb.Int32Value)(nil),            // 24: google.protobuf.Int32Value
+	(*Pagination)(nil),                       // 25: matrixhub.v1alpha1.Pagination
+	(*timestamppb.Timestamp)(nil),            // 26: google.protobuf.Timestamp
+	(ProjectRoleType)(0),                     // 27: matrixhub.v1alpha1.ProjectRoleType
 }
 var file_v1alpha1_project_proto_depIdxs = []int32{
 	0,  // 0: matrixhub.v1alpha1.CreateProjectRequest.type:type_name -> matrixhub.v1alpha1.ProjectType
-	23, // 1: matrixhub.v1alpha1.CreateProjectRequest.registry_id:type_name -> google.protobuf.Int32Value
+	24, // 1: matrixhub.v1alpha1.CreateProjectRequest.registry_id:type_name -> google.protobuf.Int32Value
 	0,  // 2: matrixhub.v1alpha1.ListProjectsRequest.type:type_name -> matrixhub.v1alpha1.ProjectType
-	12, // 3: matrixhub.v1alpha1.ListProjectsResponse.projects:type_name -> matrixhub.v1alpha1.Project
-	24, // 4: matrixhub.v1alpha1.ListProjectsResponse.pagination:type_name -> matrixhub.v1alpha1.Pagination
-	0,  // 5: matrixhub.v1alpha1.GetProjectResponse.type:type_name -> matrixhub.v1alpha1.ProjectType
-	25, // 6: matrixhub.v1alpha1.GetProjectResponse.updated_at:type_name -> google.protobuf.Timestamp
-	0,  // 7: matrixhub.v1alpha1.UpdateProjectRequest.type:type_name -> matrixhub.v1alpha1.ProjectType
-	0,  // 8: matrixhub.v1alpha1.Project.type:type_name -> matrixhub.v1alpha1.ProjectType
-	25, // 9: matrixhub.v1alpha1.Project.updated_at:type_name -> google.protobuf.Timestamp
-	15, // 10: matrixhub.v1alpha1.ListProjectMembersResponse.members:type_name -> matrixhub.v1alpha1.ProjectMember
-	24, // 11: matrixhub.v1alpha1.ListProjectMembersResponse.pagination:type_name -> matrixhub.v1alpha1.Pagination
-	1,  // 12: matrixhub.v1alpha1.ProjectMember.member_type:type_name -> matrixhub.v1alpha1.MemberType
-	26, // 13: matrixhub.v1alpha1.ProjectMember.role:type_name -> matrixhub.v1alpha1.ProjectRoleType
-	1,  // 14: matrixhub.v1alpha1.AddProjectMemberWithRoleRequest.member_type:type_name -> matrixhub.v1alpha1.MemberType
-	26, // 15: matrixhub.v1alpha1.AddProjectMemberWithRoleRequest.role:type_name -> matrixhub.v1alpha1.ProjectRoleType
-	19, // 16: matrixhub.v1alpha1.RemoveProjectMembersRequest.members:type_name -> matrixhub.v1alpha1.MemberToRemove
-	1,  // 17: matrixhub.v1alpha1.MemberToRemove.member_type:type_name -> matrixhub.v1alpha1.MemberType
-	1,  // 18: matrixhub.v1alpha1.UpdateProjectMemberRoleRequest.member_type:type_name -> matrixhub.v1alpha1.MemberType
-	26, // 19: matrixhub.v1alpha1.UpdateProjectMemberRoleRequest.role:type_name -> matrixhub.v1alpha1.ProjectRoleType
-	2,  // 20: matrixhub.v1alpha1.Projects.CreateProject:input_type -> matrixhub.v1alpha1.CreateProjectRequest
-	4,  // 21: matrixhub.v1alpha1.Projects.ListProjects:input_type -> matrixhub.v1alpha1.ListProjectsRequest
-	6,  // 22: matrixhub.v1alpha1.Projects.GetProject:input_type -> matrixhub.v1alpha1.GetProjectRequest
-	10, // 23: matrixhub.v1alpha1.Projects.UpdateProject:input_type -> matrixhub.v1alpha1.UpdateProjectRequest
-	8,  // 24: matrixhub.v1alpha1.Projects.DeleteProject:input_type -> matrixhub.v1alpha1.DeleteProjectRequest
-	13, // 25: matrixhub.v1alpha1.Projects.ListProjectMembers:input_type -> matrixhub.v1alpha1.ListProjectMembersRequest
-	16, // 26: matrixhub.v1alpha1.Projects.AddProjectMemberWithRole:input_type -> matrixhub.v1alpha1.AddProjectMemberWithRoleRequest
-	18, // 27: matrixhub.v1alpha1.Projects.RemoveProjectMembers:input_type -> matrixhub.v1alpha1.RemoveProjectMembersRequest
-	21, // 28: matrixhub.v1alpha1.Projects.UpdateProjectMemberRole:input_type -> matrixhub.v1alpha1.UpdateProjectMemberRoleRequest
-	3,  // 29: matrixhub.v1alpha1.Projects.CreateProject:output_type -> matrixhub.v1alpha1.CreateProjectResponse
-	5,  // 30: matrixhub.v1alpha1.Projects.ListProjects:output_type -> matrixhub.v1alpha1.ListProjectsResponse
-	7,  // 31: matrixhub.v1alpha1.Projects.GetProject:output_type -> matrixhub.v1alpha1.GetProjectResponse
-	11, // 32: matrixhub.v1alpha1.Projects.UpdateProject:output_type -> matrixhub.v1alpha1.UpdateProjectResponse
-	9,  // 33: matrixhub.v1alpha1.Projects.DeleteProject:output_type -> matrixhub.v1alpha1.DeleteProjectResponse
-	14, // 34: matrixhub.v1alpha1.Projects.ListProjectMembers:output_type -> matrixhub.v1alpha1.ListProjectMembersResponse
-	17, // 35: matrixhub.v1alpha1.Projects.AddProjectMemberWithRole:output_type -> matrixhub.v1alpha1.AddProjectMemberWithRoleResponse
-	20, // 36: matrixhub.v1alpha1.Projects.RemoveProjectMembers:output_type -> matrixhub.v1alpha1.RemoveProjectMembersResponse
-	22, // 37: matrixhub.v1alpha1.Projects.UpdateProjectMemberRole:output_type -> matrixhub.v1alpha1.UpdateProjectMemberRoleResponse
-	29, // [29:38] is the sub-list for method output_type
-	20, // [20:29] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	1,  // 3: matrixhub.v1alpha1.ListProjectsRequest.permission_filter:type_name -> matrixhub.v1alpha1.ProjectPermissionFilter
+	13, // 4: matrixhub.v1alpha1.ListProjectsResponse.projects:type_name -> matrixhub.v1alpha1.Project
+	25, // 5: matrixhub.v1alpha1.ListProjectsResponse.pagination:type_name -> matrixhub.v1alpha1.Pagination
+	0,  // 6: matrixhub.v1alpha1.GetProjectResponse.type:type_name -> matrixhub.v1alpha1.ProjectType
+	26, // 7: matrixhub.v1alpha1.GetProjectResponse.updated_at:type_name -> google.protobuf.Timestamp
+	0,  // 8: matrixhub.v1alpha1.UpdateProjectRequest.type:type_name -> matrixhub.v1alpha1.ProjectType
+	0,  // 9: matrixhub.v1alpha1.Project.type:type_name -> matrixhub.v1alpha1.ProjectType
+	26, // 10: matrixhub.v1alpha1.Project.updated_at:type_name -> google.protobuf.Timestamp
+	16, // 11: matrixhub.v1alpha1.ListProjectMembersResponse.members:type_name -> matrixhub.v1alpha1.ProjectMember
+	25, // 12: matrixhub.v1alpha1.ListProjectMembersResponse.pagination:type_name -> matrixhub.v1alpha1.Pagination
+	2,  // 13: matrixhub.v1alpha1.ProjectMember.member_type:type_name -> matrixhub.v1alpha1.MemberType
+	27, // 14: matrixhub.v1alpha1.ProjectMember.role:type_name -> matrixhub.v1alpha1.ProjectRoleType
+	2,  // 15: matrixhub.v1alpha1.AddProjectMemberWithRoleRequest.member_type:type_name -> matrixhub.v1alpha1.MemberType
+	27, // 16: matrixhub.v1alpha1.AddProjectMemberWithRoleRequest.role:type_name -> matrixhub.v1alpha1.ProjectRoleType
+	20, // 17: matrixhub.v1alpha1.RemoveProjectMembersRequest.members:type_name -> matrixhub.v1alpha1.MemberToRemove
+	2,  // 18: matrixhub.v1alpha1.MemberToRemove.member_type:type_name -> matrixhub.v1alpha1.MemberType
+	2,  // 19: matrixhub.v1alpha1.UpdateProjectMemberRoleRequest.member_type:type_name -> matrixhub.v1alpha1.MemberType
+	27, // 20: matrixhub.v1alpha1.UpdateProjectMemberRoleRequest.role:type_name -> matrixhub.v1alpha1.ProjectRoleType
+	3,  // 21: matrixhub.v1alpha1.Projects.CreateProject:input_type -> matrixhub.v1alpha1.CreateProjectRequest
+	5,  // 22: matrixhub.v1alpha1.Projects.ListProjects:input_type -> matrixhub.v1alpha1.ListProjectsRequest
+	7,  // 23: matrixhub.v1alpha1.Projects.GetProject:input_type -> matrixhub.v1alpha1.GetProjectRequest
+	11, // 24: matrixhub.v1alpha1.Projects.UpdateProject:input_type -> matrixhub.v1alpha1.UpdateProjectRequest
+	9,  // 25: matrixhub.v1alpha1.Projects.DeleteProject:input_type -> matrixhub.v1alpha1.DeleteProjectRequest
+	14, // 26: matrixhub.v1alpha1.Projects.ListProjectMembers:input_type -> matrixhub.v1alpha1.ListProjectMembersRequest
+	17, // 27: matrixhub.v1alpha1.Projects.AddProjectMemberWithRole:input_type -> matrixhub.v1alpha1.AddProjectMemberWithRoleRequest
+	19, // 28: matrixhub.v1alpha1.Projects.RemoveProjectMembers:input_type -> matrixhub.v1alpha1.RemoveProjectMembersRequest
+	22, // 29: matrixhub.v1alpha1.Projects.UpdateProjectMemberRole:input_type -> matrixhub.v1alpha1.UpdateProjectMemberRoleRequest
+	4,  // 30: matrixhub.v1alpha1.Projects.CreateProject:output_type -> matrixhub.v1alpha1.CreateProjectResponse
+	6,  // 31: matrixhub.v1alpha1.Projects.ListProjects:output_type -> matrixhub.v1alpha1.ListProjectsResponse
+	8,  // 32: matrixhub.v1alpha1.Projects.GetProject:output_type -> matrixhub.v1alpha1.GetProjectResponse
+	12, // 33: matrixhub.v1alpha1.Projects.UpdateProject:output_type -> matrixhub.v1alpha1.UpdateProjectResponse
+	10, // 34: matrixhub.v1alpha1.Projects.DeleteProject:output_type -> matrixhub.v1alpha1.DeleteProjectResponse
+	15, // 35: matrixhub.v1alpha1.Projects.ListProjectMembers:output_type -> matrixhub.v1alpha1.ListProjectMembersResponse
+	18, // 36: matrixhub.v1alpha1.Projects.AddProjectMemberWithRole:output_type -> matrixhub.v1alpha1.AddProjectMemberWithRoleResponse
+	21, // 37: matrixhub.v1alpha1.Projects.RemoveProjectMembers:output_type -> matrixhub.v1alpha1.RemoveProjectMembersResponse
+	23, // 38: matrixhub.v1alpha1.Projects.UpdateProjectMemberRole:output_type -> matrixhub.v1alpha1.UpdateProjectMemberRoleResponse
+	30, // [30:39] is the sub-list for method output_type
+	21, // [21:30] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_v1alpha1_project_proto_init() }
@@ -1489,7 +1554,7 @@ func file_v1alpha1_project_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_v1alpha1_project_proto_rawDesc), len(file_v1alpha1_project_proto_rawDesc)),
-			NumEnums:      2,
+			NumEnums:      3,
 			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/api/go/v1alpha1/project.pb.validate.go
+++ b/api/go/v1alpha1/project.pb.validate.go
@@ -346,7 +346,7 @@ func (m *ListProjectsRequest) validate(all bool) error {
 
 	// no validation rules for Type
 
-	// no validation rules for ManagedOnly
+	// no validation rules for PermissionFilter
 
 	// no validation rules for Page
 

--- a/api/openapiv2/v1alpha1/project.swagger.json
+++ b/api/openapiv2/v1alpha1/project.swagger.json
@@ -53,10 +53,18 @@
             "default": "PROJECT_TYPE_UNSPECIFIED"
           },
           {
-            "name": "managedOnly",
+            "name": "permissionFilter",
+            "description": " - PERMISSION_FILTER_UNSPECIFIED: Default: returns accessible projects + public projects (compatible with old managed_only=false)\n - PERMISSION_FILTER_MANAGED_ONLY: Returns only explicitly authorized projects, excluding public (compatible with old managed_only=true)\n - PERMISSION_FILTER_CAN_WRITE: Returns only projects where user has write permission (model.push or dataset.push)\n - PERMISSION_FILTER_CAN_READ: Returns projects where user has read permission + public projects",
             "in": "query",
             "required": false,
-            "type": "boolean"
+            "type": "string",
+            "enum": [
+              "PERMISSION_FILTER_UNSPECIFIED",
+              "PERMISSION_FILTER_MANAGED_ONLY",
+              "PERMISSION_FILTER_CAN_WRITE",
+              "PERMISSION_FILTER_CAN_READ"
+            ],
+            "default": "PERMISSION_FILTER_UNSPECIFIED"
           },
           {
             "name": "page",
@@ -620,6 +628,17 @@
           "$ref": "#/definitions/v1alpha1ProjectRoleType"
         }
       }
+    },
+    "v1alpha1ProjectPermissionFilter": {
+      "type": "string",
+      "enum": [
+        "PERMISSION_FILTER_UNSPECIFIED",
+        "PERMISSION_FILTER_MANAGED_ONLY",
+        "PERMISSION_FILTER_CAN_WRITE",
+        "PERMISSION_FILTER_CAN_READ"
+      ],
+      "default": "PERMISSION_FILTER_UNSPECIFIED",
+      "description": "ProjectPermissionFilter controls which projects are returned based on user permissions.\nWire values are backward compatible with the old bool managed_only field (false=0, true=1).\n\n - PERMISSION_FILTER_UNSPECIFIED: Default: returns accessible projects + public projects (compatible with old managed_only=false)\n - PERMISSION_FILTER_MANAGED_ONLY: Returns only explicitly authorized projects, excluding public (compatible with old managed_only=true)\n - PERMISSION_FILTER_CAN_WRITE: Returns only projects where user has write permission (model.push or dataset.push)\n - PERMISSION_FILTER_CAN_READ: Returns projects where user has read permission + public projects"
     },
     "v1alpha1ProjectRoleType": {
       "type": "string",

--- a/api/proto/v1alpha1/project.proto
+++ b/api/proto/v1alpha1/project.proto
@@ -83,7 +83,7 @@ message CreateProjectResponse {
 message ListProjectsRequest {
   string name = 1;
   ProjectType type = 2;
-  bool managed_only = 3;
+  ProjectPermissionFilter permission_filter = 3;
   int32 page = 4;
   int32 page_size = 5;
 }
@@ -134,6 +134,19 @@ enum ProjectType {
   PROJECT_TYPE_UNSPECIFIED = 0;
   PROJECT_TYPE_PRIVATE = 1;
   PROJECT_TYPE_PUBLIC = 2;
+}
+
+// ProjectPermissionFilter controls which projects are returned based on user permissions.
+// Wire values are backward compatible with the old bool managed_only field (false=0, true=1).
+enum ProjectPermissionFilter {
+  // Default: returns accessible projects + public projects (compatible with old managed_only=false)
+  PERMISSION_FILTER_UNSPECIFIED = 0;
+  // Returns only explicitly authorized projects, excluding public (compatible with old managed_only=true)
+  PERMISSION_FILTER_MANAGED_ONLY = 1;
+  // Returns only projects where user has write permission (model.push or dataset.push)
+  PERMISSION_FILTER_CAN_WRITE = 2;
+  // Returns projects where user has read permission + public projects
+  PERMISSION_FILTER_CAN_READ = 3;
 }
 
 message ListProjectMembersRequest {

--- a/api/ts/v1alpha1/project.pb.ts
+++ b/api/ts/v1alpha1/project.pb.ts
@@ -16,6 +16,13 @@ export enum ProjectType {
   PROJECT_TYPE_PUBLIC = "PROJECT_TYPE_PUBLIC",
 }
 
+export enum ProjectPermissionFilter {
+  PERMISSION_FILTER_UNSPECIFIED = "PERMISSION_FILTER_UNSPECIFIED",
+  PERMISSION_FILTER_MANAGED_ONLY = "PERMISSION_FILTER_MANAGED_ONLY",
+  PERMISSION_FILTER_CAN_WRITE = "PERMISSION_FILTER_CAN_WRITE",
+  PERMISSION_FILTER_CAN_READ = "PERMISSION_FILTER_CAN_READ",
+}
+
 export enum MemberType {
   MEMBER_TYPE_USER = "MEMBER_TYPE_USER",
   MEMBER_TYPE_GROUP = "MEMBER_TYPE_GROUP",
@@ -34,7 +41,7 @@ export type CreateProjectResponse = {
 export type ListProjectsRequest = {
   name?: string
   type?: ProjectType
-  managedOnly?: boolean
+  permissionFilter?: ProjectPermissionFilter
   page?: number
   pageSize?: number
 }

--- a/internal/apiserver/handler/project_handler.go
+++ b/internal/apiserver/handler/project_handler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/matrixhub-ai/matrixhub/internal/domain/auth"
 	"github.com/matrixhub-ai/matrixhub/internal/domain/authz"
 	"github.com/matrixhub-ai/matrixhub/internal/domain/project"
+	"github.com/matrixhub-ai/matrixhub/internal/domain/robot"
 	"github.com/matrixhub-ai/matrixhub/internal/domain/role"
 	"github.com/matrixhub-ai/matrixhub/internal/domain/user"
 	"github.com/matrixhub-ai/matrixhub/internal/infra/log"
@@ -116,14 +117,27 @@ func (h *ProjectHandler) ListProjects(ctx context.Context, req *projectv1alpha1.
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	_, ok := auth.IdentityFromContext(ctx)
+	identity, ok := auth.IdentityFromContext(ctx)
 	if !ok {
 		return nil, status.Error(codes.Unauthenticated, codes.Unauthenticated.String())
 	}
 
+	switch identity.(type) {
+	case *user.Identity:
+		return h.listProjectsForUser(ctx, req)
+	case *robot.Identity:
+		return nil, status.Error(codes.Unimplemented, "list projects for robot is not implemented yet")
+	default:
+		return nil, status.Error(codes.Unauthenticated, codes.Unauthenticated.String())
+	}
+}
+
+func (h *ProjectHandler) listProjectsForUser(ctx context.Context, req *projectv1alpha1.ListProjectsRequest) (*projectv1alpha1.ListProjectsResponse, error) {
 	page := utils.NewPage(req.Page, req.PageSize)
 
-	hasPlatformProjectGet, err := h.authzService.VerifyPlatformPermission(ctx, role.ProjectGet)
+	permFilter := convertProtoPermissionFilterToDomain(req.GetPermissionFilter())
+
+	hasPlatformPermission, err := h.hasPlatformPermissionForFilter(ctx, permFilter)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -132,8 +146,8 @@ func (h *ProjectHandler) ListProjects(ctx context.Context, req *projectv1alpha1.
 		ctx,
 		req.GetName(),
 		convertProtoTypeToDomain(req.GetType()),
-		req.GetManagedOnly(),
-		hasPlatformProjectGet,
+		permFilter,
+		hasPlatformPermission,
 		int(page.Page),
 		int(page.PageSize),
 	)
@@ -159,6 +173,19 @@ func (h *ProjectHandler) ListProjects(ctx context.Context, req *projectv1alpha1.
 			Pages:    utils.CalculatePages(total, req.GetPageSize()),
 		},
 	}, nil
+}
+
+func (h *ProjectHandler) hasPlatformPermissionForFilter(ctx context.Context, permFilter project.PermissionFilter) (bool, error) {
+	for _, perm := range project.PermissionsForFilter(permFilter) {
+		allowed, err := h.authzService.VerifyPlatformPermission(ctx, perm)
+		if err != nil {
+			return false, err
+		}
+		if allowed {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (h *ProjectHandler) UpdateProject(ctx context.Context, req *projectv1alpha1.UpdateProjectRequest) (*projectv1alpha1.UpdateProjectResponse, error) {
@@ -403,6 +430,19 @@ func convertDomainRoleToProto(r role.RoleType) projectv1alpha1.ProjectRoleType {
 		return projectv1alpha1.ProjectRoleType_ROLE_TYPE_PROJECT_VIEWER
 	default:
 		return projectv1alpha1.ProjectRoleType_ROLE_TYPE_PROJECT_VIEWER
+	}
+}
+
+func convertProtoPermissionFilterToDomain(f projectv1alpha1.ProjectPermissionFilter) project.PermissionFilter {
+	switch f {
+	case projectv1alpha1.ProjectPermissionFilter_PERMISSION_FILTER_MANAGED_ONLY:
+		return project.PermissionFilterManagedOnly
+	case projectv1alpha1.ProjectPermissionFilter_PERMISSION_FILTER_CAN_WRITE:
+		return project.PermissionFilterCanWrite
+	case projectv1alpha1.ProjectPermissionFilter_PERMISSION_FILTER_CAN_READ:
+		return project.PermissionFilterCanRead
+	default:
+		return project.PermissionFilterUnspecified
 	}
 }
 

--- a/internal/domain/authz/authz_service.go
+++ b/internal/domain/authz/authz_service.go
@@ -116,7 +116,6 @@ func (s *AuthzService) getUserPermissions(ctx context.Context, id *user.Identity
 	if err != nil {
 		return nil, err
 	}
-
 	return append(platformPerms, projectPerms...), nil
 }
 

--- a/internal/domain/authz/authz_service.go
+++ b/internal/domain/authz/authz_service.go
@@ -108,6 +108,9 @@ func (s *AuthzService) getUserPermissions(ctx context.Context, id *user.Identity
 	if err != nil {
 		return nil, err
 	}
+	if projectId == 0 {
+		return platformPerms, nil
+	}
 
 	projectPerms, err := s.authzRepo.GetUserProjectPermissions(ctx, id.GetID(), projectId)
 	if err != nil {

--- a/internal/domain/project/project.go
+++ b/internal/domain/project/project.go
@@ -70,7 +70,7 @@ const (
 func PermissionsForFilter(f PermissionFilter) []role.Permission {
 	switch f {
 	case PermissionFilterCanWrite:
-		return []role.Permission{role.ModelPush, role.DatasetPush}
+		return role.ProjectWritePermission
 	default:
 		return []role.Permission{role.ProjectGet}
 	}

--- a/internal/domain/project/project.go
+++ b/internal/domain/project/project.go
@@ -54,6 +54,28 @@ func (p *Project) IsPublic() bool {
 	return p.Type == ProjectTypePublic
 }
 
+type PermissionFilter int
+
+const (
+	PermissionFilterUnspecified PermissionFilter = iota
+	PermissionFilterManagedOnly
+	PermissionFilterCanWrite
+	PermissionFilterCanRead
+)
+
+// PermissionsForFilter maps a PermissionFilter to the permission points that
+// satisfy it. CanWrite requires write access to models or datasets (OR logic);
+// all other filters require read access. It is a domain rule shared by both the
+// handler (platform-level checks) and the repo (project-level checks).
+func PermissionsForFilter(f PermissionFilter) []role.Permission {
+	switch f {
+	case PermissionFilterCanWrite:
+		return []role.Permission{role.ModelPush, role.DatasetPush}
+	default:
+		return []role.Permission{role.ProjectGet}
+	}
+}
+
 type MemberType string
 
 const (
@@ -87,7 +109,7 @@ type IProjectRepo interface {
 	GetProjectByID(ctx context.Context, id int) (*Project, error)
 	GetProjectByName(ctx context.Context, name string) (*Project, error)
 	GetProjectIDByName(ctx context.Context, name string) (int, error)
-	ListProjects(ctx context.Context, name string, projectType ProjectType, managedOnly bool, hasPlatformProjectGet bool, page, pageSize int) ([]*Project, int64, error)
+	ListProjects(ctx context.Context, name string, projectType ProjectType, permFilter PermissionFilter, hasPlatformPermission bool, page, pageSize int) ([]*Project, int64, error)
 	UpdateProject(ctx context.Context, project *Project) error
 	DeleteProject(ctx context.Context, id int) error
 	ListProjectInfoByNames(ctx context.Context, names []string) ([]*Project, error)

--- a/internal/domain/role/role.go
+++ b/internal/domain/role/role.go
@@ -34,6 +34,8 @@ const (
 	ProjectRoleViewer
 )
 
+var ProjectWritePermission = []Permission{ModelPush, DatasetPush}
+
 // Role represents a role in the system
 type Role struct {
 	ID          int            `gorm:"primary_key"`

--- a/internal/repo/project_db.go
+++ b/internal/repo/project_db.go
@@ -18,12 +18,9 @@ import (
 	"context"
 	"errors"
 
-	"github.com/samber/lo"
 	"gorm.io/gorm"
 
-	"github.com/matrixhub-ai/matrixhub/internal/domain/auth"
 	"github.com/matrixhub-ai/matrixhub/internal/domain/project"
-	"github.com/matrixhub-ai/matrixhub/internal/domain/robot"
 	"github.com/matrixhub-ai/matrixhub/internal/domain/role"
 	"github.com/matrixhub-ai/matrixhub/internal/domain/user"
 	"github.com/matrixhub-ai/matrixhub/internal/infra/utils"
@@ -112,7 +109,7 @@ func (r *ProjectDBRepo) GetProjectIDByName(ctx context.Context, name string) (in
 	return p.ID, nil
 }
 
-func (r *ProjectDBRepo) ListProjects(ctx context.Context, name string, projectType project.ProjectType, managedOnly bool, hasPlatformProjectGet bool, page, pageSize int) (projects []*project.Project, total int64, err error) {
+func (r *ProjectDBRepo) ListProjects(ctx context.Context, name string, projectType project.ProjectType, permFilter project.PermissionFilter, hasPlatformPermission bool, page, pageSize int) (projects []*project.Project, total int64, err error) {
 	query := r.db.WithContext(ctx).Model(&project.Project{})
 
 	if name != "" {
@@ -122,33 +119,21 @@ func (r *ProjectDBRepo) ListProjects(ctx context.Context, name string, projectTy
 		query = query.Where("type = ?", projectType)
 	}
 
-	if !hasPlatformProjectGet {
-		identity, ok := auth.IdentityFromContext(ctx)
-		if !ok {
-			return
-		}
-		var accessibleIDs []int
-		switch identity.(type) {
-		case *user.Identity:
-			accessibleIDs, err = r.userProjectIDsWithPermission(ctx, identity.GetID(), role.ProjectGet)
-			if err != nil {
-				return
-			}
-		case *robot.Identity:
-			accessibleIDs, err = r.robotProjectIDsWithPermission(ctx, identity.GetID(), role.ProjectGet)
-			if err != nil {
-				return
-			}
-		default:
-			return
+	if !hasPlatformPermission {
+		requiredPerms := project.PermissionsForFilter(permFilter)
+
+		accessibleIDs, err := r.userProjectIDsWithAnyPermission(ctx, user.GetCurrentUserId(ctx), requiredPerms)
+		if err != nil {
+			return nil, 0, err
 		}
 
-		if managedOnly {
+		switch permFilter {
+		case project.PermissionFilterManagedOnly, project.PermissionFilterCanWrite:
 			if len(accessibleIDs) == 0 {
 				return []*project.Project{}, 0, nil
 			}
 			query = query.Where("projects.id IN ?", accessibleIDs)
-		} else {
+		default:
 			if len(accessibleIDs) == 0 {
 				query = query.Where("type = ?", project.ProjectTypePublic)
 			} else {
@@ -179,7 +164,7 @@ func (r *ProjectDBRepo) ListProjects(ctx context.Context, name string, projectTy
 	return
 }
 
-func (r *ProjectDBRepo) userProjectIDsWithPermission(ctx context.Context, userID int, perm role.Permission) ([]int, error) {
+func (r *ProjectDBRepo) userProjectIDsWithAnyPermission(ctx context.Context, userID int, perms []role.Permission) ([]int, error) {
 	type binding struct {
 		ProjectID   int
 		Permissions role.PermissionList
@@ -198,25 +183,14 @@ func (r *ProjectDBRepo) userProjectIDsWithPermission(ctx context.Context, userID
 
 	ids := make([]int, 0, len(bindings))
 	for _, b := range bindings {
-		if role.MatchPermissions(b.Permissions, perm) {
-			ids = append(ids, b.ProjectID)
+		for _, perm := range perms {
+			if role.MatchPermissions(b.Permissions, perm) {
+				ids = append(ids, b.ProjectID)
+				break
+			}
 		}
 	}
 	return ids, nil
-}
-
-func (r *ProjectDBRepo) robotProjectIDsWithPermission(ctx context.Context, robotId int, perm role.Permission) ([]int, error) {
-	var rb robot.Robot
-	err := r.db.WithContext(ctx).Where("id = ?", robotId).Preload("Projects").First(&rb).Error
-	if err != nil {
-		return nil, err
-	}
-	if !role.MatchPermissions(rb.ProjectPermissions, perm) {
-		return nil, nil
-	}
-	return lo.Map(rb.Projects, func(item *project.Project, _ int) int {
-		return item.ID
-	}), nil
 }
 
 func (r *ProjectDBRepo) UpdateProject(ctx context.Context, p *project.Project) error {

--- a/ui/src/features/models/components/ModelsFilterPanel.tsx
+++ b/ui/src/features/models/components/ModelsFilterPanel.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 
 import {
   useModelLibraryLabels,
-  useModelProjects,
+  useReadableModelProjects,
   useModelTaskLabels,
 } from '@/features/models/models.query'
 import { LibraryFilterPanel } from '@/shared/components/resource-filter-panel/LibraryFilterPanel'
@@ -58,7 +58,7 @@ export function ModelsFilterPanel() {
   const {
     data: projects = [],
     isLoading: projectsLoading,
-  } = useModelProjects()
+  } = useReadableModelProjects()
 
   const search = modelsRouteApi.useSearch()
   const {

--- a/ui/src/features/models/models.query.ts
+++ b/ui/src/features/models/models.query.ts
@@ -5,7 +5,7 @@ import {
   type ListModelsRequest,
   Models,
 } from '@matrixhub/api-ts/v1alpha1/model.pb'
-import { Projects } from '@matrixhub/api-ts/v1alpha1/project.pb'
+import { ProjectPermissionFilter, Projects } from '@matrixhub/api-ts/v1alpha1/project.pb'
 import { queryOptions, useQuery } from '@tanstack/react-query'
 
 import { DEFAULT_PAGE_SIZE } from '@/utils/constants.ts'
@@ -27,7 +27,7 @@ export const modelKeys = {
 
   taskLabels: () => [...modelKeys.all, 'task-labels'] as const,
   libraryLabels: () => [...modelKeys.all, 'library-labels'] as const,
-  projects: () => [...modelKeys.all, 'projects'] as const,
+  projects: (permissionFilter: ProjectPermissionFilter) => [...modelKeys.all, 'projects', permissionFilter] as const,
 
   commits: () => [...modelKeys.all, 'commit-list'] as const,
   commitsList: (projectId: string, modelName: string, params: Pick<ListModelCommitsRequest, 'revision' | 'page' | 'pageSize'>) => [
@@ -246,18 +246,29 @@ export function useModelLibraryLabels() {
   })
 }
 
-export function useModelProjects() {
-  return useQuery({
-    queryKey: modelKeys.projects(),
+function modelProjectsQueryOptions(permissionFilter: ProjectPermissionFilter) {
+  return queryOptions({
+    queryKey: modelKeys.projects(permissionFilter),
     queryFn: async () => {
       const response = await Projects.ListProjects({
         page: 1,
         pageSize: -1,
+        permissionFilter,
       })
 
       return response.projects ?? []
     },
   })
+}
+
+// Marketplace filter panel: any project the user can read (incl. public).
+export function useReadableModelProjects() {
+  return useQuery(modelProjectsQueryOptions(ProjectPermissionFilter.PERMISSION_FILTER_CAN_READ))
+}
+
+// Create-model page: only projects the user can push models to.
+export function useWritableModelProjects() {
+  return useQuery(modelProjectsQueryOptions(ProjectPermissionFilter.PERMISSION_FILTER_CAN_WRITE))
 }
 
 // -- Internal helpers --

--- a/ui/src/features/models/pages/ModelCreatePage.tsx
+++ b/ui/src/features/models/pages/ModelCreatePage.tsx
@@ -13,7 +13,7 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { createModelMutationOptions } from '@/features/models/models.mutation'
-import { useModelProjects } from '@/features/models/models.query.ts'
+import { useWritableModelProjects } from '@/features/models/models.query.ts'
 import { createModelSchema } from '@/features/models/models.schema'
 import { ProjectSelect } from '@/shared/components/ProjectSelect'
 import { useForm } from '@/shared/hooks/useForm'
@@ -66,7 +66,7 @@ export function ModelCreatePage({ initialProjectId = '' }: ModelCreatePageProps)
     },
   })
 
-  const { data: projects = [] } = useModelProjects()
+  const { data: projects = [] } = useWritableModelProjects()
 
   useEffect(() => {
     const projectId = form.state.values.projectId

--- a/ui/src/features/projects/projects.query.ts
+++ b/ui/src/features/projects/projects.query.ts
@@ -1,4 +1,4 @@
-import { Projects } from '@matrixhub/api-ts/v1alpha1/project.pb'
+import { Projects, ProjectPermissionFilter } from '@matrixhub/api-ts/v1alpha1/project.pb'
 import {
   keepPreviousData,
   queryOptions,
@@ -35,7 +35,7 @@ export function projectsQueryOptions(search: ProjectsSearch) {
       name: search.query || undefined,
       page: search.page,
       pageSize: DEFAULT_PROJECTS_PAGE_SIZE,
-      managedOnly: true,
+      permissionFilter: ProjectPermissionFilter.PERMISSION_FILTER_MANAGED_ONLY,
     }),
   })
 }


### PR DESCRIPTION
# What type of PR is this?

/kind feature
/kind api-change

# What this PR does / why we need it:
### Summary
- Replace `managed_only` bool with a `ProjectPermissionFilter` enum on `ListProjects`, letting the frontend scope results per use case.
- `CAN_WRITE`: projects the user can push to (`model.push` OR `dataset.push`) — create-model/dataset pages.
- `CAN_READ` / `UNSPECIFIED`: readable projects + all public projects — model marketplace.
- `MANAGED_ONLY`: only explicitly authorized projects, public excluded — project management.
- Platform-level permission holders (e.g. `*.*` admin) bypass filtering and see all projects.

### Compatibility
Enum wire values stay backward compatible with the old `managed_only` bool: `false`→`0/UNSPECIFIED`, `true`→`1/MANAGED_ONLY`. Existing clients keep working.

### Design
Filter→permission mapping centralized in `project.PermissionsForFilter`, shared by the handler (platform-level check) and repo (project-level check). Write permissions are an OR set (model.push OR dataset.push), not model-only.

# Which issue(s) this PR fixes:
Fixes
#424
Special notes for your reviewer:
Does this PR introduce a user-facing change?


