### PR TITLE
fix(project update): add prompt after api success

### DIFF
--- a/ui/src/features/projects/projects.mutation.ts
+++ b/ui/src/features/projects/projects.mutation.ts
@@ -47,6 +47,7 @@ export function updateProjectMutationOptions() {
     mutationFn: (input: UpdateProjectRequest) =>
       Projects.UpdateProject(input),
     meta: {
+      successMessage: i18n.t('projects.detail.settingsPage.updateSuccess'),
       errorMessage: i18n.t('projects.detail.settingsPage.updateError'),
       invalidates: [projectKeys.all],
     } satisfies NotificationMeta,

--- a/ui/src/locales/en/projects.json
+++ b/ui/src/locales/en/projects.json
@@ -21,6 +21,7 @@
       "proxyOrganization": "Proxy Organization",
       "save": "Save",
       "cancel": "Cancel",
+      "updateSuccess": "Project settings updated",
       "updateError": "Failed to update project settings"
     },
     "membersPage": {

--- a/ui/src/locales/zh/projects.json
+++ b/ui/src/locales/zh/projects.json
@@ -21,6 +21,7 @@
       "proxyOrganization": "代理组织",
       "save": "保存",
       "cancel": "取消",
+      "updateSuccess": "项目设置已更新",
       "updateError": "更新项目设置失败"
     },
     "membersPage": {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
Add prompt after update project api success

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #433

#### Special notes for your reviewer:

#### Checklist
<!-- For behavior changes, check the items below. If an item does not apply, leave it unchecked and explain in the reviewer notes above. -->
- [ ] UT/E2E added or updated
- [ ] User-facing behavior changes are documented

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Project settings now display a success notification after changes are saved.
```