### PR TITLE
docs(issue-template): add subtask templates, rename enhancement to feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/BACKEND_TASK.md
+++ b/.github/ISSUE_TEMPLATE/BACKEND_TASK.md
@@ -1,0 +1,25 @@
+---
+name: Backend Task
+about: A backend task. Defaults to a subtask of a parent issue
+title: "[Backend] "
+labels: kind/feature
+
+---
+<!-- Defaults to a subtask of a parent (tracking) issue. To use as a standalone/normal issue, overwrite the requirement section below with the actual details. -->
+
+**What is the requirement and Why is this needed**:
+
+The requirements are detailed in the parent issue.
+
+---
+
+**Completion requirements**:
+
+It requires the following artifacts:
+
+- [ ] **Technical design (doc)**: <!-- link the design/approach; get maintainer review before coding -->
+- [ ] **UT** <!-- unit tests for new domain/jobserver logic; patch coverage gate must pass -->
+- [ ] **E2E** <!-- relevant e2e scenarios pass (smoke or targeted) -->
+- [ ] **API change**: <!-- list new/changed proto or HTTP APIs, or "none" -->
+
+The artifacts above should be linked in this issue or the associated PR.

--- a/.github/ISSUE_TEMPLATE/DOC_TASK.md
+++ b/.github/ISSUE_TEMPLATE/DOC_TASK.md
@@ -1,0 +1,22 @@
+---
+name: Doc Task
+about: A documentation task. Defaults to a subtask of a parent issue
+title: "[Doc] "
+labels: kind/documentation
+
+---
+<!-- Defaults to a subtask of a parent (tracking) issue. To use as a standalone/normal issue, overwrite the requirement section below with the actual details. -->
+
+**What is the requirement and Why is this needed**:
+
+The requirements are detailed in the parent issue.
+
+---
+
+**Completion requirements**:
+
+It requires the following artifacts:
+
+- [ ] **Final user doc link**: <!-- paste the URL of the published/merged user-facing usage documentation -->
+
+The final user documentation link above is required before this subtask can be closed.

--- a/.github/ISSUE_TEMPLATE/FEATURE.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE.md
@@ -1,10 +1,10 @@
 ---
-name: Enhancement Request
-about: Suggest an enhancement to the MatrixHub project
+name: Feature
+about: Suggest a new feature or enhancement for the MatrixHub project
 labels: kind/feature
 
 ---
-<!-- Please only use this template for submitting enhancement requests -->
+<!-- Please only use this template for submitting feature requests -->
 
 **What would you like to be added**:
 
@@ -12,10 +12,11 @@ labels: kind/feature
 
 **Completion requirements**:
 
-This enhancement requires the following artifacts:
+This feature requires the following artifacts:
 
 - [ ] Design doc
 - [ ] API change
+- [ ] Test
 - [ ] Docs update
 
 The artifacts should be linked in subsequent comments.

--- a/.github/ISSUE_TEMPLATE/QA_TASK.md
+++ b/.github/ISSUE_TEMPLATE/QA_TASK.md
@@ -1,0 +1,24 @@
+---
+name: QA Task
+about: A QA task. Defaults to a subtask of a parent issue
+title: "[QA] "
+labels: kind/feature, area/test
+
+---
+<!-- Defaults to a subtask of a parent (tracking) issue. To use as a standalone/normal issue, overwrite the requirement section below with the actual details. -->
+
+**What is the requirement and Why is this needed**:
+
+The requirements are detailed in the parent issue.
+
+---
+
+**Completion requirements**:
+
+It requires the following artifacts:
+
+- [ ] **Test Cases**: <!-- link the test cases / scenarios to be covered -->
+- [ ] **Manual Test** <!-- manual verification steps performed, with results -->
+- [ ] **Verify user docs** <!-- follow the user-facing documentation and confirm the steps/examples are accurate and work -->
+
+The artifacts above should be linked in this issue or the associated PR.

--- a/.github/ISSUE_TEMPLATE/UI_TASK.md
+++ b/.github/ISSUE_TEMPLATE/UI_TASK.md
@@ -1,0 +1,12 @@
+---
+name: UI Task
+about: A UI task. Defaults to a subtask of a parent issue
+title: "[UI] "
+labels: kind/feature, area/ui
+
+---
+<!-- Defaults to a subtask of a parent (tracking) issue. To use as a standalone/normal issue, overwrite the requirement section below with the actual details. -->
+
+**What is the requirement and Why is this needed**:
+
+The requirements are detailed in the parent issue.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,3 @@
-component:ui:
+area/ui:
   - changed-files:
       - any-glob-to-any-file: 'ui/**'


### PR DESCRIPTION
## What

Adds a set of **compatible** issue task templates, tidies the existing ones, and aligns the labeler config with a renamed label.

- **Backend / UI / QA / Doc task templates** — each defaults to a *subtask of a parent issue* (requirements live in the parent), but can be overwritten to use as a standalone issue. Each prefills a `[Area]` title prefix.
  - **Backend**: Completion requirements — Technical design (doc), API change, UT, E2E.
  - **UI**: lightweight (no checklist).
  - **QA**: Test Cases, Manual Test, Verify user docs.
  - **Doc**: requires the final user-facing documentation link before closing.
- **Rename** `Enhancement Request` → `Feature` (aligns the template name with its `kind/feature` label).
- **labeler.yml**: rename the `component:ui` rule to `area/ui` to match the renamed label.

## Why

Give a consistent, low-overhead way to break a feature into per-area subtasks while keeping the parent issue as the single source of requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)