### PR TITLE
docs(issue-template): rename completion section to checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-FEATURE.md
+++ b/.github/ISSUE_TEMPLATE/01-FEATURE.md
@@ -10,13 +10,11 @@ labels: kind/feature
 
 **Why is this needed**:
 
-**Completion requirements**:
-
-This feature requires the following artifacts:
+**Completion checklist**:
 
 - [ ] Design doc
 - [ ] API change
 - [ ] Test
 - [ ] Docs update
 
-The artifacts should be linked in subsequent comments.
+The artifacts above should be described or linked in this checklist or the associated PR/issues.

--- a/.github/ISSUE_TEMPLATE/07-BACKEND_TASK.md
+++ b/.github/ISSUE_TEMPLATE/07-BACKEND_TASK.md
@@ -13,13 +13,11 @@ The requirements are detailed in the parent issue.
 
 ---
 
-**Completion requirements**:
-
-It requires the following artifacts:
+**Completion checklist**:
 
 - [ ] **Technical design (doc)**: <!-- link the design/approach; get maintainer review before coding -->
 - [ ] **UT** <!-- unit tests for new domain/jobserver logic; patch coverage gate must pass -->
 - [ ] **E2E** <!-- relevant e2e scenarios pass (smoke or targeted) -->
 - [ ] **API change**: <!-- list new/changed proto or HTTP APIs, or "none" -->
 
-The artifacts above should be linked in this issue or the associated PR.
+The artifacts above should be described or linked in this checklist or the associated PR.

--- a/.github/ISSUE_TEMPLATE/09-QA_TASK.md
+++ b/.github/ISSUE_TEMPLATE/09-QA_TASK.md
@@ -13,12 +13,10 @@ The requirements are detailed in the parent issue.
 
 ---
 
-**Completion requirements**:
-
-It requires the following artifacts:
+**Completion checklist**:
 
 - [ ] **Test Cases**: <!-- link the test cases / scenarios to be covered -->
 - [ ] **Manual Test** <!-- manual verification steps performed, with results -->
-- [ ] **Verify user docs** <!-- follow the user-facing documentation and confirm the steps/examples are accurate and work -->
+- [ ] **Adjust and verify user docs** <!-- follow the user-facing documentation and confirm the steps/examples are accurate and work; user doc link is in the Doc task or Backend task -->
 
-The artifacts above should be linked in this issue or the associated PR.
+The artifacts above should be described or linked in this checklist or the associated PR.

--- a/.github/ISSUE_TEMPLATE/10-DOC_TASK.md
+++ b/.github/ISSUE_TEMPLATE/10-DOC_TASK.md
@@ -13,10 +13,8 @@ The requirements are detailed in the parent issue.
 
 ---
 
-**Completion requirements**:
-
-It requires the following artifacts:
+**Completion checklist**:
 
 - [ ] **Final user doc link**: <!-- paste the URL of the published/merged user-facing usage documentation -->
 
-The final user documentation link above is required before this subtask can be closed.
+The artifacts above should be described or linked in this checklist.


### PR DESCRIPTION
## Summary
- Rename **Completion requirements** to **Completion checklist** in Feature, Backend, QA, and Doc issue templates
- Remove redundant "It requires the following artifacts" intro lines
- Unify closing guidance: artifacts should be described or linked in the checklist or associated PR
- QA task: rename **Verify user docs** to **Adjust and verify user docs**, with a note that the user doc link lives in the Doc or Backend task

## Test plan
- [ ] Open **New issue** and preview Feature / Backend / QA / Doc templates; confirm section title and checklist wording


Made with [Cursor](https://cursor.com)