### PR TITLE
docs: populate MAINTAINERS.md and add yankay as approver

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,14 +2,19 @@
 
 This file lists people responsible for the [MatrixHub](https://github.com/matrixhub-ai/matrixhub) project. Governance and decision-making are described in [GOVERNANCE.md](GOVERNANCE.md).
 
+Day-to-day PR review permissions (`/lgtm`, `/approve`) are defined in [OWNERS](OWNERS). This table lists **approvers** (project leadership); keep it aligned with the `approvers` list in `OWNERS`.
+
 ## Active maintainers
 
 | Name | GitHub | Email | Organization | Areas |
 |------|--------|-------|--------------|-------|
-| _TODO: Full name_ | [@TODO-github-id](https://github.com/TODO-github-id) | TODO@example.com | _TODO: Company or Independent_ | _e.g. core API, storage, Helm_ |
-| _TODO_ | [@TODO](https://github.com/TODO) | TODO@example.com | _TODO_ | _TODO_ |
+| Shiming Zhang | [@wzshiming](https://github.com/wzshiming) | shiming.zhang@daocloud.io | [DaoCloud](https://daocloud.io) | Core platform |
+| Chuanjia Lu | [@samzong](https://github.com/samzong) | samzong.lu@gmail.com | [LangGenius](https://langgenius.ai) | Core platform |
+| Yiting Jiang | [@yitingdc](https://github.com/yitingdc) | yiting.jiang@daocloud.io | [DaoCloud](https://daocloud.io) | Core platform |
+| Henry Liu | [@lsq645599166](https://github.com/lsq645599166) | henry.liu@daocloud.io | [DaoCloud](https://daocloud.io) | Frontend (`ui/`) |
+| Kay Yan | [@yankay](https://github.com/yankay) | kay.yan@daocloud.io | [DaoCloud](https://daocloud.io) | Core platform |
 
-> **How to update:** Open a pull request that updates this table. Adding or removing maintainers follows [GOVERNANCE.md](GOVERNANCE.md).
+> **How to update:** Open a pull request that updates this table and the `approvers` list in [OWNERS](OWNERS) together. Adding or removing maintainers follows [GOVERNANCE.md](GOVERNANCE.md).
 
 ## Emeritus maintainers
 

--- a/OWNERS
+++ b/OWNERS
@@ -7,6 +7,7 @@ approvers:
   - samzong
   - yitingdc
   - lsq645599166
+  - yankay
 
 # List of usernames who may use /lgtm
 reviewers:

--- a/OWNERS
+++ b/OWNERS
@@ -25,3 +25,4 @@ reviewers:
   - fkajerry
   - CoderTH
   - shijinye
+  - windsonsea


### PR DESCRIPTION
## Summary

- Populate **MAINTAINERS.md** with the five active **approvers** (aligned with `OWNERS`): name, email, organization, and areas.
- Add **yankay** to the `approvers` list in **OWNERS** so `/approve` permissions match project leadership.

Maintainer organizations: DaoCloud (4) and LangGenius (1).

## Test plan

- [x] `MAINTAINERS.md` approver rows match `OWNERS` `approvers` list.
- [x] Links (GitHub profiles, DaoCloud, LangGenius) resolve.

Made with [Cursor](https://cursor.com)