### PR TITLE
chore: group Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,16 @@ updates:
     labels:
       - "dependencies"
       - "automated"
+    groups:
+      security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+      all:
+        applies-to: "version-updates"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Maintain npm dependencies for web
   - package-ecosystem: "npm"
@@ -19,7 +29,12 @@ updates:
       - "dependencies"
       - "automated"
     groups:
+      security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
       all:
+        applies-to: "version-updates"
         update-types:
           - "minor"
           - "patch"
@@ -33,7 +48,12 @@ updates:
       - "dependencies"
       - "automated"
     groups:
+      security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
       all:
+        applies-to: "version-updates"
         update-types:
           - "minor"
           - "patch"
@@ -48,7 +68,12 @@ updates:
       - "automated"
     open-pull-requests-limit: 10
     groups:
+      security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
       all:
+        applies-to: "version-updates"
         update-types:
           - "minor"
           - "patch"
@@ -61,3 +86,8 @@ updates:
     labels:
       - "dependencies"
       - "automated"
+    groups:
+      security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Configure Dependabot grouping for the existing dependency ecosystems.

This PR:
- adds `security` groups for Go modules, npm, GitHub Actions, and Docker security updates
- adds/keeps `all` version-update groups for Go modules, npm, and GitHub Actions minor/patch updates
- makes existing `all` groups explicitly apply to version updates only
- leaves Docker routine version updates ungrouped, while grouping Docker security updates

This keeps security remediation separate from routine dependency maintenance and reduces Dependabot PR noise without mixing Docker base image version bumps into broader version-update groups.

#### Special notes for your reviewer:

This is a GitHub configuration-only change. No runtime behavior is changed.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```