### PR TITLE
chore: upgrade website lucide-react

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13,7 +13,7 @@
         "@docusaurus/preset-classic": "3.10.2",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
-        "lucide-react": "^0.562.0",
+        "lucide-react": "^1.24.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -11964,9 +11964,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.562.0",
-      "resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-0.562.0.tgz",
-      "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-1.24.0.tgz",
+      "integrity": "sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/website/package.json
+++ b/website/package.json
@@ -20,7 +20,7 @@
     "@docusaurus/preset-classic": "3.10.2",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
-    "lucide-react": "^0.562.0",
+    "lucide-react": "^1.24.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -8,7 +8,7 @@ import {
   Database,
   Network,
   ArrowRight,
-  Github,
+  Code,
   Lock,
   Rocket,
   ShieldCheck,
@@ -193,7 +193,7 @@ export default function Home(): React.ReactElement {
                     href="https://github.com/matrixhub-ai/matrixhub"
                     className="px-6 sm:px-8 py-3 sm:py-4 bg-[#161b22] hover:bg-[#21262d] text-white border border-slate-700 rounded-lg font-bold text-base sm:text-lg transition-all flex items-center justify-center gap-2 hover:text-white hover:no-underline hover:border-slate-600"
                   >
-                    <Github size={20} /> <Translate id="homepage.hero.github">View on GitHub</Translate>
+                    <Code size={20} /> <Translate id="homepage.hero.github">View on GitHub</Translate>
                   </a>
                 </div>
               </div>


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Upgrade the Website from `lucide-react` 0.562.0 to 1.24.0.
- Replace the removed `Github` export with the supported `Code` icon.
- Replace Dependabot PR #792, which failed static site generation because the removed icon rendered as `undefined`.

#### Which issue(s) this PR fixes:

Related to #758

#### Special notes for your reviewer:

- `npm run build` passes for both `en` and `zh-CN` locales.
- The dependency update and required icon compatibility change are kept in one focused PR.

#### Checklist

- [x] Tests(ut, e2e) added or updated, or not needed and explained
- [x] Docs(tech docs, usage docs) updated, or not needed and explained

No tests or documentation were added because this is a dependency upgrade with a build-time compatibility fix. The production Website build is the relevant validation.

#### Does this PR introduce a user-facing change?

```release-note
None
```
