### PR TITLE
docs: publish demo site link and login credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 **MatrixHub** is an open-source, self-hosted AI model registry engineered for large-scale enterprise inference. It serves as a drop-in private replacement for Hugging Face, purpose-built to accelerate **vLLM** and **SGLang** workloads.
 
+## 🌐 Live Demo
+
+Try MatrixHub instantly at **[demo.matrixhub.ai](https://demo.matrixhub.ai/)** — no setup required.
+
+Sign in with the public demo credentials:
+
+| Username | Password |
+| --- | --- |
+| `admin` | `changeme` |
+
+> The demo is for evaluation only and may be reset at any time.
+
 ## 💡 Why MatrixHub?
 
 MatrixHub streamlines the transition from public model hubs to production-grade infrastructure:

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -6,6 +6,12 @@ sidebar_position: 1
 
 Welcome to **MatrixHub**—an open-source, self-hosted AI model registry engineered for large-scale enterprise inference. It serves as a **drop-in private replacement for Hugging Face**, purpose-built to accelerate **vLLM** and **SGLang** workloads.
 
+:::tip Live Demo
+Try MatrixHub instantly at **[demo.matrixhub.ai](https://demo.matrixhub.ai/)**—no setup required.
+
+Sign in with the public demo credentials: username `admin`, password `changeme`. The demo is for evaluation only and may be reset at any time.
+:::
+
 ## Why MatrixHub?
 
 MatrixHub streamlines the transition from public model hubs to production-grade infrastructure:

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/intro.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/intro.md
@@ -7,6 +7,12 @@ title: 介绍
 
 欢迎使用 **MatrixHub**——这是一个专为大规模企业级推理而设计的开源、支持私有化部署的 AI 模型中心。它可以作为 **Hugging Face 的私有替代方案** 实现开箱即用的替换，专门用于加速 **vLLM** 和 **SGLang** 等推理工作负载。
 
+:::tip 在线体验
+无需安装，立即访问 **[demo.matrixhub.ai](https://demo.matrixhub.ai/)** 体验 MatrixHub。
+
+使用公开演示账号登录：用户名 `admin`，密码 `changeme`。演示环境仅供评估，数据可能随时被重置。
+:::
+
 ## 为什么选择 MatrixHub？
 
 MatrixHub 简化了从公共模型中心向生产级基础设施过渡的过程：


### PR DESCRIPTION
## What

Publishes the demo site as a user-facing entry point and documents how to sign in:

- **README**: new "🌐 Live Demo" section with the link **https://demo.matrixhub.ai/** and the public credentials (`admin` / `changeme`).
- **Website intro** (EN `website/docs/intro.md` and zh-CN i18n): a "Live Demo" tip admonition with the same link and credentials.

The link uses `https://` (http redirects to https → 200).

## Why

The demo requires login. Showing the link without credentials leaves users stuck after opening the site. Presenting the link and credentials together is effectively the public release of the demo.

Fixes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)