### PR TITLE
add specific config.yaml for later docker compose document optimize

### DIFF
--- a/deploy/config.yaml
+++ b/deploy/config.yaml
@@ -1,0 +1,39 @@
+# Docker Compose runtime config. Local development defaults live in config/config.yaml.
+debug: true
+migrationPath: /etc/matrixhub/migrations
+log:
+  level: debug
+dataDir: /data
+database:
+  driver: mysql
+  accessType: readwrite
+  maxOpenConns: 100
+  maxIdleConns: 10
+  connMaxLifetimeSeconds: 3600
+  connMaxIdleSeconds: 1800
+  migrate: true
+apiServer:
+  port: 3001
+  externalURL: ""
+jobServer:
+  enabled: true
+  shutdownGrace: 30s
+  syncPolicy:
+    pollInterval: 30s
+    maxConcurrent: 5
+    taskMaxDuration: 2h
+  syncTask:
+    pollInterval: 30s
+    maxConcurrent: 5
+    taskMaxDuration: 2h
+  syncJob:
+    pollInterval: 30s
+    maxConcurrent: 5
+    taskMaxDuration: 2h
+  logDir: ""
+ui:
+  staticDir: /app
+session:
+  persistentSessionLifetime: 720h
+  persistentSessionIdleTimeout: 168h
+  nonPersistentIdleTimeout: 8h


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

add config.yaml specific for later docker compose document optimize

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refs #787 #29

#### Special notes for your reviewer:
I won't change test and doc in this pr, because:

After this pr is merged, I will cherry-pick it to release/0.1 branch and create v0.1.1 release, then change the readme about docker compose setup part to use this config.yaml in the same folder with docker-compose.yml, then later I readme will be updated like this in next pr:

```bash
export MATRIXHUB_VERSION=v0.1.1

mkdir -p matrixhub
cd matrixhub

curl -fL https://raw.githubusercontent.com/matrixhub-ai/matrixhub/${MATRIXHUB_VERSION}/deploy/docker-compose.yml \
  -o docker-compose.yml
curl -fL https://raw.githubusercontent.com/matrixhub-ai/matrixhub/${MATRIXHUB_VERSION}/deploy/config.yaml \
  -o config.yaml

MATRIXHUB_IMAGE_TAG="${MATRIXHUB_VERSION}" docker compose up -d
```

#### Checklist
<!-- If an item does not apply, leave it unchecked and explain in the reviewer notes above.

Please use the following format for linking documentation below checkbox:
- [Tech doc]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
- [ ] Tests(ut, e2e) added or updated, or not needed and explained
- [ ] Docs(tech docs, usage docs) updated, or not needed and explained

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Prepare config.yaml in the same folder with docker-compose.yml to make docker compose setup steps easier
```
