### PR TITLE
fix: use tree size for model metadata

### DIFF
--- a/internal/repo/git_repo.go
+++ b/internal/repo/git_repo.go
@@ -569,8 +569,10 @@ func (g *gitRepo) ExtractMetadata(ctx context.Context, repoType, project, name s
 		}
 	}
 
-	// Compute repository size
-	if size, err := repo.DiskUsage(); err == nil {
+	// Compute model content size from the default branch tree. DiskUsage
+	// includes bare Git repository storage overhead, which is not user-visible
+	// model file size.
+	if size, err := repo.TreeSize(rev, ""); err == nil {
 		metadata.Size = size
 	}
 

--- a/internal/repo/git_repo_metadata_test.go
+++ b/internal/repo/git_repo_metadata_test.go
@@ -1,0 +1,66 @@
+// Copyright The MatrixHub Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixhub-ai/hfd/pkg/repository"
+	hfdstorage "github.com/matrixhub-ai/hfd/pkg/storage"
+
+	"github.com/matrixhub-ai/matrixhub/internal/domain/git"
+)
+
+func TestExtractMetadataUsesTreeSize(t *testing.T) {
+	ctx := context.Background()
+	repo := NewGitDB(hfdstorage.NewStorage(hfdstorage.WithRootDir(t.TempDir())), nil)
+
+	const (
+		project = "test-project"
+		name    = "test-model"
+		readme  = "# Test\n"
+		lfsSize = int64(1024)
+	)
+
+	if err := repo.CreateRepository(ctx, "model", project, name); err != nil {
+		t.Fatalf("CreateRepository() error = %v", err)
+	}
+
+	lfsPointer := []byte("version https://git-lfs.github.com/spec/v1\n" +
+		"oid sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n" +
+		"size 1024\n")
+
+	if _, err := repo.CreateCommit(ctx, "model", project, name, "main", &git.Commit{
+		Message:     "Add model files",
+		AuthorName:  "test",
+		AuthorEmail: "test@example.com",
+	}, []git.CommitOperation{
+		{Type: git.CommitOperationAdd, Path: "README.md", Content: []byte(readme)},
+		{Type: git.CommitOperationAdd, Path: "model.bin", Content: lfsPointer},
+	}); err != nil {
+		t.Fatalf("CreateCommit() error = %v", err)
+	}
+
+	metadata, err := repo.ExtractMetadata(ctx, "model", project, name)
+	if err != nil {
+		t.Fatalf("ExtractMetadata() error = %v", err)
+	}
+
+	expectedSize := int64(len(repository.GitattributesText)+len(readme)) + lfsSize
+	if metadata.Size != expectedSize {
+		t.Fatalf("metadata.Size = %d, want tree size %d", metadata.Size, expectedSize)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
The model detail page can show an incorrect model size because MatrixHub stored bare Git repository disk usage as model metadata size. That value includes Git object storage overhead and can be larger than the actual files visible in the model tree.

- Use the default branch tree size for model metadata instead of bare Git repository disk usage.
- Keep model size consistent with the model file tree and Hugging Face tree size behavior.
- Add a repo test covering metadata size calculation with an LFS pointer.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #447

#### Special notes for your reviewer:

#### Checklist
<!-- For behavior changes, check the items below. If an item does not apply, leave it unchecked and explain in the reviewer notes above. -->
- [x] UT/E2E added or updated
- [ ] User-facing behavior changes are documented

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed model size display to use repository tree content size instead of Git repository disk usage.
```
