### PR TITLE
chore: disable UI Dependabot version PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,7 @@ updates:
     labels:
       - "dependencies"
       - "automated"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     groups:
       mantine:
         applies-to: "version-updates"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Set `open-pull-requests-limit` to `0` for the npm configuration under `/ui`.

This stops Dependabot version-update pull requests for UI dependencies while leaving Dependabot security alert scanning and the update configurations for Go, Website, GitHub Actions, and Docker unchanged. UI security alerts continue to be handled by the repository's auto-triage rule.

#### Which issue(s) this PR fixes:

Related to #758

#### Special notes for your reviewer:

This setting only prevents new UI version-update pull requests. Any existing UI Dependabot pull requests need to be closed separately.

The UI dependency groups remain in the configuration so version updates can be restored by changing the limit back to a positive value.

Validation:

- Parsed `.github/dependabot.yml` successfully with Ruby's YAML parser.
- Verified limits: Go `5`, UI `0`, Website `5`, GitHub Actions `5`, Docker `3`.
- `git diff --check`

#### Checklist

- [x] Tests(ut, e2e) added or updated, or not needed and explained
- [x] Docs(tech docs, usage docs) updated, or not needed and explained

Tests and documentation are not needed because this is a one-line Dependabot configuration change validated by parsing the YAML.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
