### PR TITLE
docs: harden contributor & security docs for CNCF sandbox

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,24 @@
+# Adopters
+
+This file lists organizations that use MatrixHub. Sharing your adoption helps the project build credibility and grow the community.
+
+MatrixHub is an open-source, self-hosted, Hugging Face–compatible model registry for enterprise AI inference on Kubernetes.
+
+## How to add your organization
+
+Open a pull request that updates this file. Use a commit message like `docs: add <ORGANIZATION> to ADOPTERS.md` and follow [CONTRIBUTING.md](CONTRIBUTING.md).
+
+Please include:
+
+- Organization name (with a link if public)
+- Contact (GitHub handle or email)
+- A short description of how MatrixHub is used
+- **Environment** — for example `Production`, `POC`, or `Evaluation`
+
+If you need permission to list your company publicly, obtain it before submitting.
+
+## MatrixHub adopters
+
+| Organization | Contact | Environment | Description of use |
+| ------------ | ------- | ----------- | ------------------ |
+| [DaoCloud](https://daocloud.io) | kay.yan@daocloud.io | Internal POC | DaoCloud runs MatrixHub inside the company as a **proof of concept** for a private model hub. The deployment targets Kubernetes (Helm), exercises Hugging Face–compatible access (`HF_ENDPOINT`), and evaluates workflows such as intranet model caching, project-scoped repositories, and operational readiness ahead of broader production use. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,62 +1,208 @@
-# Contributing Guidelines
+# Contributing to MatrixHub
 
-Welcome to MatrixHub! We are excited to have you here. This project follows the CNCF [Code of Conduct](CODE_OF_CONDUCT.md). An excerpt:
+Welcome, and thank you for your interest in contributing to MatrixHub! 🎉
 
-_As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities._
+MatrixHub is a community-led open source project. Contributions of all kinds are
+welcome — code, tests, documentation, bug reports, design feedback, reviews, and
+helping other users. This guide explains how to get involved.
 
-## Before You Start
+By participating, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md)
+(the CNCF Code of Conduct).
 
-- Read the [Code of Conduct](CODE_OF_CONDUCT.md).
-- Check open [issues](https://github.com/matrixhub-ai/matrixhub/issues) and [pull requests](https://github.com/matrixhub-ai/matrixhub/pulls) to avoid duplicate work.
+## Ways to contribute
 
-## Local Development
+You don't have to write code to make a difference:
+
+- **Report bugs** and **request features** using the [issue templates](https://github.com/matrixhub-ai/matrixhub/issues/new/choose).
+- **Improve documentation** — the `docs/`, the `website/`, and inline docs.
+- **Review pull requests** and help triage issues.
+- **Answer questions** and help others in [Slack](https://cloud-native.slack.com/archives/C0A8UKWR8HG) and [GitHub Discussions](https://github.com/matrixhub-ai/matrixhub/discussions).
+- **Write code** — bug fixes and features.
+
+New here? Look for issues labeled
+[`good first issue`](https://github.com/matrixhub-ai/matrixhub/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+and
+[`help wanted`](https://github.com/matrixhub-ai/matrixhub/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+Feel free to comment on an issue to let us know you're working on it.
+
+## Reporting issues
+
+- **Bugs & features:** open an issue via the [templates](https://github.com/matrixhub-ai/matrixhub/issues/new/choose).
+  Before filing, please search existing [issues](https://github.com/matrixhub-ai/matrixhub/issues)
+  and [pull requests](https://github.com/matrixhub-ai/matrixhub/pulls) to avoid duplicates.
+- **Security vulnerabilities:** **do not** open a public issue. Follow the private
+  reporting process in [SECURITY.md](SECURITY.md).
+
+## Communication
+
+- **GitHub Issues / Pull Requests** — primary development venue.
+- **GitHub Discussions** — questions, ideas, and broader design conversations.
+- **Slack** — [`#matrixhub`](https://cloud-native.slack.com/archives/C0A8UKWR8HG) in the CNCF Slack workspace.
+- **Public roadmap** — [docs/roadmap.md](docs/roadmap.md).
+
+For large or breaking changes, please open an issue or discussion **before**
+investing significant implementation effort, so maintainers can align on the
+approach early (see [GOVERNANCE.md](GOVERNANCE.md)).
+
+## Local development
 
 ### Prerequisites
 
-- [Go](https://go.dev/)
-- [Node.js](https://nodejs.org/en)
+- [Go](https://go.dev/) (see the version in [`go.mod`](go.mod))
+- [Node.js](https://nodejs.org/en) + [pnpm](https://pnpm.io/) (for the UI and website)
+- [Docker](https://www.docker.com/) (for MySQL and building images)
+- MySQL — required by the API server (see [docs/development.md](docs/development.md))
 
-### Build and run
+### Run the API server
+
+The API server needs MySQL running first (see [docs/development.md](docs/development.md)
+for the connection setup):
 
 ```bash
-make build
-./bin/matrixhub
+make local-run-api        # go run ./cmd/matrixhub apiserver
 ```
 
-Open the app at http://localhost:9527.
+### Run the web frontend
 
-## Faster Builds with Proxies
+The UI dev server (Vite) runs separately and proxies API calls to the backend —
+no MySQL needed just to work on the frontend:
 
-If downloads are slow, you can use HTTP(S) proxies and an image mirror:
+```bash
+make local-run-web        # cd ui && pnpm i && pnpm dev
+```
+
+### Build a binary or container image
+
+```bash
+go build ./cmd/matrixhub  # build the matrixhub binary
+make image-build          # build the container image
+```
+
+### Documentation website
+
+```bash
+make serve-website        # run the docs site locally
+```
+
+### Faster builds behind a proxy
+
+If downloads are slow, use HTTP(S) proxies, an image mirror, and/or a Go module proxy:
 
 ```bash
 export HTTP_PROXY=http://your-proxy:port
 export HTTPS_PROXY=http://your-proxy:port
 export BASE_IMAGE_PREFIX=m.daocloud.io/docker.io
-make build
-```
-
-Or configure the Go module proxy:
-
-```bash
 export GOPROXY=https://goproxy.io,direct
-make build
+make image-build
 ```
 
-## Run with Docker Compose
+For a quick non-development run via Docker Compose, see the **Quick Start** in the
+[README](README.md).
 
-Build and start the local stack:
+## Making a change
+
+1. **Align on scope.** Open or pick up an issue (use the issue templates). For
+   large or complex work, agree on the approach in the issue/discussion first; for
+   complex backend changes, write a short design doc under `docs/design/` and get
+   maintainer review **before coding**.
+2. **Fork** the repository and create a topic branch.
+3. **Make your change**, following the architecture rules in
+   [AGENTS.md](AGENTS.md) (backend) and [ui/AGENTS.md](ui/AGENTS.md) (frontend).
+4. **Add tests** (see the [testing policy](#testing-policy)) and run them locally.
+5. **Run the checks** below and make sure they pass.
+6. **Sign your commits** (see [Developer Certificate of Origin](#developer-certificate-of-origin-dco)).
+7. **Open a pull request** that links the issue (e.g. `Closes #123`) and fills in
+   the PR checklist.
+
+## Coding standards
+
+- **License headers:** every Go source file must start with the Apache 2.0 license
+  header (enforced by the `goheader` linter).
+- **Linting:** run and fix lints before pushing:
+
+  ```bash
+  make lint-fix             # golangci-lint v2.8.0 with --fix
+  ```
+
+- **Generated code is not hand-edited.** Regenerate it after changing the source of
+  truth:
+
+  ```bash
+  make genproto             # after editing api/proto/v1alpha1/*.proto
+  make gen_openapi_sdk      # after swagger changes (test HTTP SDK)
+  make generate-mocks       # after changing a mocked interface
+  ```
+
+- Follow the conventions and dependency direction described in
+  [AGENTS.md](AGENTS.md) and [CLAUDE.md](CLAUDE.md).
+
+## Developer Certificate of Origin (DCO)
+
+All commits must be **signed off** to certify that you wrote the patch or otherwise
+have the right to submit it under the project's open source license, per the
+[Developer Certificate of Origin](https://developercertificate.org/).
+
+Add a `Signed-off-by` line by committing with `-s`:
 
 ```bash
-make compose-deploy
+git commit -s -m "Your commit message"
 ```
 
-## Run in local environment
+This adds a line like:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+The name and email must match your Git author identity. If you forget, you can
+amend the last commit with `git commit --amend -s`, or sign off a range of commits
+with `git rebase --signoff`.
+
+## Testing policy
+
+MatrixHub relies on an automated test suite to stay stable. As a matter of policy:
+
+- **New functionality and bug fixes MUST come with tests.** A pull request that
+  adds or changes behavior is expected to add or update automated tests covering
+  that behavior. Reviewers may request tests before approving.
+- **Domain logic must have unit tests.** Code under `internal/domain/...` and
+  `internal/jobserver/...` is pure, dependency-light logic and must be covered by
+  unit tests. Adapters (`internal/repo/...`) and transport/handlers are primarily
+  covered by end-to-end tests.
+- **Coverage of changed code is checked in CI.** New/changed lines are measured by
+  Codecov's patch report on each PR.
+
+### Running the tests
 
 ```bash
-go run main.go
+go test ./...                                  # all unit tests
+go test ./internal/jobserver/...               # jobserver logic (no DB needed)
+make test.e2e level=smoke                      # e2e against a running instance
+make test.e2e.kind                             # full e2e in a KIND cluster
 ```
 
-## Contact
+See [docs/development.md](docs/development.md) for prerequisites.
 
-- [Slack](https://cloud-native.slack.com/archives/C0A8UKWR8HG) - Join us in the CNCF Slack workspace.
+## Pull request and review process
+
+- Keep PRs focused and reasonably small; link the issue they address.
+- Ensure **CI is green** (lint, unit tests, and other checks) and that your commits
+  are **signed off**.
+- Reviews follow the [`OWNERS`](OWNERS) model: maintainers use `/lgtm` and `/approve`
+  on PRs. A PR is merged once it has the required approvals and CI passes.
+- Be responsive to review feedback; maintainers aim to review promptly but this is a
+  community project, so please be patient.
+
+See [GOVERNANCE.md](GOVERNANCE.md) for roles, decision making, and how to become a
+maintainer.
+
+## License of contributions
+
+MatrixHub is licensed under the [Apache License 2.0](LICENSE). By contributing, you
+agree that your contributions will be licensed under the same license (inbound =
+outbound), and you certify your right to do so via the DCO sign-off described above.
+
+---
+
+Thank you for helping make MatrixHub better! If anything here is unclear, open an
+issue or ask in [Slack](https://cloud-native.slack.com/archives/C0A8UKWR8HG).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -10,7 +10,7 @@ MatrixHub is an open-source, self-hosted model registry and distribution system 
 - Private deployment, caching, governance, replication, and air-gapped workflows
 - Cloud-native operation (Kubernetes, Helm, object storage)
 
-Out of scope items are tracked in the project roadmap and product direction; large changes should be discussed in issues before substantial implementation.
+Out of scope items are tracked in the [public roadmap](docs/roadmap.md) and discussed in GitHub issues or [Discussions](https://github.com/matrixhub-ai/matrixhub/discussions); large changes should be discussed there before substantial implementation.
 
 ## Roles
 
@@ -20,12 +20,14 @@ Anyone may contribute via issues, documentation, and pull requests under the [Co
 
 ### Maintainers
 
-Maintainers are listed in [MAINTAINERS.md](MAINTAINERS.md). They are responsible for:
+Maintainers are listed in [MAINTAINERS.md](MAINTAINERS.md). They hold merge authority and are responsible for:
 
 - Reviewing and merging pull requests
 - Cutting releases and publishing artifacts
 - Triaging issues and security reports ([SECURITY.md](SECURITY.md))
 - Upholding project quality, inclusivity, and technical direction
+
+The [OWNERS](OWNERS) file defines GitHub review labels (`/approve`, `/lgtm`) for day-to-day pull requests. The maintainer list in [MAINTAINERS.md](MAINTAINERS.md) is the source of truth for project leadership; approvers and reviewers in `OWNERS` should stay aligned with active maintainers.
 
 ### Emeritus maintainers
 
@@ -55,9 +57,17 @@ Removal or emeritus status follows the same process when a maintainer is inactiv
 - Release notes summarize user-visible changes and security fixes.
 - Maintainers decide release timing and versioning (semver where applicable).
 
+## Vendor neutrality
+
+MatrixHub is a community-led open source project. Technical direction, release priorities, and acceptance of contributions are decided in the interest of the project and its users—not to favor a single vendor, employer, or commercial offering.
+
+- Maintainers and contributors may work for different organizations; affiliation is disclosed in [MAINTAINERS.md](MAINTAINERS.md) and does not confer special control.
+- Commercial support, hosted services, or enterprise packaging built around MatrixHub are separate from the core repository. Features intended for the community are developed in public issues and pull requests on the default branch.
+- No single company may block community consensus on project direction, governance, or CNCF participation.
+
 ## Code of Conduct
 
-All participants must follow the [MatrixHub Code of Conduct](CODE_OF_CONDUCT.md). Maintainers may warn, moderate, or ban contributors for violations, consistent with that policy and platform rules (GitHub, CNCF Slack).
+All participants must follow the [MatrixHub Code of Conduct](CODE_OF_CONDUCT.md), which adopts the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md). Violations may be reported to the maintainers or to the CNCF Code of Conduct Committee at <conduct@cncf.io>. Maintainers may warn, moderate, or ban contributors for violations, consistent with that policy and platform rules (GitHub, CNCF Slack).
 
 ## Security
 
@@ -65,8 +75,8 @@ Security reporting and response are defined in [SECURITY.md](SECURITY.md). Maint
 
 ## Intellectual property
 
-- Contributions are accepted under the project’s [Apache License 2.0](LICENSE).
-- Contributors should sign commits per project contribution requirements (for example DCO when enabled).
+- Contributions are accepted under the project’s [Apache License 2.0](LICENSE) (inbound = outbound).
+- Contributors must sign off their commits under the [Developer Certificate of Origin (DCO)](https://developercertificate.org/); see [CONTRIBUTING.md](CONTRIBUTING.md).
 - Trademark and project asset policies may change if the project joins the CNCF; such changes will be announced to the community.
 
 ## Communication
@@ -78,7 +88,3 @@ Security reporting and response are defined in [SECURITY.md](SECURITY.md). Maint
 ## Amending this document
 
 Changes to `GOVERNANCE.md` require a pull request approved by at least **two-thirds of active maintainers**, with a **7-day** comment period for other maintainers and the community.
-
----
-
-_This governance model is a starting template. Replace `TODO` entries in [MAINTAINERS.md](MAINTAINERS.md) before submitting a CNCF Sandbox application._

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,33 @@ MatrixHub provides security fixes for maintained release branches. Versions that
 
 Check [GitHub releases](https://github.com/matrixhub-ai/matrixhub/releases) for the current supported version.
 
+## Scope
+
+**In scope** (please report):
+
+- The MatrixHub source code in this repository
+- Official container images (`ghcr.io/matrixhub-ai/matrixhub`) and the Helm chart
+- Authentication, authorization, multi-tenancy, and data-isolation issues
+
+**Out of scope** (please do not file as vulnerabilities):
+
+- The public demo at [demo.matrixhub.ai](https://demo.matrixhub.ai/) and its
+  documented default credentials (`admin` / `changeme`) — these are intentional for
+  evaluation only.
+- Vulnerabilities in third-party dependencies that are already publicly known and do
+  not have a MatrixHub-specific impact (these are tracked via Dependabot).
+- Issues that require physical access, a compromised host, or misconfiguration
+  contrary to the hardening guidance below.
+
+If you are unsure whether something is in scope, report it — we would rather triage a
+borderline report than miss a real issue.
+
+## Security contacts
+
+Security reports and triage are handled by the active maintainers listed in [MAINTAINERS.md](MAINTAINERS.md).
+
+For vulnerability reports, use the private reporting channel described below (not public issues or maintainer DMs).
+
 ## Reporting a vulnerability
 
 **Please do not report security vulnerabilities through public GitHub issues.**
@@ -32,6 +59,10 @@ When submitting an advisory, include:
 - Affected versions or commits
 - Any proof-of-concept or logs (avoid sharing secrets)
 
+### Bug bounty
+
+There is **no bug bounty program** at this time.
+
 ## Response expectations
 
 | Stage | Target |
@@ -44,12 +75,15 @@ These are goals, not guarantees. Complex issues may take longer.
 
 ## Disclosure process
 
-1. Reporter submits a private advisory or email.
+1. Reporter submits a private [GitHub Security Advisory](https://github.com/matrixhub-ai/matrixhub/security/advisories).
 2. Maintainers confirm the issue, assign severity, and develop a fix (often on a private branch).
 3. A patched release is published; credit is given to the reporter if desired.
-4. A public advisory or release note describes the issue after a fix is available.
+4. A public advisory is published via [GitHub Security Advisories (GHSA)](https://github.com/matrixhub-ai/matrixhub/security/advisories), and a **CVE ID is requested** where applicable. Release notes reference the fix.
 
-We follow coordinated disclosure: please allow reasonable time for a fix before public disclosure.
+We follow **coordinated disclosure**. We aim to disclose publicly once a fix is
+available, and ask reporters to observe an embargo of up to **90 days** from the
+initial report before public disclosure, to give users time to upgrade. We are happy
+to coordinate timing with the reporter and other affected projects.
 
 ## Security hardening (operators)
 
@@ -60,6 +94,31 @@ MatrixHub is often deployed on private networks. Operators should:
 - Keep dependencies and container images updated
 - Follow your organization’s model-artifact and supply-chain policies
 
+## Supply chain security
+
+MatrixHub publishes signed artifacts to help you verify provenance:
+
+- **Signed container images.** Release images are signed **keylessly** with
+  [Cosign](https://docs.sigstore.dev/) using GitHub Actions OIDC (Fulcio/Rekor), so
+  no long-lived signing keys are involved.
+- **Software Bill of Materials (SBOM).** An SPDX SBOM is generated for each release
+  image and attached alongside it.
+
+Verify an image and download its SBOM:
+
+```bash
+# Verify the signature (keyless, GitHub Actions OIDC)
+cosign verify \
+  --certificate-identity-regexp 'https://github.com/matrixhub-ai/matrixhub/.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  ghcr.io/matrixhub-ai/matrixhub:<tag>
+
+# Download the attached SBOM
+cosign download sbom ghcr.io/matrixhub-ai/matrixhub:<tag>
+```
+
 ## Comments on this policy
 
-Open a pull request against this file or discuss with maintainers on Slack (see [MAINTAINERS.md](MAINTAINERS.md)).
+Open a pull request against this file or discuss with maintainers in the
+[`#matrixhub`](https://cloud-native.slack.com/archives/C0A8UKWR8HG) channel on the
+CNCF Slack.


### PR DESCRIPTION
## Summary

Strengthen MatrixHub's collaboration & security documentation ahead of the CNCF Sandbox application. Docs-only change (no code).

- **CONTRIBUTING.md**: fix inaccurate commands (drop non-existent `make build` / `make compose-deploy` / `go run main.go`; use real targets `make local-run-api` / `make local-run-web` / `make image-build` / `go build ./cmd/matrixhub`). Add ways to contribute (`good first issue` / `help wanted`), issue & security reporting, communication channels, coding standards (lint, codegen, license headers), **DCO sign-off**, PR/review process (OWNERS `/lgtm` + `/approve`), and inbound=outbound licensing.
- **SECURITY.md**: add a **Scope** section (in/out of scope; clarify demo defaults are intentional), document coordinated disclosure with a **90-day embargo** + **GHSA/CVE** handling, and add a **Supply chain security** section (keyless cosign signing + SPDX SBOM) with verification commands.
- **GOVERNANCE.md**: align DCO wording with CONTRIBUTING (sign-off required; inbound=outbound) and point Code of Conduct reporting to `conduct@cncf.io`.
- **ADOPTERS.md** (new): add an adopters file (DaoCloud as internal POC) with instructions for organizations to add themselves.

## Notes

- The Dependabot `/web` → `/ui` fix is intentionally **not** included here; it is tracked separately in #703.

## Test plan

- [x] Documented commands match the current `Makefile` targets (verified).
- [x] Internal links resolve (`OWNERS`, `docs/development.md`, `MAINTAINERS.md`, `CODE_OF_CONDUCT.md`).