### PR TITLE
ci: validate GitHub Actions workflow refs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,9 +28,15 @@ Fixes #
 #### Special notes for your reviewer:
 
 #### Checklist
-<!-- For behavior changes, check the items below. If an item does not apply, leave it unchecked and explain in the reviewer notes above. -->
-- [ ] UT/E2E added or updated
-- [ ] User-facing behavior changes are documented
+<!-- If an item does not apply, leave it unchecked and explain in the reviewer notes above.
+
+Please use the following format for linking documentation below checkbox:
+- [Tech doc]: <link>
+- [Usage]: <link>
+- [Other doc]: <link>
+-->
+- [ ] Tests(ut, e2e) added or updated, or not needed and explained
+- [ ] Docs(tech docs, usage docs) updated, or not needed and explained
 
 #### Does this PR introduce a user-facing change?
 <!--

--- a/.github/workflows/build-image-ci.yaml
+++ b/.github/workflows/build-image-ci.yaml
@@ -14,7 +14,7 @@ on:
         type: string
       push:
         required: true
-        type: string
+        type: boolean
     outputs:
       imageTag:
         description: "tag of image ci"

--- a/.github/workflows/call-release-chart.yaml
+++ b/.github/workflows/call-release-chart.yaml
@@ -15,7 +15,7 @@ on:
         type: string
       submit:
         required: true
-        type: string
+        type: boolean
     outputs:
       artifact:
         description: "Name of chart artifact"
@@ -172,4 +172,3 @@ jobs:
           helm pull oci://ghcr.io/${REPO_OWNER}/${{ env.CHART_NAME }} --version ${{ needs.get-ref.outputs.chart-version }} --destination /tmp/verify
           ls -la /tmp/verify/
           echo "Verification successful!"
-

--- a/.github/workflows/call-release-image.yaml
+++ b/.github/workflows/call-release-image.yaml
@@ -129,7 +129,7 @@ jobs:
           cosign sign -y "${{ env.ONLINE_REGISTER }}/${{ env.repo_lower }}@${sbom_digest}"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.32.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: '${{ env.ONLINE_REGISTER }}/${{ env.repo_lower }}@${{ steps.docker_build_release.outputs.digest }}'
           format: 'sarif'

--- a/.github/workflows/workflow-lint.yaml
+++ b/.github/workflows/workflow-lint.yaml
@@ -1,0 +1,87 @@
+name: Workflow Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install actionlint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- latest
+
+      - name: Run actionlint
+        run: ./actionlint -color -shellcheck=
+
+      - name: Validate action refs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          status=0
+
+          while IFS= read -r line; do
+            file=${line%%:*}
+            rest=${line#*:}
+            lineno=${rest%%:*}
+            value=${line#*uses:}
+            value=${value%%#*}
+            value=$(echo "$value" | xargs)
+            value=${value#\"}
+            value=${value%\"}
+            value=${value#\'}
+            value=${value%\'}
+
+            if [[ -z "$value" || "$value" == ./* || "$value" == docker://* ]]; then
+              continue
+            fi
+            if [[ "$value" == *'$'* ]]; then
+              echo "::warning file=${file},line=${lineno}::Skipping dynamic action ref: ${value}"
+              continue
+            fi
+            if [[ "$value" != *@* ]]; then
+              echo "::error file=${file},line=${lineno}::Action ref is missing @ref: ${value}"
+              status=1
+              continue
+            fi
+
+            action_path=${value%@*}
+            ref=${value##*@}
+            owner_repo=$(echo "$action_path" | cut -d/ -f1-2)
+
+            if [[ "$owner_repo" != */* ]]; then
+              echo "::error file=${file},line=${lineno}::Invalid action reference: ${value}"
+              status=1
+              continue
+            fi
+
+            if git ls-remote --exit-code "https://github.com/${owner_repo}.git" "refs/tags/${ref}" >/dev/null 2>&1 ||
+               git ls-remote --exit-code "https://github.com/${owner_repo}.git" "refs/heads/${ref}" >/dev/null 2>&1 ||
+               gh api "repos/${owner_repo}/commits/${ref}" >/dev/null 2>&1 ||
+               gh api "repos/${owner_repo}/releases/tags/${ref}" >/dev/null 2>&1; then
+              echo "OK ${value}"
+            else
+              echo "::error file=${file},line=${lineno}::Cannot resolve action ref: ${value}"
+              status=1
+            fi
+          done < <(grep -RInE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*[^[:space:]]+' .github/workflows .github/actions || true)
+
+          exit "$status"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Add a single Workflow Lint check for GitHub Actions workflow/action changes so invalid workflow syntax and missing action refs are caught in PR CI before they reach `main`.

This PR addresses the release image failure in https://github.com/matrixhub-ai/matrixhub/actions/runs/28350372725/job/83981852730, where GitHub Actions failed while preparing actions because it could not resolve `aquasecurity/trivy-action@0.32.0`.

This PR:
- adds `.github/workflows/workflow-lint.yaml`
- runs `actionlint` for workflow validation
- validates static `uses:` action refs with `git ls-remote` plus GitHub API fallbacks so missing action versions fail in PR CI instead of after merge
- fixes the invalid Trivy GitHub Action version in the release-image workflow (`aquasecurity/trivy-action@0.32.0` -> `aquasecurity/trivy-action@v0.36.0`)
- aligns reusable workflow boolean input types for `actionlint`

#### Which issue(s) this PR fixes:

Refs #703

#### Special notes for your reviewer:

`actionlint` disables shellcheck integration for this first rollout so existing shell style warnings do not block unrelated workflow validation. This PR has no app runtime behavior change.

Checklist items are intentionally left unchecked: this workflow-only change is validated by workflow lint/manual checks instead of UT/E2E, and it does not require tech docs or usage docs.

Validation performed:
- local `actionlint -shellcheck=`
- local action ref validation script
- `git diff --check`
- PR `workflow-lint` check passed

#### Checklist
<!-- If an item does not apply, leave it unchecked and explain in the reviewer notes above.

Please use the following format for linking documentation below checkbox:
- [Tech doc]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
- [ ] Tests added or updated, or not needed and explained
- [ ] Docs(tech docs, usage docs) updated, or not needed and explained

#### Does this PR introduce a user-facing change?
```release-note
NONE
```