### PR TITLE
chore(deps): refine Dependabot update grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,8 @@ updates:
     labels:
       - "dependencies"
       - "automated"
+    open-pull-requests-limit: 5
     groups:
-      security:
-        applies-to: "security-updates"
-        patterns:
-          - "*"
       all:
         applies-to: "version-updates"
         update-types:
@@ -28,16 +25,31 @@ updates:
     labels:
       - "dependencies"
       - "automated"
+    open-pull-requests-limit: 5
     groups:
-      security:
-        applies-to: "security-updates"
+      mantine:
         patterns:
-          - "*"
-      all:
-        applies-to: "version-updates"
-        update-types:
-          - "minor"
-          - "patch"
+          - "@mantine/*"
+          - "mantine-react-table"
+        update-types: [minor, patch]
+      tanstack:
+        patterns:
+          - "@tanstack/*"
+        update-types: [minor, patch]
+      vite:
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+          - "vite-*"
+          - "rollup"
+        update-types: [minor, patch]
+      lint:
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+          - "@typescript-eslint/*"
+          - "typescript-eslint"
+        update-types: [minor, patch]
 
   # Maintain npm dependencies for website
   - package-ecosystem: "npm"
@@ -47,31 +59,23 @@ updates:
     labels:
       - "dependencies"
       - "automated"
+    open-pull-requests-limit: 5
     groups:
-      security:
-        applies-to: "security-updates"
+      docusaurus:
         patterns:
-          - "*"
-      all:
-        applies-to: "version-updates"
-        update-types:
-          - "minor"
-          - "patch"
+          - "@docusaurus/*"
+        update-types: [minor, patch]
 
   # Maintain GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - "dependencies"
       - "automated"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     groups:
-      security:
-        applies-to: "security-updates"
-        patterns:
-          - "*"
       all:
         applies-to: "version-updates"
         update-types:
@@ -86,8 +90,4 @@ updates:
     labels:
       - "dependencies"
       - "automated"
-    groups:
-      security:
-        applies-to: "security-updates"
-        patterns:
-          - "*"
+    open-pull-requests-limit: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,15 +28,18 @@ updates:
     open-pull-requests-limit: 5
     groups:
       mantine:
+        applies-to: "version-updates"
         patterns:
           - "@mantine/*"
           - "mantine-react-table"
         update-types: [minor, patch]
       tanstack:
+        applies-to: "version-updates"
         patterns:
           - "@tanstack/*"
         update-types: [minor, patch]
       vite:
+        applies-to: "version-updates"
         patterns:
           - "vite"
           - "@vitejs/*"
@@ -44,9 +47,13 @@ updates:
           - "rollup"
         update-types: [minor, patch]
       lint:
+        applies-to: "version-updates"
         patterns:
           - "eslint"
+          - "eslint-*"
           - "@eslint/*"
+          - "@eslint-react/*"
+          - "@stylistic/*"
           - "@typescript-eslint/*"
           - "typescript-eslint"
         update-types: [minor, patch]
@@ -62,6 +69,7 @@ updates:
     open-pull-requests-limit: 5
     groups:
       docusaurus:
+        applies-to: "version-updates"
         patterns:
           - "@docusaurus/*"
         update-types: [minor, patch]
@@ -82,9 +90,9 @@ updates:
           - "minor"
           - "patch"
 
-  # Maintain Dockerfile
+  # Maintain the MatrixHub Dockerfile
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/deploy/docker/matrixhub"
     schedule:
       interval: "weekly"
     labels:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refines Dependabot update grouping to keep dependency PRs focused and easier to review.

- Removes wildcard security-update groups so security fixes are isolated.
- Splits UI and website minor/patch updates into focused dependency families.
- Expands the UI lint group to cover the existing ESLint ecosystem.
- Points Docker updates at `deploy/docker/matrixhub/Dockerfile`.
- Limits ordinary update PR queues and changes GitHub Actions updates from daily to weekly.

#### Which issue(s) this PR fixes:

Fixes #758

#### Special notes for your reviewer:

This PR intentionally changes only `.github/dependabot.yml`.

No auto-merge, reviewer assignment, global major-version ignore rule, cooldown, or dependency lockfile update is included.

#### Checklist

- [x] Tests(ut, e2e) added or updated, or not needed and explained
  - Not needed: this is Dependabot YAML configuration only; YAML parsing, semantic assertions, and `git diff --check` passed.
- [x] Docs(tech docs, usage docs) updated, or not needed and explained
  - Not needed: no user-facing behavior or usage documentation changes.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```