### PR TITLE
release: bootstrap v0.1.0 notes and release process

### DIFF
--- a/.github/workflows/call-release-changelog.yaml
+++ b/.github/workflows/call-release-changelog.yaml
@@ -1,10 +1,8 @@
 name: Call Release Changelog
 
 env:
-  SCRIPT_PATH: "./scripts/changelog.sh"
-  LABEL_FEATURE: "release/feature-new"
-  LABEL_CHANGED: "release/feature-changed"
-  LABEL_BUG: "release/bug"
+  RELEASE_NOTES_SCRIPT: "./scripts/release-notes.sh"
+
 on:
   workflow_call:
     inputs:
@@ -23,7 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       dest_tag: ${{ env.dest_tag }}
-      begin_tag: ${{ env.begin_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,31 +45,21 @@ jobs:
           fi
           echo "RUN_dest_tag=${dest_tag}" >> $GITHUB_ENV
 
-      - name: Generate Changelog
+      - name: Generate Release Notes
         run: |
           set -x
-          export LABEL_FEATURE=${{ env.LABEL_FEATURE }}
-          export LABEL_CHANGED=${{ env.LABEL_CHANGED }}
-          export LABEL_BUG=${{ env.LABEL_BUG }}
-          export PROJECT_REPO=${{ github.repository }}
-          export GH_TOKEN=${{ github.token }}
           mkdir changelog
-          ${{ env.SCRIPT_PATH }} ./changelog ${{ env.RUN_dest_tag }} \
-            || { echo "error, failed to generate changelog " ; exit 1 ; }
-          FILE_NAME=` ls changelog `
-          [ -n "$FILE_NAME" ] || { echo "error, failed to find changelog " ; exit 2 ; }
-          #
-          TMP=` echo ${FILE_NAME%.*}`
-          begin_tag=`awk -F'_' '{print $3}' <<< "${TMP}" `
-          dest_tag=`awk -F'_' '{print $5}' <<< "${TMP}" `
-          echo "dest_tag=${dest_tag}" >> $GITHUB_ENV
-          echo "begin_tag=${begin_tag}" >> $GITHUB_ENV
-          FILE_PATH=` echo ${PWD}/changelog/${FILE_NAME} `
+          ${{ env.RELEASE_NOTES_SCRIPT }} ./changelog ${{ env.RUN_dest_tag }} \
+            || { echo "error, failed to generate release notes " ; exit 1 ; }
+          FILE_NAME=$(ls changelog)
+          [ -n "$FILE_NAME" ] || { echo "error, failed to find release notes " ; exit 2 ; }
+          echo "dest_tag=${{ env.RUN_dest_tag }}" >> $GITHUB_ENV
+          FILE_PATH="${PWD}/changelog/${FILE_NAME}"
           echo "FILE_PATH=${FILE_PATH}" >> $GITHUB_ENV
           echo "------------------------------------"
-          cat ${FILE_PATH}
+          cat "${FILE_PATH}"
 
-      - name: Upload Changelog
+      - name: Upload Release Notes
         uses: actions/upload-artifact@v4.6.0
         with:
           name: changelog_artifact_${{ env.RUN_dest_tag }}

--- a/CHANGELOG/CHANGELOG-0.1.md
+++ b/CHANGELOG/CHANGELOG-0.1.md
@@ -1,0 +1,82 @@
+# MatrixHub v0.1.x release notes
+
+## v0.1.0
+
+MatrixHub **v0.1.0** is the first official release. It matches the code shipped in `v0.1.0-rc.1` and delivers the **V0 / M0–M1 baseline** described in the [roadmap](../docs/roadmap.md): a self-hosted, Hugging Face–compatible model registry for private inference clusters.
+
+### Downloads
+
+#### Container image
+
+```
+ghcr.io/matrixhub-ai/matrixhub:v0.1.0
+```
+
+Images are published for `linux/amd64` and `linux/arm64`, signed with [Cosign](https://docs.sigstore.dev/) (keyless), and ship with an SPDX SBOM attachment.
+
+Verify signature (optional):
+
+```bash
+cosign verify ghcr.io/matrixhub-ai/matrixhub:v0.1.0 \
+  --certificate-identity-regexp='.*' \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+```
+
+#### Helm chart (OCI)
+
+```bash
+export CHART_VERSION=0.1.0
+export NAMESPACE=matrixhub
+
+helm install matrixhub oci://ghcr.io/matrixhub-ai/matrixhub \
+  --version "${CHART_VERSION}" \
+  --namespace "${NAMESPACE}" \
+  --create-namespace
+```
+
+See the [README](../README.md) and [documentation site](https://matrixhub.ai) for Docker Compose, storage, and upgrade guidance.
+
+### Changelog since project inception
+
+#### Feature
+
+- Added a Hugging Face–compatible Git, Git LFS, and HTTP surface so clients such as **vLLM** and **SGLang** can use MatrixHub as a private model hub with `HF_ENDPOINT`.
+- Added model repository lifecycle: create, browse, upload, download, and delete with project-scoped isolation.
+- Added a Web UI for repository administration, user profile, access tokens, and platform settings.
+- Added remote **registry** management with proxy-cache mode to localize public Hugging Face models on first request (pull-once, serve-all within the cluster).
+- Added **sync policies** and an in-process job server to schedule registry replication tasks with resumable transfer foundations.
+- Added token-based authentication, projects, roles, robots, and permission-aware project listing for multi-tenant operation.
+- Added dataset repository support (initial).
+- Added Docker Compose and **Helm** deployment paths with multi-arch container images published to `ghcr.io`.
+- Added release automation: OCI Helm charts, Cosign signing, and SPDX SBOM generation for official tags.
+- Added documentation site content at [matrixhub.ai](https://matrixhub.ai) and CNCF Slack community channel ([#matrixhub](https://cloud-native.slack.com/archives/C0A8UKWR8HG)).
+
+#### Bug or Regression
+
+- Fixed file size display in the UI to use SI units consistently.
+- Fixed project permission resolution for list and detail APIs.
+- Additional stability and UI fixes merged before `v0.1.0-rc.1`.
+
+#### Documentation
+
+- Published installation, operations, and development guides on the documentation site.
+- Added project governance documents: Contributing, Security, Governance, and Maintainers.
+
+### Known limitations
+
+The following items are on the [roadmap](../docs/roadmap.md) but **not** part of v0.1.0:
+
+- Full LDAP/OIDC/SSO integration
+- Storage quotas and automated cleanup policies (design in progress)
+- Model signing, malware scanning, and tag-locking promotion workflows
+- S3-compatible storage as a first-class backend (PVC/local focus in this release)
+
+Track follow-up work in [GitHub issues](https://github.com/matrixhub-ai/matrixhub/issues).
+
+### Upgrade notes
+
+There is no prior official release. Install from the container image or Helm chart above. To evaluate quickly, use the public demo at [demo.matrixhub.ai](https://demo.matrixhub.ai/) (credentials in the README).
+
+---
+
+<!-- v0.1.1 and later official releases: append new ## vX.Y.Z sections above this line. -->

--- a/CHANGELOG/README.md
+++ b/CHANGELOG/README.md
@@ -1,0 +1,7 @@
+# CHANGELOGs
+
+MatrixHub release notes are maintained per minor version (Kubernetes-style). Official releases (`vX.Y.Z`) update these files and the [GitHub Releases](https://github.com/matrixhub-ai/matrixhub/releases) page. RC and dev tags do not update this directory.
+
+- [CHANGELOG-0.1.md](./CHANGELOG-0.1.md)
+
+Contributors record user-visible changes in pull request `release-note` blocks; maintainers aggregate them into the appropriate file at official release time. See [Release process](../docs/release-process.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -54,7 +54,8 @@ Removal or emeritus status follows the same process when a maintainer is inactiv
 ## Releases
 
 - Releases are tagged from the default branch following project quality checks (CI, review).
-- Release notes summarize user-visible changes and security fixes.
+- **Release notes are published only for official semver tags (`vX.Y.Z`).** RC and dev tags produce container images and Helm charts only; they do not create GitHub Releases or changelog entries.
+- Contributors record user-visible changes in pull request `release-note` blocks; maintainers aggregate them at official release time (Kubernetes-style). See [Release process](docs/release-process.md).
 - Maintainers decide release timing and versioning (semver where applicable).
 
 ## Vendor neutrality

--- a/README.md
+++ b/README.md
@@ -144,9 +144,11 @@ helm install matrixhub oci://ghcr.io/matrixhub-ai/matrixhub \
 
 - [Documentation site](https://matrixhub.ai)
 - [Development guide](docs/development.md)
+- [Release notes (CHANGELOG)](CHANGELOG/README.md)
 
 ## Project governance
 
+- [Release process](docs/release-process.md)
 - [Maintainers](MAINTAINERS.md)
 - [Governance](GOVERNANCE.md)
 - [Security policy](SECURITY.md)

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,340 @@
+# MatrixHub Release Process
+
+This document describes how maintainers cut releases for MatrixHub. It is intended for [maintainers](../MAINTAINERS.md) and release managers.
+
+## Release versioning
+
+MatrixHub follows [Semantic Versioning](https://semver.org/). Given a version number `<major>.<minor>.<patch>`, increment the:
+
+1. **`<major>`** version when you make incompatible API changes
+2. **`<minor>`** version when you add functionality in a backwards compatible manner
+3. **`<patch>`** version when you make backwards compatible bug fixes
+
+Pre-release tags use semver pre-release identifiers:
+
+| Tag pattern | Purpose | Container + Helm | Release notes |
+|-------------|---------|------------------|---------------|
+| `vX.Y.Z-dev.N` | Early integration builds | Yes | **No** |
+| `vX.Y.Z-rc.N` | Release candidates | Yes | **No** |
+| `vX.Y.Z` | Official release | Yes | **Yes** |
+
+- [Release notes policy](#release-notes-policy)
+- [Release candidate process](#release-candidate-process)
+- [Official release process](#official-release-process)
+- [Patch release process](#patch-release-process)
+
+## Release notes policy
+
+**Release notes are published only for official tags (`vX.Y.Z`).** RC and dev tags do not get release notes, changelogs, or GitHub Releases.
+
+| Version kind | GitHub Releases page | `CHANGELOG/` in repo | What users get |
+|--------------|----------------------|----------------------|----------------|
+| `-dev` / `-rc` | Nothing new | No update | Installable image + Helm chart only |
+| Official `vX.Y.Z` | Published release with notes | Updated | Image, chart, and human-readable release notes |
+
+This matches the [Release workflow](../.github/workflows/release.yml): jobs `release-changelog` and `create-release` run only when the tag matches `vX.Y.Z` (no `-rc` / `-dev` suffix).
+
+**Do not** manually create a GitHub Release for an RC or dev tag. Use RC tags for smoke-testing artifacts; write and publish release notes when cutting the official tag.
+
+### Where release notes come from (Kubernetes-style)
+
+MatrixHub follows the Kubernetes model:
+
+1. **During development:** contributors add a `release-note` block (or `NONE`) in each pull request — this is source material, not a published release note by itself.
+2. **At an official release:** maintainers aggregate those PR release notes into [`CHANGELOG/`](../CHANGELOG/) and the [GitHub Releases](https://github.com/matrixhub-ai/matrixhub/releases) page for that version.
+3. **RC tags:** skipped — no aggregation and no publication until the official tag.
+
+See [Adding release notes in pull requests](#adding-release-notes-in-pull-requests).
+
+## Tags and branches
+
+MatrixHub releases are tagged from the default branch (`main`) unless a patch is cut from a release branch (see [Cherry-pick patch release](#cherry-pick-patch-release)).
+
+```mermaid
+gitGraph
+  commit id: "main"
+  commit id: "feature"
+  commit tag: "v0.1.0-rc.1"
+  commit id: "fix"
+  commit tag: "v0.1.0"
+  commit id: "main continues"
+  commit tag: "v0.1.1"
+```
+
+Typical flow:
+
+1. Tag `vX.Y.Z-rc.N` on `main` when the branch is feature-complete for that minor line.
+2. Smoke-test the RC artifacts (container image + Helm chart).
+3. Tag `vX.Y.Z` on the RC commit (promotion) or on a later `main` commit (if additional fixes landed).
+4. Continue development on `main`; cut `vX.Y.(Z+1)` for patch fixes.
+
+## Automated release pipeline
+
+Pushing a semver tag (or running the [Release workflow](https://github.com/matrixhub-ai/matrixhub/actions/workflows/release.yml) manually) triggers [`.github/workflows/release.yml`](../.github/workflows/release.yml).
+
+For **every** tag (`-dev`, `-rc`, and official):
+
+1. Build and push a multi-arch container image to `ghcr.io/matrixhub-ai/matrixhub:<tag>`
+2. Sign the image with [Cosign](https://docs.sigstore.dev/) (keyless)
+3. Generate and attach an SPDX SBOM (Syft)
+4. Package the Helm chart and push it to `oci://ghcr.io/matrixhub-ai`
+
+For **official** tags only (`vX.Y.Z` without `-rc` / `-dev`):
+
+5. Build release notes from merged PR `release-note` blocks (see below; automation is being aligned with this policy)
+6. Create a **draft** [GitHub Release](https://github.com/matrixhub-ai/matrixhub/releases) with the release notes and Helm chart `.tgz` attached
+
+Maintainers must **review and publish** the draft release manually. Until automation is fully migrated, bootstrap or edit release notes in [`CHANGELOG/`](../CHANGELOG/) and paste the official section into the draft release body.
+
+### Adding release notes in pull requests
+
+Every pull request with a user-visible change should include a release note in the PR template’s `release-note` block (or `NONE` if not user-facing). Reviewers check release note quality before merge — same idea as [Kubernetes](https://github.com/kubernetes/community/blob/main/contributors/guide/release-notes.md).
+
+Example:
+
+```release-note
+Added MatrixHub-type registry configuration for private deployments. (#710, @contributor)
+```
+
+These blocks are **not** shown as a versioned release note until an **official** tag is cut. RC tags do not trigger collection or publication.
+
+## Release candidate process
+
+### Overview
+
+A release candidate is e.g. `v0.1.0-rc.1`. Use RC tags to validate install paths and smoke tests before the official `vX.Y.Z` tag.
+
+An RC requires:
+
+- CI green on the commit to be tagged
+- Tag the RC
+- Verify release workflow succeeded
+- Smoke-test image and Helm chart
+- Fix blockers on `main`, then cut `vX.Y.Z-rc.(N+1)` or proceed to the official release
+
+### Process
+
+#### Check CI is green
+
+Ensure the commit you plan to tag passes CI on `main` (including relevant E2E jobs).
+
+#### Tag the RC
+
+From your local clone (maintainer with tag push access):
+
+```bash
+git fetch origin
+git checkout main
+git pull origin main
+git tag v0.1.0-rc.1
+git push origin v0.1.0-rc.1
+```
+
+Or create the tag from the GitHub **Releases → Draft a new release → Choose a tag** UI.
+
+Alternatively, run **Actions → Release → Run workflow** and enter the tag name.
+
+#### Verify the pipeline
+
+Open the [Release workflow run](https://github.com/matrixhub-ai/matrixhub/actions/workflows/release.yml) for the new tag and confirm all jobs succeed.
+
+Artifacts produced:
+
+- Container: `ghcr.io/matrixhub-ai/matrixhub:v0.1.0-rc.1`
+- Helm chart: `oci://ghcr.io/matrixhub-ai/matrixhub:0.1.0-rc.1`
+
+No GitHub Release, no `CHANGELOG/` update, and no release notes for this tag. The [Releases](https://github.com/matrixhub-ai/matrixhub/releases) page stays unchanged until the official `vX.Y.Z` tag.
+
+#### Smoke-test the RC
+
+Install from the RC tag and run a minimal validation (API health, model pull/push, UI login). See [README](../README.md) for Helm install examples; substitute the RC tag/chart version.
+
+Document any blocking issues as GitHub issues before promoting to an official release.
+
+## Official release process
+
+### Overview
+
+An official (minor or initial) release is e.g. `v0.1.0`.
+
+An official release requires:
+
+- Prepare release notes (aggregate PR `release-note` blocks or bootstrap `CHANGELOG/` for the first GA)
+- CI green on the commit to be tagged
+- Tag the release (often after a final RC)
+- Verify release workflow succeeded
+- Review and **publish** the draft GitHub Release (this is where release notes become public)
+- Smoke-test the published artifacts
+- Announce the release
+
+### Process
+
+#### Prepare release notes
+
+Review merged PRs since the **last official tag** (not since the last RC). Collect non-`NONE` `release-note` blocks into the version section of [`CHANGELOG/`](../CHANGELOG/) (for example `CHANGELOG/CHANGELOG-0.1.md` for the v0.1 line).
+
+For the **first official release** (`v0.1.0`), bootstrap that file manually if historical PRs lack release notes; see the bootstrap step in [Review and publish the GitHub Release](#review-and-publish-the-github-release).
+
+#### Check CI is green
+
+Same as RC: the tagged commit must be green on `main`.
+
+#### Tag the release
+
+**Promote an RC** (same commit as the last RC, no new code):
+
+```bash
+git tag v0.1.0 v0.1.0-rc.1^{}
+git push origin v0.1.0
+```
+
+**Release from current `main`** (includes commits after the last RC):
+
+```bash
+git checkout main
+git pull origin main
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+#### Verify the pipeline
+
+Confirm the Release workflow completes: image, chart, release-notes artifact (if generated), and draft GitHub Release are created.
+
+Download the workflow artifact `image-digest-artifact-matrixhub-v0.1.0` if you need the exact image digest for release notes.
+
+#### Review and publish the GitHub Release
+
+This step is **only for official tags**. It is what makes release notes visible on the repository [Releases](https://github.com/matrixhub-ai/matrixhub/releases) tab.
+
+1. Open [Releases](https://github.com/matrixhub-ai/matrixhub/releases) and find the **Draft** for `v0.1.0`.
+2. Set the body from the `CHANGELOG/` section for this version (or the generated draft); fix gaps, add upgrade notes, and include install commands (below).
+3. Confirm the Helm chart `.tgz` is attached.
+4. Click **Publish release**.
+
+After publish, users see release notes on the Releases page; the same content should live under `CHANGELOG/` in the repo for a permanent record.
+
+Suggested release notes footer (adjust version):
+
+````markdown
+## Install
+
+### Container image
+
+```
+ghcr.io/matrixhub-ai/matrixhub:v0.1.0
+```
+
+Verify signature (optional):
+
+```bash
+cosign verify ghcr.io/matrixhub-ai/matrixhub:v0.1.0 \
+  --certificate-identity-regexp='.*' \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+```
+
+### Helm
+
+```bash
+export CHART_VERSION=0.1.0
+helm install matrixhub oci://ghcr.io/matrixhub-ai/matrixhub \
+  --version "${CHART_VERSION}"
+```
+
+See the [documentation site](https://matrixhub.ai) for full install and upgrade guides.
+````
+
+#### Smoke-test the release
+
+Repeat smoke tests against the **official** tag (not only the RC).
+
+#### Announce
+
+- Post in [CNCF Slack #matrixhub](https://cloud-native.slack.com/archives/C0A8UKWR8HG)
+- Optionally open a [GitHub Discussion](https://github.com/matrixhub-ai/matrixhub/discussions) release announcement
+- Update [matrixhub.ai](https://matrixhub.ai) or docs if the release introduces user-visible changes
+
+## Patch release process
+
+### Overview
+
+A patch release is e.g. `v0.1.1`.
+
+#### Simple patch release
+
+If only bug fixes landed on `main` since the last official release (`v0.1.0`) and `main` is stable, follow the [Official release process](#official-release-process) on the current `main` HEAD with the next patch version.
+
+#### Cherry-pick patch release
+
+If `main` contains new features but a patch release (`v0.1.1`) should include **only** fixes relative to `v0.1.0`, use a release branch:
+
+A cherry-pick patch release requires:
+
+- Create (or reuse) a release branch
+- Cherry-pick fix commits into the release branch
+- Ensure cherry-pick PRs include `release-note` blocks for the patch notes
+- Tag the patch on the release branch
+- Verify pipeline, publish draft release, smoke-test, announce
+
+##### Create release branch
+
+If it does not exist yet:
+
+```bash
+git fetch origin --tags
+git checkout -b release/0.1 v0.1.0
+git push origin release/0.1
+```
+
+##### Cherry-pick fixes
+
+```bash
+git checkout release/0.1
+git cherry-pick <SHA>   # repeat for each fix
+git push origin release/0.1
+```
+
+Open a PR into `release/0.1` when cherry-picks need review.
+
+##### Tag patch release
+
+```bash
+git checkout release/0.1
+git pull origin release/0.1
+git tag v0.1.1
+git push origin v0.1.1
+```
+
+Then follow [Review and publish the GitHub Release](#review-and-publish-the-github-release).
+
+Port documentation or release-note edits back to `main` if needed.
+
+## Security releases
+
+Security fixes follow the same tagging pipeline. Additionally:
+
+1. Follow [SECURITY.md](../SECURITY.md) coordinated disclosure.
+2. Prefer a patch tag (`vX.Y.Z`) on the affected release line.
+3. Mention the advisory link in the published release notes after disclosure.
+
+## Checklist (maintainers)
+
+Use this quick checklist for every official release:
+
+- [ ] Target commit is green on CI
+- [ ] Release notes prepared in `CHANGELOG/` (or draft body edited manually)
+- [ ] RC smoke-tested (recommended for minor releases)
+- [ ] Tag pushed (`vX.Y.Z`)
+- [ ] Release workflow succeeded (image, chart, SBOM, cosign)
+- [ ] Draft GitHub Release reviewed and **published**
+- [ ] Post-release smoke test passed
+- [ ] Community announcement sent
+- [ ] Docs / website updated if user-facing behavior changed
+
+## Related links
+
+- [Governance — Releases](../GOVERNANCE.md#releases)
+- [Security policy](../SECURITY.md)
+- [Maintainers](../MAINTAINERS.md)
+- [GitHub Releases](https://github.com/matrixhub-ai/matrixhub/releases)
+- [Release workflow](https://github.com/matrixhub-ai/matrixhub/actions/workflows/release.yml)

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Copyright 2026 MatrixHub Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Generate GitHub Release notes for an official tag from CHANGELOG/ files.
+#
+# Usage:
+#   ./scripts/release-notes.sh <output-dir> <dest-tag>
+#
+# If CHANGELOG is not present at the checked-out ref (for example when promoting
+# v0.1.0 on the same commit as v0.1.0-rc.1), the script falls back to
+# origin/main for the CHANGELOG file.
+
+set -euo pipefail
+
+OUTPUT_DIR=${1:-}
+DEST_TAG=${2:-}
+
+if [ -z "${OUTPUT_DIR}" ] || [ -z "${DEST_TAG}" ]; then
+  echo "usage: $0 <output-dir> <dest-tag>" >&2
+  exit 1
+fi
+
+if ! [[ "${DEST_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: dest tag must be an official release (vX.Y.Z), got ${DEST_TAG}" >&2
+  exit 1
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+OUTPUT_DIR=$(cd "${OUTPUT_DIR}" && pwd)
+
+VERSION="${DEST_TAG#v}"
+MAJOR_MINOR=$(echo "${VERSION}" | cut -d. -f1,2)
+CHANGELOG_PATH="CHANGELOG/CHANGELOG-${MAJOR_MINOR}.md"
+OUTPUT_FILE="${OUTPUT_DIR}/release_notes_${DEST_TAG}.md"
+
+extract_section() {
+  local file=$1
+  awk -v tag="${DEST_TAG}" '
+    BEGIN { found=0 }
+    $0 ~ "^## " tag "$" { found=1; print; next }
+    found && $0 ~ "^## v[0-9]+\\.[0-9]+\\.[0-9]+" { exit }
+    found { print }
+  ' "${file}"
+}
+
+resolve_changelog_file() {
+  if [ -f "${CHANGELOG_PATH}" ]; then
+    echo "${CHANGELOG_PATH}"
+    return
+  fi
+
+  if git show "origin/main:${CHANGELOG_PATH}" >/dev/null 2>&1; then
+    git show "origin/main:${CHANGELOG_PATH}" > "/tmp/${CHANGELOG_PATH//\//_}"
+    echo "/tmp/${CHANGELOG_PATH//\//_}"
+    return
+  fi
+
+  echo ""
+}
+
+main() {
+  git fetch origin main --quiet 2>/dev/null || true
+
+  local source
+  source=$(resolve_changelog_file)
+  if [ -z "${source}" ]; then
+    echo "error: missing ${CHANGELOG_PATH} at current ref and on origin/main" >&2
+    exit 1
+  fi
+
+  extract_section "${source}" > "${OUTPUT_FILE}"
+
+  if [ "$(wc -l < "${OUTPUT_FILE}")" -lt 5 ]; then
+    echo "error: release notes section for ${DEST_TAG} is empty in ${CHANGELOG_PATH}" >&2
+    exit 1
+  fi
+
+  echo "Wrote ${OUTPUT_FILE}"
+  cat "${OUTPUT_FILE}"
+}
+
+main


### PR DESCRIPTION
## Summary

Prepare the first official MatrixHub release (`v0.1.0`, same commit as `v0.1.0-rc.1`):

- Bootstrap `CHANGELOG/CHANGELOG-0.1.md` with v0.1.0 release notes (Kubernetes-style)
- Add maintainer [release process](docs/release-process.md): RC/dev tags have no release notes; official tags only
- Replace label-based changelog generation with `scripts/release-notes.sh` (reads `CHANGELOG/`, falls back to `origin/main` when GA is tagged on the RC commit)

## After merge

Maintainers with tag push access:

```bash
git fetch upstream --tags
git tag v0.1.0 v0.1.0-rc.1^{}
git push upstream v0.1.0
```

Then review and **Publish** the draft GitHub Release created by CI.

## Test plan

- [x] `./scripts/release-notes.sh /tmp/out v0.1.0` extracts the v0.1.0 section locally
- [ ] Merge PR → push `v0.1.0` tag → verify Release workflow → publish draft release


Made with [Cursor](https://cursor.com)