### PR TITLE
ci: gate new code on unit-test patch coverage via Codecov

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -45,4 +45,13 @@ jobs:
         continue-on-error: true
 
       - name: Run unit tests
-        run: go test cmd/... internal/... -short -count=1 -v
+        run: go test cmd/... internal/... -short -count=1 -v -coverprofile=coverage.out -covermode=atomic
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+          flags: unittests
+          # Required for private repos; for a public repo it is optional but recommended.
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+# Codecov configuration.
+# Docs: https://docs.codecov.com/docs/codecov-yaml
+coverage:
+  status:
+    # Patch = coverage of the lines changed in the PR. This is the merge gate:
+    # new/changed code must be covered by tests, or the check fails.
+    patch:
+      default:
+        target: 70%
+        informational: false
+    # Project = overall repo coverage. Kept informational for now so refactors
+    # and code removal don't block PRs or push teams toward padding tests.
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: true


### PR DESCRIPTION
## What

Adds a unit-test coverage gate so **new/changed code must be covered by unit tests**.

- `unit-test.yml`: run `go test` with `-coverprofile=coverage.out -covermode=atomic` and upload to Codecov (`flags: unittests`).
- `codecov.yml`:
  - **patch** coverage `target: 70%`, `informational: false` → enforced (the merge gate on changed lines).
  - **project** coverage kept `informational: true` for now, so refactors / code removal don't block PRs or push toward padding tests.

## How to make it actually block merges

1. Add **`codecov/patch`** to Branch protection → required status checks.
2. Set the **`CODECOV_TOKEN`** secret (required for private repos; optional but recommended for public).

## Why

CI currently runs unit tests but doesn't measure coverage, so untested new code can merge freely. A patch-coverage gate ensures added logic comes with tests, without the pain of a hard project-wide threshold.

E2E coverage gating is intentionally **not** included here — it's better tackled separately (Go binary `-cover` instrumentation merged into the same patch gate) once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)