### PR TITLE
ci: run the same gating CI on release branch PRs as main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - main
+      - 'release/*'
+      - 'release-*'
   pull_request:
     branches:
       - main
+      - 'release/*'
+      - 'release-*'
   schedule:
     - cron: '0 8 * * 1'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,9 +5,11 @@ on:
   push:
     branches:
       - main
+      - 'release-*'
   pull_request:
     branches:
       - main
+      - 'release-*'
   schedule:
     - cron: '0 8 * * 1'
 

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - 'release/*'
+      - 'release-*'
     paths:
       - 'cmd/**'
       - 'internal/**'
@@ -14,6 +16,8 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/*'
+      - 'release-*'
     paths:
       - 'cmd/**'
       - 'internal/**'

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'release-*'
     paths:
       - 'cmd/**'
       - 'internal/**'
@@ -14,6 +15,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'release-*'
     paths:
       - 'cmd/**'
       - 'internal/**'

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - 'release/*'
+      - 'release-*'
     paths:
       - '**.go'
       - 'go.mod'
@@ -11,6 +13,8 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/*'
+      - 'release-*'
     paths:
       - '**.go'
       - 'go.mod'

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'release-*'
     paths:
       - '**.go'
       - 'go.mod'
@@ -11,6 +12,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'release-*'
     paths:
       - '**.go'
       - 'go.mod'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - 'release/*'
+      - 'release-*'
     paths:
       - 'cmd/**'
       - 'internal/**'
@@ -11,6 +13,8 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/*'
+      - 'release-*'
     paths:
       - 'cmd/**'
       - 'internal/**'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'release-*'
     paths:
       - 'cmd/**'
       - 'internal/**'
@@ -11,6 +12,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'release-*'
     paths:
       - 'cmd/**'
       - 'internal/**'

--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -4,11 +4,15 @@ on:
   push:
     branches:
       - main
+      - 'release/*'
+      - 'release-*'
     paths:
       - website/**
   pull_request:
     branches:
       - main
+      - 'release/*'
+      - 'release-*'
     paths:
       - website/**
 

--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - main
+      - 'release-*'
     paths:
       - website/**
   pull_request:
     branches:
       - main
+      - 'release-*'
     paths:
       - website/**
 

--- a/.github/workflows/workflow-lint.yaml
+++ b/.github/workflows/workflow-lint.yaml
@@ -4,12 +4,16 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/*'
+      - 'release-*'
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
   push:
     branches:
       - main
+      - 'release/*'
+      - 'release-*'
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'

--- a/.github/workflows/workflow-lint.yaml
+++ b/.github/workflows/workflow-lint.yaml
@@ -4,12 +4,14 @@ on:
   pull_request:
     branches:
       - main
+      - 'release-*'
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
   push:
     branches:
       - main
+      - 'release-*'
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -327,6 +327,13 @@ git push origin release-0.1
 
 Open a PR into `release-0.1` when cherry-picks need review.
 
+> **CI parity:** PRs (and pushes) to a `release/*` branch run the same gating CI as
+> `main` — Unit tests, Go Lint, govulncheck, CodeQL, Workflow Lint, and Website tests,
+> subject to their path filters. Cherry-pick PRs into a release branch **must be green
+> under these same checks as `main`** before merge, so the commit you tag from the
+> release line is CI-green. The workflows list `main`, `release/*`, and `release-*` in
+> their `branches` filters; keep any new gating workflow aligned with this pattern.
+
 ##### Tag patch release
 
 ```bash

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -327,6 +327,13 @@ git push origin release-0.1
 
 Open a PR into `release-0.1` when cherry-picks need review.
 
+> **CI parity:** PRs (and pushes) to a `release-*` branch run the same gating CI as
+> `main` — Unit tests, Go Lint, govulncheck, CodeQL, Workflow Lint, and Website tests,
+> subject to their path filters. Cherry-pick PRs into a release branch **must be green
+> under these same checks as `main`** before merge, so the commit you tag from the
+> release line is CI-green. The workflows list `main` and `release-*` in their
+> `branches` filters; keep any new gating workflow aligned with this pattern.
+
 ##### Tag patch release
 
 ```bash


### PR DESCRIPTION
## What / Why

Cherry-pick / patch PRs targeting a release line (e.g. `release-0.1`) skipped most CI because several workflows hard-code `pull_request.branches: [main]` (and matching `push.branches`). The release process expects the commit tagged from a release line to be CI-green under the same gates as `main`. Fixes #821.

## Change

Add `release-*` to the `push` and `pull_request` `branches` filters of the gating workflows (path filters unchanged):

| Workflow | File |
| --- | --- |
| Unit tests | `.github/workflows/unit-test.yml` |
| Go Lint | `.github/workflows/go-lint.yml` |
| govulncheck | `.github/workflows/govulncheck.yml` |
| CodeQL | `.github/workflows/codeql.yml` |
| Workflow Lint | `.github/workflows/workflow-lint.yaml` |
| Website tests | `.github/workflows/website-test.yml` |

`ui-ci.yml` already has **no** branch filter, so it runs on every branch (release included) — left unchanged. `auto-pr-ci.yaml` (CI image build + E2E) likewise has no branch filter and already runs for release PRs. `build-image-latest.yaml` stays `main`-only by design: release-line images are published from tags via `release.yml`.

### Note on the branch pattern

`release-*` is the repo's convention, and this PR uses it everywhere:

- `docs/release-process.md` documents the release branch as `release-<minor>`, e.g. `release-0.1`.
- The `protect-main-and-release-branches` ruleset matches `refs/heads/release-*` and `refs/heads/main`.
- Issue #821 is worded against `release-*`.

A slash form (`release/0.1`) would fall outside that ruleset and is not used, so no `release/*` glob is added.

## Docs

`docs/release-process.md` (Cherry-pick patch release) now states that PRs into a `release-*` branch run the same gating CI as `main` and must be green under those checks before merge.

## Verification

- All six workflow YAML files parse cleanly; each now resolves to `branches: [main, release-*]` on both `push` and `pull_request`.
- `workflow-lint` (actionlint) runs on this PR since it touches `.github/workflows/**`.
- Full end-to-end confirmation requires a PR into an actual `release-*` branch; none exists yet. Once one is cut, a sample cherry-pick PR should show Unit tests / Go Lint / govulncheck / CodeQL / Workflow Lint / Website tests as they do on `main` (subject to path filters).

## Not covered by this PR: required status checks

#821's third dev requirement — *"Confirm branch protection / required checks for `release-*` (if any) match what CI emits after the change"* — is answered here rather than silently: they currently do **not** match, and this PR does not change that.

- Ruleset `protect-main-and-release-branches` (id 18910651) contains only `deletion`, `non_fast_forward`, and `pull_request` (0 required approvals) — there is **no** `required_status_checks` rule.
- `main` has no legacy branch protection either (`GET /repos/.../branches/main/protection` → 404).

So after this change CI *runs* on `release-*` PRs but does not *block* a red one from merging — same as `main` today. Making the checks required is a repo-settings change (admin-only, not expressible in this diff). It also needs care: several of these workflows have `paths` filters, so a PR that does not touch those paths never reports the check at all, and a naively-added required check would leave such PRs stuck on *Expected*. Doing it properly means an always-run gate job that reports status and internally skips work (the pattern `auto-pr-ci.yaml` already uses via `dorny/paths-filter`). Flagging the gap here so it is explicit rather than silently implied by the checklist.

## Checklist mapping (#821)

Mapped against the issue's **Completion checklist**:

- [x] Technical design: workflows + `branches`/`paths` filters listed above
- [x] Test cases reviewed and commented: N/A (no QA task)
- [x] UT: N/A (workflow config)
- [x] E2E: N/A (workflow config)
- [x] API change: none
- [x] Workflows for Unit tests / Go Lint / govulncheck / CodeQL / Workflow Lint accept `release-*` (Website in scope too; UI already unfiltered)
- [x] Release-process doc notes cherry-pick PRs to `release-*` must pass the same CI as `main`
- [ ] Confirmed on a PR targeting `release-*` that the expected checks run — blocked: no `release-*` branch exists yet

Dev requirement 3 ("confirm branch protection / required checks match what CI emits") is answered in the section above: they do not match, and closing that gap is a repo-settings change outside this diff.
