### PR TITLE
fix: validate model names

### DIFF
--- a/api/go/v1alpha1/model.pb.go
+++ b/api/go/v1alpha1/model.pb.go
@@ -1835,10 +1835,10 @@ const file_v1alpha1_model_proto_rawDesc = "" +
 	"pagination\"t\n" +
 	"\x0fGetModelRequest\x12!\n" +
 	"\aproject\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\aproject\x12>\n" +
-	"\x04name\x18\x02 \x01(\tB*\xfaB'r%\x10\x01Z\x06modelsZ\bdatasetsZ\x06spacesZ\aresolveR\x04name\"z\n" +
+	"\x04name\x18\x02 \x01(\tB*\xfaB'r%\x10\x01Z\x06modelsZ\bdatasetsZ\x06spacesZ\aresolveR\x04name\"\x98\x01\n" +
 	"\x12CreateModelRequest\x12!\n" +
-	"\aproject\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\aproject\x12A\n" +
-	"\x04name\x18\x02 \x01(\tB-\xfaB*r(\x10\x01\x18\xfb\x01Z\x06modelsZ\bdatasetsZ\x06spacesZ\aresolveR\x04name\"\x15\n" +
+	"\aproject\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\aproject\x12_\n" +
+	"\x04name\x18\x02 \x01(\tBK\xfaBHrF\x10\x01\x18\xfb\x012\x1c^[A-Za-z0-9][A-Za-z0-9_.-]*$Z\x06modelsZ\bdatasetsZ\x06spacesZ\aresolveR\x04name\"\x15\n" +
 	"\x13CreateModelResponse\"T\n" +
 	"\x12DeleteModelRequest\x12!\n" +
 	"\aproject\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\aproject\x12\x1b\n" +

--- a/api/go/v1alpha1/model.pb.validate.go
+++ b/api/go/v1alpha1/model.pb.validate.go
@@ -988,6 +988,17 @@ func (m *CreateModelRequest) validate(all bool) error {
 		errors = append(errors, err)
 	}
 
+	if !_CreateModelRequest_Name_Pattern.MatchString(m.GetName()) {
+		err := CreateModelRequestValidationError{
+			field:  "Name",
+			reason: "value does not match regex pattern \"^[A-Za-z0-9][A-Za-z0-9_.-]*$\"",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
 	if len(errors) > 0 {
 		return CreateModelRequestMultiError(errors)
 	}
@@ -1074,6 +1085,8 @@ var _CreateModelRequest_Name_NotInLookup = map[string]struct{}{
 	"spaces":   {},
 	"resolve":  {},
 }
+
+var _CreateModelRequest_Name_Pattern = regexp.MustCompile("^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 
 // Validate checks the field values on CreateModelResponse with the rules
 // defined in the proto definition for this message. If any rules are

--- a/api/proto/v1alpha1/model.proto
+++ b/api/proto/v1alpha1/model.proto
@@ -110,7 +110,12 @@ message GetModelRequest {
 
 message CreateModelRequest {
   string project = 1 [(validate.rules).string.min_len = 1];
-  string name = 2 [(validate.rules).string = {min_len: 1, max_len: 251, not_in: ["models", "datasets", "spaces", "resolve"]}];
+  string name = 2 [(validate.rules).string = {
+    min_len: 1,
+    max_len: 251,
+    pattern: "^[A-Za-z0-9][A-Za-z0-9_.-]*$",
+    not_in: ["models", "datasets", "spaces", "resolve"]
+  }];
 }
 
 message CreateModelResponse {

--- a/internal/domain/model/model_service.go
+++ b/internal/domain/model/model_service.go
@@ -81,13 +81,8 @@ func NewModelService(modelRepo IModelRepo, labelRepo ILabelRepo, gitRepo git.IGi
 	}
 }
 
-func normalizeModelIdentity(project, name string) (string, string) {
-	return strings.TrimSpace(project), strings.TrimSpace(name)
-}
-
 // CreateModel creates a new model in the system.
 func (s *ModelService) CreateModel(ctx context.Context, project, name string) (*Model, error) {
-	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return nil, errors.New("invalid project")
 	}
@@ -120,7 +115,6 @@ func (s *ModelService) CreateModel(ctx context.Context, project, name string) (*
 
 // GetModel retrieves a model by project and name.
 func (s *ModelService) GetModel(ctx context.Context, project, name string) (*Model, error) {
-	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return nil, errors.New("invalid project")
 	}
@@ -150,7 +144,6 @@ func (s *ModelService) ListModels(ctx context.Context, filter *Filter) ([]*Model
 
 // DeleteModel deletes a model by project and name.
 func (s *ModelService) DeleteModel(ctx context.Context, project, name string) error {
-	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return errors.New("invalid project")
 	}
@@ -178,7 +171,6 @@ func (s *ModelService) ListModelFrameLabels(ctx context.Context) ([]*Label, erro
 
 // ListModelRevisions returns all branches and tags for a model.
 func (s *ModelService) ListModelRevisions(ctx context.Context, project, name string) (*git.Revisions, error) {
-	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return nil, errors.New("invalid project")
 	}
@@ -197,7 +189,6 @@ func (s *ModelService) ListModelRevisions(ctx context.Context, project, name str
 
 // ListModelCommits returns the commit history for a model.
 func (s *ModelService) ListModelCommits(ctx context.Context, project, name, revision string, page, pageSize int) ([]*git.Commit, int64, error) {
-	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return nil, 0, errors.New("invalid project")
 	}
@@ -225,7 +216,6 @@ func (s *ModelService) ListModelCommits(ctx context.Context, project, name, revi
 
 // GetModelCommit returns a specific commit by ID.
 func (s *ModelService) GetModelCommit(ctx context.Context, project, name, commitID string) (*git.Commit, error) {
-	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return nil, errors.New("invalid project")
 	}
@@ -247,7 +237,6 @@ func (s *ModelService) GetModelCommit(ctx context.Context, project, name, commit
 
 // CreateModelCommit creates a new model commit.
 func (s *ModelService) CreateModelCommit(ctx context.Context, project, name, revision string, commit *git.Commit, ops []git.CommitOperation) (string, error) {
-	project, name = normalizeModelIdentity(project, name)
 	prj, err := s.projectRepo.GetProjectByName(ctx, project)
 	if err != nil {
 		return "", err
@@ -282,7 +271,6 @@ func (s *ModelService) CreateModelCommit(ctx context.Context, project, name, rev
 
 // GetModelTree returns the file tree at a specific revision and path.
 func (s *ModelService) GetModelTree(ctx context.Context, project, name, revision, path string) ([]*git.TreeEntry, error) {
-	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return nil, errors.New("invalid project")
 	}
@@ -301,7 +289,6 @@ func (s *ModelService) GetModelTree(ctx context.Context, project, name, revision
 
 // GetModelBlob returns the content of a file at a specific revision.
 func (s *ModelService) GetModelBlob(ctx context.Context, project, name, revision, path string) (*git.TreeEntry, error) {
-	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return nil, errors.New("invalid project")
 	}
@@ -320,7 +307,6 @@ func (s *ModelService) GetModelBlob(ctx context.Context, project, name, revision
 
 // UpdateModelSetting updates model settings such as the popular flag.
 func (s *ModelService) UpdateModelSetting(ctx context.Context, project, name string, update *SettingUpdate) error {
-	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return errors.New("invalid project")
 	}
@@ -338,7 +324,6 @@ func (s *ModelService) UpdateModelSetting(ctx context.Context, project, name str
 
 // SyncMetadata synchronizes Git repository metadata to the database.
 func (s *ModelService) SyncMetadata(ctx context.Context, project, name string) error {
-	project, name = normalizeModelIdentity(project, name)
 	m, err := s.modelRepo.GetByProjectAndName(ctx, project, name)
 	if err != nil {
 		return fmt.Errorf("model not found: %w", err)
@@ -384,7 +369,6 @@ func (s *ModelService) updateModelLabels(ctx context.Context, modelID int64, tag
 }
 
 func (s *ModelService) CheckOrSyncFromRemote(ctx context.Context, project, name string) error {
-	project, name = normalizeModelIdentity(project, name)
 	prj, err := s.projectRepo.GetProjectByName(ctx, project)
 	if err != nil {
 		return err
@@ -437,7 +421,6 @@ func (s *ModelService) CheckOrSyncFromRemote(ctx context.Context, project, name 
 }
 
 func (s *ModelService) EnsureModel(ctx context.Context, project, name string) (*Model, error) {
-	project, name = normalizeModelIdentity(project, name)
 	model, err := s.modelRepo.GetByProjectAndName(ctx, project, name)
 	if err == nil {
 		return model, nil

--- a/internal/domain/model/model_service.go
+++ b/internal/domain/model/model_service.go
@@ -81,8 +81,13 @@ func NewModelService(modelRepo IModelRepo, labelRepo ILabelRepo, gitRepo git.IGi
 	}
 }
 
+func normalizeModelIdentity(project, name string) (string, string) {
+	return strings.TrimSpace(project), strings.TrimSpace(name)
+}
+
 // CreateModel creates a new model in the system.
 func (s *ModelService) CreateModel(ctx context.Context, project, name string) (*Model, error) {
+	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return nil, errors.New("invalid project")
 	}
@@ -115,6 +120,7 @@ func (s *ModelService) CreateModel(ctx context.Context, project, name string) (*
 
 // GetModel retrieves a model by project and name.
 func (s *ModelService) GetModel(ctx context.Context, project, name string) (*Model, error) {
+	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return nil, errors.New("invalid project")
 	}
@@ -144,6 +150,7 @@ func (s *ModelService) ListModels(ctx context.Context, filter *Filter) ([]*Model
 
 // DeleteModel deletes a model by project and name.
 func (s *ModelService) DeleteModel(ctx context.Context, project, name string) error {
+	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return errors.New("invalid project")
 	}
@@ -171,6 +178,7 @@ func (s *ModelService) ListModelFrameLabels(ctx context.Context) ([]*Label, erro
 
 // ListModelRevisions returns all branches and tags for a model.
 func (s *ModelService) ListModelRevisions(ctx context.Context, project, name string) (*git.Revisions, error) {
+	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return nil, errors.New("invalid project")
 	}
@@ -189,6 +197,7 @@ func (s *ModelService) ListModelRevisions(ctx context.Context, project, name str
 
 // ListModelCommits returns the commit history for a model.
 func (s *ModelService) ListModelCommits(ctx context.Context, project, name, revision string, page, pageSize int) ([]*git.Commit, int64, error) {
+	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return nil, 0, errors.New("invalid project")
 	}
@@ -216,6 +225,7 @@ func (s *ModelService) ListModelCommits(ctx context.Context, project, name, revi
 
 // GetModelCommit returns a specific commit by ID.
 func (s *ModelService) GetModelCommit(ctx context.Context, project, name, commitID string) (*git.Commit, error) {
+	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return nil, errors.New("invalid project")
 	}
@@ -237,6 +247,7 @@ func (s *ModelService) GetModelCommit(ctx context.Context, project, name, commit
 
 // CreateModelCommit creates a new model commit.
 func (s *ModelService) CreateModelCommit(ctx context.Context, project, name, revision string, commit *git.Commit, ops []git.CommitOperation) (string, error) {
+	project, name = normalizeModelIdentity(project, name)
 	prj, err := s.projectRepo.GetProjectByName(ctx, project)
 	if err != nil {
 		return "", err
@@ -271,6 +282,7 @@ func (s *ModelService) CreateModelCommit(ctx context.Context, project, name, rev
 
 // GetModelTree returns the file tree at a specific revision and path.
 func (s *ModelService) GetModelTree(ctx context.Context, project, name, revision, path string) ([]*git.TreeEntry, error) {
+	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return nil, errors.New("invalid project")
 	}
@@ -289,6 +301,7 @@ func (s *ModelService) GetModelTree(ctx context.Context, project, name, revision
 
 // GetModelBlob returns the content of a file at a specific revision.
 func (s *ModelService) GetModelBlob(ctx context.Context, project, name, revision, path string) (*git.TreeEntry, error) {
+	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return nil, errors.New("invalid project")
 	}
@@ -307,6 +320,7 @@ func (s *ModelService) GetModelBlob(ctx context.Context, project, name, revision
 
 // UpdateModelSetting updates model settings such as the popular flag.
 func (s *ModelService) UpdateModelSetting(ctx context.Context, project, name string, update *SettingUpdate) error {
+	project, name = normalizeModelIdentity(project, name)
 	if project == "" {
 		return errors.New("invalid project")
 	}
@@ -324,6 +338,7 @@ func (s *ModelService) UpdateModelSetting(ctx context.Context, project, name str
 
 // SyncMetadata synchronizes Git repository metadata to the database.
 func (s *ModelService) SyncMetadata(ctx context.Context, project, name string) error {
+	project, name = normalizeModelIdentity(project, name)
 	m, err := s.modelRepo.GetByProjectAndName(ctx, project, name)
 	if err != nil {
 		return fmt.Errorf("model not found: %w", err)
@@ -369,6 +384,7 @@ func (s *ModelService) updateModelLabels(ctx context.Context, modelID int64, tag
 }
 
 func (s *ModelService) CheckOrSyncFromRemote(ctx context.Context, project, name string) error {
+	project, name = normalizeModelIdentity(project, name)
 	prj, err := s.projectRepo.GetProjectByName(ctx, project)
 	if err != nil {
 		return err
@@ -421,6 +437,7 @@ func (s *ModelService) CheckOrSyncFromRemote(ctx context.Context, project, name 
 }
 
 func (s *ModelService) EnsureModel(ctx context.Context, project, name string) (*Model, error) {
+	project, name = normalizeModelIdentity(project, name)
 	model, err := s.modelRepo.GetByProjectAndName(ctx, project, name)
 	if err == nil {
 		return model, nil


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Creating a model with leading or trailing whitespace could save a DB/Git repository name that did not match the trimmed name used by model cards when navigating to details. This made the created model appear in the list, but the details route could request a different name and return 404.

- Validate new model names at the protobuf API boundary with the same allowed character set as the UI.
- Normalize model project/name identifiers in the domain service before DB and Git operations.
- Add tests for create-name validation and whitespace normalization.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #446

#### Special notes for your reviewer:
No frontend source changes. User-facing behavior is limited to rejecting invalid create names; no docs page was updated.

#### Checklist
<!-- For behavior changes, check the items below. If one does not apply, leave it unchecked and explain in the reviewer notes above. -->
- [x] UT/E2E added or updated
- [ ] User-facing behavior changes are documented

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Creating a model now rejects invalid names and normalizes model identifiers to avoid detail-page 404s caused by leading or trailing whitespace.
```