### PR TITLE
fix(ci): correct RUN_E2E_LABELS so full e2e runs on PRs

### DIFF
--- a/.github/workflows/auto-pr-ci.yaml
+++ b/.github/workflows/auto-pr-ci.yaml
@@ -73,9 +73,9 @@ jobs:
             echo "RUN_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
             if ${{ steps.filter_pr.outputs.all_e2e == 'true' }} ; then
                 # run all e2e
-                echo "RUN_E2E_LABEL=all" >> $GITHUB_ENV
+                echo "RUN_E2E_LABELS=all" >> $GITHUB_ENV
             else
-                echo "RUN_E2E_LABEL=smoke" >> $GITHUB_ENV
+                echo "RUN_E2E_LABELS=smoke" >> $GITHUB_ENV
             fi
             echo "RUN_E2E_ENABLED=${{ steps.filter_pr.outputs.run_e2e }}" >> $GITHUB_ENV
             echo "RUN_UNITTEST_ENABLED=true" >> $GITHUB_ENV


### PR DESCRIPTION
## Problem

In `auto-pr-ci.yaml`, the PR-event branch sets **`RUN_E2E_LABEL`** (missing the trailing `S`):

```sh
echo "RUN_E2E_LABEL=all"   >> $GITHUB_ENV
echo "RUN_E2E_LABEL=smoke" >> $GITHUB_ENV
```

but the job output reads **`RUN_E2E_LABELS`**:

```yaml
e2e_labels: ${{ env.RUN_E2E_LABELS }}
```

So the smoke/all selection is written to an unused variable, `e2e_labels` is always empty on PRs, and `e2e-init.yaml` falls back to its default (`smoke`). The "run **all** e2e when `test/**`, charts, etc. change" logic never actually takes effect — every PR only runs smoke.

## Fix

Rename the two assignments to `RUN_E2E_LABELS` so they match the output and the `workflow_dispatch` branch (which already uses the correct name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)