### PR TITLE
docs(website): point community channel to CNCF Slack #matrixhub

### DIFF
--- a/website/i18n/zh-CN/code.json
+++ b/website/i18n/zh-CN/code.json
@@ -481,10 +481,10 @@
     "message": "社区频道"
   },
   "community.channels.description": {
-    "message": "在 Discord、GitHub Discussions 或我们的邮件列表中参与交流。"
+    "message": "加入 CNCF Slack 的 #matrixhub 频道，与维护者和用户交流。"
   },
   "community.channels.linkText": {
-    "message": "加入 Discord →"
+    "message": "加入 CNCF Slack 的 #matrixhub →"
   },
   "community.title": {
     "message": "社区"

--- a/website/src/pages/community.tsx
+++ b/website/src/pages/community.tsx
@@ -21,9 +21,9 @@ export default function Community(): React.ReactElement {
     {
       emoji: '💬',
       title: translate({ id: 'community.channels.title', message: 'Community Channels' }),
-      description: translate({ id: 'community.channels.description', message: 'Join the conversation on Discord, GitHub Discussions, or our mailing list.' }),
-      linkText: translate({ id: 'community.channels.linkText', message: 'Join Discord →' }),
-      href: 'https://discord.gg/Jwbvn46Bc8',
+      description: translate({ id: 'community.channels.description', message: 'Join the #matrixhub channel on CNCF Slack to chat with maintainers and users.' }),
+      linkText: translate({ id: 'community.channels.linkText', message: 'Join #matrixhub on CNCF Slack →' }),
+      href: 'https://cloud-native.slack.com/archives/C0A8UKWR8HG',
     },
   ];
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The community page on the website still links to a Discord invite, but the
project's CONTRIBUTING, README, MAINTAINERS, and GOVERNANCE all point
contributors to the CNCF Slack `#matrixhub` channel
(https://cloud-native.slack.com/archives/C0A8UKWR8HG).

This PR updates the community page (and its zh-CN translation) so the
link, button text, and description match the rest of the project.

Changes:
- `website/src/pages/community.tsx`: replace the Discord card with one pointing to `#matrixhub` on CNCF Slack.
- `website/i18n/zh-CN/code.json`: update the matching zh-CN translations.

#### Which issue(s) this PR fixes:

Refs #659

#### Special notes for your reviewer:

The CNCF Slack channel already exists and is referenced from CONTRIBUTING.md, README.md, MAINTAINERS.md, and GOVERNANCE.md — this PR just brings the website in sync.

#### Does this PR introduce a user-facing change?

```release-note
docs(website): community page now links to the CNCF Slack `#matrixhub` channel instead of Discord.
```
