### PR TITLE
fix(deps): remediate Go vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matrixhub-ai/matrixhub
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/alexedwards/scs/mysqlstore v0.0.0-20251002162104-209de6e426de
@@ -117,7 +117,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/quic-go/quic-go v0.59.0 // indirect
+	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/rubyist/tracerx v0.0.0-20170927163412-787959303086 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
-github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
+github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
+github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

- Upgrades Go from 1.25.11 to 1.25.12 to remediate GO-2026-5856.
- Upgrades `github.com/quic-go/quic-go` from v0.59.0 to v0.59.1 to remediate GO-2026-5676.
- Restores the `govulncheck` security gate currently blocking #780.

#### Which issue(s) this PR fixes:

Related to #758

#### Special notes for your reviewer:

This PR intentionally contains only the two version upgrades required by the reachable vulnerabilities. Merge it before rebasing #780.

Validation:
- `govulncheck ./...`: no reachable vulnerabilities found.
- `go mod verify`: all modules verified.
- `go test ./cmd/... ./internal/... -short -count=1`: all packages except `internal/apiserver/handler/hf` passed; that package hits a pre-existing nil test fixture dependency in `handleCreateRepo`.
- `go mod tidy` cannot complete because the repository contains frontend directory names with `(` and `$`, which Go rejects as import paths while scanning the module root.

#### Checklist

- [x] Tests(ut, e2e) added or updated, or not needed and explained
- [x] Docs(tech docs, usage docs) updated, or not needed and explained

No tests or docs were added because this is a dependency-only security remediation; validation details are listed above.

#### Does this PR introduce a user-facing change?

```release-note
Updated Go and quic-go to address known security vulnerabilities.
```