### PR TITLE
fix(ui): keep markdown preview in light color scheme

### DIFF
--- a/ui/src/features/file-viewer/components/MarkdownViewer.tsx
+++ b/ui/src/features/file-viewer/components/MarkdownViewer.tsx
@@ -1,7 +1,7 @@
 import { Box } from '@mantine/core'
 import Markdown from 'react-markdown'
 
-import 'github-markdown-css/github-markdown.css'
+import 'github-markdown-css/github-markdown-light.css'
 
 interface MarkdownViewerProps {
   content: string


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Keeps the Markdown preview in the light color scheme by using the light-only GitHub Markdown stylesheet. This prevents the preview from unexpectedly switching to dark colors when the system uses dark mode.

#### Which issue(s) this PR fixes:
Fixes #431 

#### Special notes for your reviewer:

#### Checklist
<!-- If an item does not apply, leave it unchecked and explain in the reviewer notes above.

Please use the following format for linking documentation below checkbox:
- [Tech doc]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
- [x] Tests(ut, e2e) added or updated, or not needed and explained
- [x] Docs(tech docs, usage docs) updated, or not needed and explained

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix Markdown previews to consistently use the light color scheme.
```
