### PR TITLE
fix: mount deploy/config.yaml beside docker-compose.yml

### DIFF
--- a/.github/workflows/deploy-demosite.yml
+++ b/.github/workflows/deploy-demosite.yml
@@ -29,7 +29,7 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ env.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
-          script: mkdir -p ${{ env.DEPLOY_PATH }} /root/matrixhub/config
+          script: mkdir -p ${{ env.DEPLOY_PATH }}
 
       - name: Sync configs to ECS
         uses: appleboy/scp-action@v0.1.7
@@ -38,7 +38,7 @@ jobs:
           username: ${{ env.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           # Preserve directory structure so files land at the correct paths under /root/matrixhub
-          source: "deploy/docker-compose.yml,deploy/docker-compose.override.yml,deploy/nginx.conf,config/config.yaml"
+          source: "deploy/docker-compose.yml,deploy/docker-compose.override.yml,deploy/nginx.conf,deploy/config.yaml"
           target: /root/matrixhub
           strip_components: 0
 
@@ -53,9 +53,6 @@ jobs:
             cd ${{ env.DEPLOY_PATH }}
             IMAGE_TAG="${{ github.event.inputs.image_tag }}"
             echo "[$(date '+%F %T')] === deploy start (tag: ${IMAGE_TAG}) ==="
-
-            # Patch migrationPath to use the path baked into the image
-            sed -i 's|^migrationPath: \./db/migrations|migrationPath: /etc/matrixhub/migrations|' /root/matrixhub/config/config.yaml
 
             # Create .env with random passwords on first deploy; only update image tag on subsequent runs
             if [ ! -f .env ]; then

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,4 +1,4 @@
-# Local development. Demo environment additions are in docker-compose.override.yml.
+# Docker Compose deployment. Demo environment additions are in docker-compose.override.yml.
 services:
   mysql:
     image: mysql:8.4
@@ -29,10 +29,10 @@ services:
       - -c
       - /etc/matrixhub/config.yaml
     ports:
-      - "3001:3001"
+      - "${MATRIXHUB_HTTP_PORT:-3001}:3001"
     volumes:
       - ./data/matrixhub:/data/
-      - ../config/config.yaml:/etc/matrixhub/config.yaml:ro
+      - ./config.yaml:/etc/matrixhub/config.yaml:ro
     environment:
       - MATRIXHUB_DATABASE_DSN=matrixhub:${MYSQL_PASSWORD:-changeme}@tcp(mysql:3306)/matrixhub?charset=utf8mb4&multiStatements=true&parseTime=true
     depends_on:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`deploy/docker-compose.yml` on `release-0.1` still mounts `../config/config.yaml`. The Quick Start curl flow downloads `docker-compose.yml` and `deploy/config.yaml` into the same directory as `config.yaml`, so the host path is missing and Docker creates a directory at the mount point. Apiserver then fails with:

`read /etc/matrixhub/config.yaml: is a directory`

This PR:

- Mounts `./config.yaml` (and allows optional `MATRIXHUB_HTTP_PORT`)
- Updates Deploy Demo Site to sync `deploy/config.yaml` into `/root/matrixhub/deploy/` and drops the old `config/config.yaml` + `sed` path, so demo redeploys stay compatible with the new mount

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

- Intended for `release-0.1` so a retagged or follow-up `v0.1.1` / `v0.1.2` can serve a working Quick Start.
- Same compose + demosite alignment is on the docs PR to `main` (#818).
- Merging alone does not redeploy demo; after merge, a manual Deploy Demo Site run from this branch is safe.

#### Checklist

- [x] Tests(ut, e2e) added or updated, or not needed and explained
  - Deploy layout fix; verify locally with curl + `docker compose up`, and optionally one demo redeploy.
- [x] Docs(tech docs, usage docs) updated, or not needed and explained
  - README Quick Start that matches this layout is on the docs PR to `main` (#818).

#### Does this PR introduce a user-facing change?

```release-note
Fixed Docker Compose config mount to use `./config.yaml` beside `docker-compose.yml`, so Quick Start downloads in the same directory start without a config path error.
```