### PR TITLE
fix: count safetensors model parameters

### DIFF
--- a/internal/domain/git/git.go
+++ b/internal/domain/git/git.go
@@ -98,6 +98,7 @@ type RepoMetadataFiles struct {
 	ReadmeContent        []byte
 	ConfigJSON           []byte
 	SafetensorsIndexJSON []byte
+	SafetensorsFiles     map[string][]byte
 	Size                 int64
 }
 

--- a/internal/domain/model/metadata_analyzer.go
+++ b/internal/domain/model/metadata_analyzer.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"math"
 	"strings"
@@ -43,6 +44,10 @@ type safetensorsIndex struct {
 	Metadata struct {
 		TotalSize int64 `json:"total_size"`
 	} `json:"metadata"`
+}
+
+type safetensorsTensor struct {
+	Shape []int64 `json:"shape"`
 }
 
 // AnalyzeRepoMetadata converts raw repo files into model-domain metadata.
@@ -74,7 +79,7 @@ func AnalyzeRepoMetadata(files *git.RepoMetadataFiles) (*RepoMetadata, error) {
 		}
 	}
 
-	// parameter_count inference only uses config.json + model.safetensors.index.json.
+	// parameter_count inference only uses config.json and safetensors metadata.
 	// README.md is intentionally excluded here because it is descriptive text,
 	// not structured machine metadata.
 	//
@@ -104,6 +109,9 @@ func AnalyzeRepoMetadata(files *git.RepoMetadataFiles) (*RepoMetadata, error) {
 		if err := json.Unmarshal(files.SafetensorsIndexJSON, &index); err == nil && index.Metadata.TotalSize > 0 {
 			metadata.ParameterCount = estimateParameterCount(index.Metadata.TotalSize, parameterBytes)
 		}
+	}
+	if metadata.ParameterCount == 0 && len(files.SafetensorsFiles) > 0 {
+		metadata.ParameterCount = countSafetensorsParameters(files.SafetensorsFiles)
 	}
 
 	metadata.Tags = deduplicateClassifiedTags(tags)
@@ -189,4 +197,55 @@ func estimateParameterCount(totalSize, parameterBytes int64) int64 {
 		return 0
 	}
 	return totalSize / parameterBytes
+}
+
+func countSafetensorsParameters(files map[string][]byte) int64 {
+	var total int64
+	for _, content := range files {
+		count, ok := countSafetensorsHeaderParameters(content)
+		if !ok {
+			continue
+		}
+		if count > math.MaxInt64-total {
+			return 0
+		}
+		total += count
+	}
+	return total
+}
+
+func countSafetensorsHeaderParameters(content []byte) (int64, bool) {
+	if len(content) < 8 {
+		return 0, false
+	}
+
+	headerLength := binary.LittleEndian.Uint64(content[:8])
+	if headerLength > uint64(len(content)-8) || headerLength > uint64(math.MaxInt64) {
+		return 0, false
+	}
+
+	var tensors map[string]safetensorsTensor
+	if err := json.Unmarshal(content[8:8+int(headerLength)], &tensors); err != nil {
+		return 0, false
+	}
+
+	var total int64
+	for name, tensor := range tensors {
+		if name == "__metadata__" {
+			continue
+		}
+
+		count := int64(1)
+		for _, dim := range tensor.Shape {
+			if dim < 0 || dim > math.MaxInt64/count {
+				return 0, false
+			}
+			count *= dim
+		}
+		if count > math.MaxInt64-total {
+			return 0, false
+		}
+		total += count
+	}
+	return total, true
 }

--- a/internal/domain/model/metadata_analyzer_test.go
+++ b/internal/domain/model/metadata_analyzer_test.go
@@ -1,0 +1,128 @@
+// Copyright The MatrixHub Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"testing"
+
+	"github.com/matrixhub-ai/matrixhub/internal/domain/git"
+)
+
+func TestAnalyzeRepoMetadataCountsSingleSafetensorsFile(t *testing.T) {
+	files := &git.RepoMetadataFiles{
+		SafetensorsFiles: map[string][]byte{
+			"model.safetensors": buildSafetensorsFile(t, map[string][]int64{
+				"model.embed_tokens.weight": {2, 3},
+				"lm_head.weight":            {4, 5},
+			}),
+		},
+	}
+
+	metadata, err := AnalyzeRepoMetadata(files)
+	if err != nil {
+		t.Fatalf("AnalyzeRepoMetadata() error = %v", err)
+	}
+
+	if metadata.ParameterCount != 26 {
+		t.Fatalf("ParameterCount = %d, want 26", metadata.ParameterCount)
+	}
+}
+
+func TestAnalyzeRepoMetadataCountsShardedSafetensorsFilesWithoutTotalSize(t *testing.T) {
+	files := &git.RepoMetadataFiles{
+		SafetensorsIndexJSON: []byte(`{
+			"weight_map": {
+				"model.embed_tokens.weight": "model-00001-of-00002.safetensors",
+				"lm_head.weight": "model-00002-of-00002.safetensors"
+			}
+		}`),
+		SafetensorsFiles: map[string][]byte{
+			"model-00001-of-00002.safetensors": buildSafetensorsFile(t, map[string][]int64{
+				"model.embed_tokens.weight": {2, 3},
+			}),
+			"model-00002-of-00002.safetensors": buildSafetensorsFile(t, map[string][]int64{
+				"lm_head.weight": {4, 5},
+			}),
+		},
+	}
+
+	metadata, err := AnalyzeRepoMetadata(files)
+	if err != nil {
+		t.Fatalf("AnalyzeRepoMetadata() error = %v", err)
+	}
+
+	if metadata.ParameterCount != 26 {
+		t.Fatalf("ParameterCount = %d, want 26", metadata.ParameterCount)
+	}
+}
+
+func TestAnalyzeRepoMetadataPrefersSafetensorsIndexTotalSize(t *testing.T) {
+	files := &git.RepoMetadataFiles{
+		ConfigJSON: []byte(`{"torch_dtype": "bfloat16"}`),
+		SafetensorsIndexJSON: []byte(`{
+			"metadata": {
+				"total_size": 100
+			}
+		}`),
+		SafetensorsFiles: map[string][]byte{
+			"model-00001-of-00002.safetensors": buildSafetensorsFile(t, map[string][]int64{
+				"model.embed_tokens.weight": {2, 3},
+			}),
+		},
+	}
+
+	metadata, err := AnalyzeRepoMetadata(files)
+	if err != nil {
+		t.Fatalf("AnalyzeRepoMetadata() error = %v", err)
+	}
+
+	if metadata.ParameterCount != 50 {
+		t.Fatalf("ParameterCount = %d, want 50", metadata.ParameterCount)
+	}
+}
+
+func buildSafetensorsFile(t *testing.T, tensors map[string][]int64) []byte {
+	t.Helper()
+
+	header := map[string]any{
+		"__metadata__": map[string]string{"format": "pt"},
+	}
+	offset := int64(0)
+	for name, shape := range tensors {
+		count := int64(1)
+		for _, dim := range shape {
+			count *= dim
+		}
+		size := count * 2
+		header[name] = map[string]any{
+			"dtype":        "BF16",
+			"shape":        shape,
+			"data_offsets": []int64{offset, offset + size},
+		}
+		offset += size
+	}
+
+	headerBytes, err := json.Marshal(header)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	content := make([]byte, 8+len(headerBytes))
+	binary.LittleEndian.PutUint64(content[:8], uint64(len(headerBytes)))
+	copy(content[8:], headerBytes)
+	return content
+}

--- a/internal/repo/git_repo.go
+++ b/internal/repo/git_repo.go
@@ -16,6 +16,7 @@ package repo
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -37,7 +38,7 @@ type gitRepo struct {
 	mirror  *mirror.Mirror
 }
 
-const maxSafetensorsHeaderPrefixBytes int64 = 16 * 1024 * 1024
+const maxSafetensorsHeaderBytes uint64 = 64 * 1024 * 1024
 
 type safetensorsIndexFiles struct {
 	WeightMap map[string]string `json:"weight_map"`
@@ -516,34 +517,50 @@ func (g *gitRepo) readBlobBytes(repo *repository.Repository, rev, path string) (
 	return io.ReadAll(rc)
 }
 
-func (g *gitRepo) readBlobPrefix(repo *repository.Repository, rev, path string, limit int64) ([]byte, error) {
+func (g *gitRepo) openBlobContent(repo *repository.Repository, rev, path string) (io.ReadCloser, error) {
 	blob, err := repo.Blob(rev, path)
 	if err != nil {
 		return nil, err
 	}
 
-	var rc io.ReadCloser
 	if ptr, err := blob.LFSPointer(); err == nil && ptr != nil {
 		store := hfdlfs.NewLocal(g.storage.LFSDir())
 		getter, ok := store.(hfdlfs.Getter)
 		if !ok {
 			return nil, fmt.Errorf("lfs storage does not support reads")
 		}
-		rc, _, err = getter.Get(ptr.OID())
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		rc, err = blob.NewReader()
-		if err != nil {
-			return nil, err
-		}
+		rc, _, err := getter.Get(ptr.OID())
+		return rc, err
+	}
+
+	return blob.NewReader()
+}
+
+func (g *gitRepo) readSafetensorsHeader(repo *repository.Repository, rev, path string) ([]byte, error) {
+	rc, err := g.openBlobContent(repo, rev, path)
+	if err != nil {
+		return nil, err
 	}
 	defer func() {
 		_ = rc.Close()
 	}()
 
-	return io.ReadAll(io.LimitReader(rc, limit))
+	var lengthPrefix [8]byte
+	if _, err := io.ReadFull(rc, lengthPrefix[:]); err != nil {
+		return nil, err
+	}
+
+	headerLength := binary.LittleEndian.Uint64(lengthPrefix[:])
+	if headerLength > maxSafetensorsHeaderBytes {
+		return nil, fmt.Errorf("safetensors header too large: %d bytes", headerLength)
+	}
+
+	content := make([]byte, 8+int(headerLength))
+	copy(content[:8], lengthPrefix[:])
+	if _, err := io.ReadFull(rc, content[8:]); err != nil {
+		return nil, err
+	}
+	return content, nil
 }
 
 func loadSafetensorsPathsFromIndex(indexJSON []byte) []string {
@@ -625,12 +642,12 @@ func (g *gitRepo) ExtractMetadata(ctx context.Context, repoType, project, name s
 	if content, err := g.readBlobBytes(repo, rev, "model.safetensors.index.json"); err == nil {
 		metadata.SafetensorsIndexJSON = content
 		for _, path := range loadSafetensorsPathsFromIndex(content) {
-			if prefix, err := g.readBlobPrefix(repo, rev, path, maxSafetensorsHeaderPrefixBytes); err == nil {
-				metadata.SafetensorsFiles[path] = prefix
+			if header, err := g.readSafetensorsHeader(repo, rev, path); err == nil {
+				metadata.SafetensorsFiles[path] = header
 			}
 		}
-	} else if prefix, err := g.readBlobPrefix(repo, rev, "model.safetensors", maxSafetensorsHeaderPrefixBytes); err == nil {
-		metadata.SafetensorsFiles["model.safetensors"] = prefix
+	} else if header, err := g.readSafetensorsHeader(repo, rev, "model.safetensors"); err == nil {
+		metadata.SafetensorsFiles["model.safetensors"] = header
 	}
 
 	// Compute model content size from the default branch tree. DiskUsage

--- a/internal/repo/git_repo.go
+++ b/internal/repo/git_repo.go
@@ -16,6 +16,7 @@ package repo
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -23,6 +24,7 @@ import (
 	stdpath "path"
 	"strings"
 
+	hfdlfs "github.com/matrixhub-ai/hfd/pkg/lfs"
 	"github.com/matrixhub-ai/hfd/pkg/mirror"
 	"github.com/matrixhub-ai/hfd/pkg/repository"
 	"github.com/matrixhub-ai/hfd/pkg/storage"
@@ -33,6 +35,12 @@ import (
 type gitRepo struct {
 	storage *storage.Storage
 	mirror  *mirror.Mirror
+}
+
+const maxSafetensorsHeaderPrefixBytes int64 = 16 * 1024 * 1024
+
+type safetensorsIndexFiles struct {
+	WeightMap map[string]string `json:"weight_map"`
 }
 
 // NewGitDB creates a new GitRepo instance
@@ -493,6 +501,73 @@ func (g *gitRepo) PullFromRemote(ctx context.Context, gitRepository *git.GitRepo
 	)
 }
 
+func (g *gitRepo) readBlobBytes(repo *repository.Repository, rev, path string) ([]byte, error) {
+	blob, err := repo.Blob(rev, path)
+	if err != nil {
+		return nil, err
+	}
+	rc, err := blob.NewReader()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = rc.Close()
+	}()
+	return io.ReadAll(rc)
+}
+
+func (g *gitRepo) readBlobPrefix(repo *repository.Repository, rev, path string, limit int64) ([]byte, error) {
+	blob, err := repo.Blob(rev, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var rc io.ReadCloser
+	if ptr, err := blob.LFSPointer(); err == nil && ptr != nil {
+		store := hfdlfs.NewLocal(g.storage.LFSDir())
+		getter, ok := store.(hfdlfs.Getter)
+		if !ok {
+			return nil, fmt.Errorf("lfs storage does not support reads")
+		}
+		rc, _, err = getter.Get(ptr.OID())
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		rc, err = blob.NewReader()
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer func() {
+		_ = rc.Close()
+	}()
+
+	return io.ReadAll(io.LimitReader(rc, limit))
+}
+
+func loadSafetensorsPathsFromIndex(indexJSON []byte) []string {
+	var index safetensorsIndexFiles
+	if err := json.Unmarshal(indexJSON, &index); err != nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	paths := make([]string, 0, len(index.WeightMap))
+	for _, path := range index.WeightMap {
+		path = stdpath.Clean(path)
+		if path == "." || strings.HasPrefix(path, "../") || strings.HasPrefix(path, "/") || !strings.HasSuffix(path, ".safetensors") {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
 // PushToRemote pushes the local repository to the remote registry.
 func (g *gitRepo) PushToRemote(ctx context.Context, gitRepository *git.GitRepository) error {
 	gitPath := g.gitPath(gitRepository.ResourceType, gitRepository.ProjectName, gitRepository.ResourceName)
@@ -525,7 +600,7 @@ func (g *gitRepo) PushToRemote(ctx context.Context, gitRepository *git.GitReposi
 
 // ExtractMetadata reads raw metadata-related files from a Git repository.
 func (g *gitRepo) ExtractMetadata(ctx context.Context, repoType, project, name string) (*git.RepoMetadataFiles, error) {
-	metadata := &git.RepoMetadataFiles{}
+	metadata := &git.RepoMetadataFiles{SafetensorsFiles: make(map[string][]byte)}
 
 	// Open Git repository
 	gitPath := g.gitPath(repoType, project, name)
@@ -537,36 +612,25 @@ func (g *gitRepo) ExtractMetadata(ctx context.Context, repoType, project, name s
 	rev := repo.DefaultBranch()
 
 	// Read README.md raw content
-	if blob, err := repo.Blob(rev, "README.md"); err == nil {
-		if rc, err := blob.NewReader(); err == nil {
-			content, err := io.ReadAll(rc)
-			_ = rc.Close()
-			if err == nil {
-				metadata.ReadmeContent = content
-			}
-		}
+	if content, err := g.readBlobBytes(repo, rev, "README.md"); err == nil {
+		metadata.ReadmeContent = content
 	}
 
 	// Read config.json raw content
-	if blob, err := repo.Blob(rev, "config.json"); err == nil {
-		if rc, err := blob.NewReader(); err == nil {
-			content, err := io.ReadAll(rc)
-			_ = rc.Close()
-			if err == nil {
-				metadata.ConfigJSON = content
-			}
-		}
+	if content, err := g.readBlobBytes(repo, rev, "config.json"); err == nil {
+		metadata.ConfigJSON = content
 	}
 
 	// Read model.safetensors.index.json raw content
-	if blob, err := repo.Blob(rev, "model.safetensors.index.json"); err == nil {
-		if rc, err := blob.NewReader(); err == nil {
-			content, err := io.ReadAll(rc)
-			_ = rc.Close()
-			if err == nil {
-				metadata.SafetensorsIndexJSON = content
+	if content, err := g.readBlobBytes(repo, rev, "model.safetensors.index.json"); err == nil {
+		metadata.SafetensorsIndexJSON = content
+		for _, path := range loadSafetensorsPathsFromIndex(content) {
+			if prefix, err := g.readBlobPrefix(repo, rev, path, maxSafetensorsHeaderPrefixBytes); err == nil {
+				metadata.SafetensorsFiles[path] = prefix
 			}
 		}
+	} else if prefix, err := g.readBlobPrefix(repo, rev, "model.safetensors", maxSafetensorsHeaderPrefixBytes); err == nil {
+		metadata.SafetensorsFiles["model.safetensors"] = prefix
 	}
 
 	// Compute model content size from the default branch tree. DiskUsage

--- a/internal/repo/git_repo_metadata_test.go
+++ b/internal/repo/git_repo_metadata_test.go
@@ -16,12 +16,17 @@ package repo
 
 import (
 	"context"
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/matrixhub-ai/hfd/pkg/repository"
 	hfdstorage "github.com/matrixhub-ai/hfd/pkg/storage"
 
 	"github.com/matrixhub-ai/matrixhub/internal/domain/git"
+	modeldomain "github.com/matrixhub-ai/matrixhub/internal/domain/model"
 )
 
 func TestExtractMetadataUsesTreeSize(t *testing.T) {
@@ -63,4 +68,85 @@ func TestExtractMetadataUsesTreeSize(t *testing.T) {
 	if metadata.Size != expectedSize {
 		t.Fatalf("metadata.Size = %d, want tree size %d", metadata.Size, expectedSize)
 	}
+}
+
+func TestExtractMetadataReadsSingleSafetensorsHeader(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	store := hfdstorage.NewStorage(hfdstorage.WithRootDir(root))
+	repoPath := store.ResolvePath("test-project/test-model")
+	if err := os.MkdirAll(filepath.Dir(repoPath), 0750); err != nil {
+		t.Fatalf("os.MkdirAll() error = %v", err)
+	}
+
+	repo, err := repository.Init(ctx, repoPath, "main")
+	if err != nil {
+		t.Fatalf("repository.Init() error = %v", err)
+	}
+
+	fullSafetensors := buildRepoTestSafetensorsFile(t, map[string][]int64{
+		"model.embed_tokens.weight": {2, 3},
+		"lm_head.weight":            {4, 5},
+	}, 1024*1024)
+
+	if _, err := repo.CreateCommit(ctx, "main", "add model", "Test", "test@example.com", []repository.CommitOperation{
+		{Type: repository.CommitOperationAdd, Path: "config.json", Content: []byte(`{"torch_dtype":"bfloat16"}`)},
+		{Type: repository.CommitOperationAdd, Path: "model.safetensors", Content: fullSafetensors},
+	}, ""); err != nil {
+		t.Fatalf("CreateCommit() error = %v", err)
+	}
+
+	gitRepo := NewGitDB(store, nil)
+	files, err := gitRepo.ExtractMetadata(ctx, "models", "test-project", "test-model")
+	if err != nil {
+		t.Fatalf("ExtractMetadata() error = %v", err)
+	}
+
+	header := files.SafetensorsFiles["model.safetensors"]
+	if len(header) == 0 {
+		t.Fatal("expected model.safetensors header to be extracted")
+	}
+	if len(header) >= len(fullSafetensors) {
+		t.Fatalf("expected only safetensors header, got full file: header=%d full=%d", len(header), len(fullSafetensors))
+	}
+
+	metadata, err := modeldomain.AnalyzeRepoMetadata(files)
+	if err != nil {
+		t.Fatalf("AnalyzeRepoMetadata() error = %v", err)
+	}
+	if metadata.ParameterCount != 26 {
+		t.Fatalf("ParameterCount = %d, want 26", metadata.ParameterCount)
+	}
+}
+
+func buildRepoTestSafetensorsFile(t *testing.T, tensors map[string][]int64, payloadSize int) []byte {
+	t.Helper()
+
+	header := map[string]any{
+		"__metadata__": map[string]string{"format": "pt"},
+	}
+	offset := int64(0)
+	for name, shape := range tensors {
+		count := int64(1)
+		for _, dim := range shape {
+			count *= dim
+		}
+		size := count * 2
+		header[name] = map[string]any{
+			"dtype":        "BF16",
+			"shape":        shape,
+			"data_offsets": []int64{offset, offset + size},
+		}
+		offset += size
+	}
+
+	headerBytes, err := json.Marshal(header)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	content := make([]byte, 8+len(headerBytes)+payloadSize)
+	binary.LittleEndian.PutUint64(content[:8], uint64(len(headerBytes)))
+	copy(content[8:], headerBytes)
+	return content
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Some Hugging Face models, such as Qwen3-0.6B, publish a single model.safetensors file without model.safetensors.index.json. MatrixHub only inferred parameter_count from the index metadata, so these models kept parameter_count at zero and rendered as 0.0 in the model list.

- Add safetensors file prefixes to extracted model metadata.
- Count parameters from safetensors headers for single-file models and sharded models without metadata.total_size.
- Keep the existing model.safetensors.index.json metadata.total_size fast path when available.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #436

#### Special notes for your reviewer:

#### Checklist
<!-- For behavior changes, check the items below. If an item does not apply, leave it unchecked and explain in the reviewer notes above. -->
- [ ] UT/E2E added or updated
- [ ] User-facing behavior changes are documented

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Model parameter counts are now displayed correctly for single-file safetensors models and sharded models without total-size metadata.
```
