### PR TITLE
docs: complete release process and contributor release-note guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,8 @@ See [docs/development.md](docs/development.md) for prerequisites.
 - Keep PRs focused and reasonably small; link the issue they address.
 - Ensure **CI is green** (lint, unit tests, and other checks) and that your commits
   are **signed off**.
+- Fill in the PR template `release-note` block for user-visible changes (see
+  [Release notes in pull requests](#release-notes-in-pull-requests)).
 - Reviews follow the [`OWNERS`](OWNERS) model: maintainers use `/lgtm` and `/approve`
   on PRs. A PR is merged once it has the required approvals and CI passes.
 - Be responsive to review feedback; maintainers aim to review promptly but this is a
@@ -195,6 +197,28 @@ See [docs/development.md](docs/development.md) for prerequisites.
 
 See [GOVERNANCE.md](GOVERNANCE.md) for roles, decision making, and how to become a
 maintainer.
+
+## Release notes in pull requests
+
+MatrixHub follows the [Kubernetes release notes model](https://github.com/kubernetes/community/blob/main/contributors/guide/release-notes.md):
+
+- **Official releases only** (`vX.Y.Z`) publish release notes on the
+  [GitHub Releases](https://github.com/matrixhub-ai/matrixhub/releases) page and in
+  [`CHANGELOG/`](CHANGELOG/README.md). RC and dev tags do **not** publish release notes.
+- **Every pull request** with a user-visible change must include a `release-note`
+  block in the PR description (or `NONE` if not user-facing). The PR template already
+  includes this section.
+- Reviewers should check release note quality during review (clear, past tense,
+  user-focused).
+
+Example:
+
+```release-note
+Added permission-based filtering to the project list API. (#664, @contributor)
+```
+
+Maintainers aggregate these notes into `CHANGELOG/` when cutting an official release.
+See [Release process](docs/release-process.md) for maintainer steps.
 
 ## License of contributions
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -68,6 +68,8 @@ Typical flow:
 3. Tag `vX.Y.Z` on the RC commit (promotion) or on a later `main` commit (if additional fixes landed).
 4. Continue development on `main`; cut `vX.Y.(Z+1)` for patch fixes.
 
+A **release branch** (for example `release/0.1`) is **not** required for the first GA or for routine releases from `main`. Create one only when you need a [cherry-pick patch release](#cherry-pick-patch-release) that excludes new features already on `main`.
+
 ## Automated release pipeline
 
 Pushing a semver tag (or running the [Release workflow](https://github.com/matrixhub-ai/matrixhub/actions/workflows/release.yml) manually) triggers [`.github/workflows/release.yml`](../.github/workflows/release.yml).
@@ -81,10 +83,12 @@ For **every** tag (`-dev`, `-rc`, and official):
 
 For **official** tags only (`vX.Y.Z` without `-rc` / `-dev`):
 
-5. Build release notes from merged PR `release-note` blocks (see below; automation is being aligned with this policy)
+5. Build release notes from [`CHANGELOG/`](../CHANGELOG/) via [`scripts/release-notes.sh`](../scripts/release-notes.sh)
 6. Create a **draft** [GitHub Release](https://github.com/matrixhub-ai/matrixhub/releases) with the release notes and Helm chart `.tgz` attached
 
-Maintainers must **review and publish** the draft release manually. Until automation is fully migrated, bootstrap or edit release notes in [`CHANGELOG/`](../CHANGELOG/) and paste the official section into the draft release body.
+Maintainers must **review and publish** the draft release manually.
+
+`scripts/release-notes.sh` reads the matching section from `CHANGELOG/CHANGELOG-X.Y.md`. If the tagged commit does not yet contain that file (for example when promoting `v0.1.0` on the same commit as `v0.1.0-rc.1`), the script falls back to `origin/main` for the changelog content. **Always verify the draft release body** before publishing — see [Promoting an RC on the same commit](#promoting-an-rc-on-the-same-commit).
 
 ### Adding release notes in pull requests
 
@@ -197,6 +201,21 @@ git tag v0.1.0
 git push origin v0.1.0
 ```
 
+#### Promoting an RC on the same commit
+
+When the official tag points at the **same commit** as the last RC (for example `v0.1.0` on `v0.1.0-rc.1`):
+
+- Container images and Helm charts are rebuilt with the official tag name.
+- GitHub Actions runs the workflow definitions **from the tagged commit**. If release automation was merged to `main` after that commit, the draft release body may be wrong or empty until `scripts/release-notes.sh` on `main` is used.
+- **Before publishing:** confirm the draft body matches the `CHANGELOG/` section for this version (from `main`). Update with `gh release edit` if needed:
+
+```bash
+./scripts/release-notes.sh /tmp/release-notes v0.1.0
+gh release edit v0.1.0 --notes-file /tmp/release-notes/release_notes_v0.1.0.md
+```
+
+For `v0.1.1` and later, tagging the current `main` HEAD avoids this mismatch because the tag commit includes current workflow and changelog files.
+
 #### Verify the pipeline
 
 Confirm the Release workflow completes: image, chart, release-notes artifact (if generated), and draft GitHub Release are created.
@@ -212,7 +231,16 @@ This step is **only for official tags**. It is what makes release notes visible 
 3. Confirm the Helm chart `.tgz` is attached.
 4. Click **Publish release**.
 
-After publish, users see release notes on the Releases page; the same content should live under `CHANGELOG/` in the repo for a permanent record.
+After publish, users see release notes on the [GitHub Releases](https://github.com/matrixhub-ai/matrixhub/releases) tab; the same content should live under `CHANGELOG/` in the repo for a permanent record.
+
+#### Editing release notes after publish
+
+Release notes are not tied to the container image digest or git tag object. Maintainers may fix typos, add missing items, or clarify upgrade guidance **after** a release is published:
+
+1. Edit the GitHub Release body on the Releases page, **and**
+2. Open a PR to update the matching section in `CHANGELOG/CHANGELOG-X.Y.md` so the repo stays the source of truth.
+
+Prefer finalizing notes before publish; post-publish edits should be limited to corrections and clarifications.
 
 Suggested release notes footer (adjust version):
 


### PR DESCRIPTION
## Summary

Follow-up to #722 / v0.1.0 release: document the full Kubernetes-style release workflow for maintainers and contributors.

- **`docs/release-process.md`**: align automation description with `scripts/release-notes.sh` + `CHANGELOG/`; document when release branches are **not** needed; add RC same-commit promotion caveats (workflow runs from tag commit); document post-publish release note edits
- **`CONTRIBUTING.md`**: add contributor guidance for PR `release-note` blocks (official releases only publish notes; RC/dev do not)

## Context

#722 merged the initial release process and CHANGELOG bootstrap. This PR captures operational lessons from cutting `v0.1.0` on the `v0.1.0-rc.1` commit.

## Test plan

- [x] Docs render correctly on GitHub
- [x] Links to `CHANGELOG/`, `GOVERNANCE.md`, and Kubernetes release-notes guide resolve


Made with [Cursor](https://cursor.com)