### PR TITLE
fix(e2e): thread label filter through to ginkgo so smoke/all works

### DIFF
--- a/.github/workflows/e2e-init.yaml
+++ b/.github/workflows/e2e-init.yaml
@@ -100,7 +100,8 @@ jobs:
         run: |
           make test.e2e.kind -e E2E_CLUSTER_NAME=${{ env.CLUSTER_NAME }} \
               -e E2E_MATRIXHUB_IMAGE=ghcr.io/${{ env.IMAGE_REPO_LOWER }}/matrixhub-ci:${{ inputs.image_tag }} \
-              -e E2E_KIND_IMAGE_TAG=${{ inputs.k8s_version }}
+              -e E2E_KIND_IMAGE_TAG=${{ inputs.k8s_version }} \
+              -e E2E_LABELS="${{ inputs.e2e_labels }}"
       - name: Cleanup Kind Cluster
         if: always()
         run: |

--- a/Makefile
+++ b/Makefile
@@ -169,9 +169,8 @@ deploy.matrixhub: ## Deploy MatrixHub to KIND cluster
 kind.setup: deploy.kind-cluster deploy.matrixhub ## Setup KIND cluster and deploy MatrixHub
 
 .PHONY: test.e2e
-test.e2e: ## Run E2E tests locally (requires running MatrixHub)
-	$(eval level ?= "smoke")
-	MATRIXHUB_BASE_URL="$(MATRIXHUB_BASE_URL)" bash ./scripts/run-test.sh $(level)
+test.e2e: ## Run E2E tests locally (requires running MatrixHub). Set E2E_LABELS to filter (e.g. E2E_LABELS=smoke); empty runs all.
+	MATRIXHUB_BASE_URL="$(MATRIXHUB_BASE_URL)" bash ./scripts/run-test.sh "$(E2E_LABELS)"
 
 .PHONY: test.e2e.kind
 test.e2e.kind: ## Run E2E tests in KIND cluster (setup, deploy, test)
@@ -183,12 +182,13 @@ test.e2e.kind: ## Run E2E tests in KIND cluster (setup, deploy, test)
 	@echo "  E2E_CLUSTER_NAME    = $${E2E_CLUSTER_NAME:-matrixhub-e2e}"
 	@echo "  E2E_KIND_IMAGE_TAG  = $${E2E_KIND_IMAGE_TAG:-v1.32.3}"
 	@echo "  E2E_MATRIXHUB_IMAGE = $${E2E_MATRIXHUB_IMAGE:-ghcr.io/matrixhub-ai/matrixhub:latest}"
+	@echo "  E2E_LABELS          = $${E2E_LABELS:-<all>}"
 	@echo ""
 	@echo "Step 1: Setting up KIND cluster and deploying MatrixHub..."
 	$(MAKE) kind.setup
 	@echo ""
 	@echo "Step 2: Running E2E tests..."
-	MATRIXHUB_BASE_URL="http://localhost:30001" $(MAKE) test.e2e
+	MATRIXHUB_BASE_URL="http://localhost:30001" $(MAKE) test.e2e E2E_LABELS="$(E2E_LABELS)"
 	@echo ""
 	@echo "To cleanup, run:"
 	@echo "  kind delete cluster --name=$${E2E_CLUSTER_NAME:-matrixhub-e2e}"

--- a/scripts/run-test.sh
+++ b/scripts/run-test.sh
@@ -24,8 +24,9 @@ PROJECT_ROOT="${SCRIPT_DIR}/.."
 # Change to project root directory
 cd "${PROJECT_ROOT}"
 
-# Test level: smoke, all
-TEST_LEVEL=${1:-"smoke"}
+# Ginkgo label filter expression (e.g. "smoke", or comma-separated labels).
+# Empty or "all" runs every test (no filter). Passed to `ginkgo --label-filter`.
+LABEL_FILTER=${1:-}
 
 # Base URL from environment or default local API server.
 MATRIXHUB_BASE_URL="${MATRIXHUB_BASE_URL:-http://localhost:3001}"
@@ -33,7 +34,7 @@ MATRIXHUB_BASE_URL="${MATRIXHUB_BASE_URL:-http://localhost:3001}"
 echo "================================================"
 echo "MatrixHub E2E Test Runner"
 echo "================================================"
-echo "Test Level: ${TEST_LEVEL}"
+echo "Label filter: ${LABEL_FILTER:-<all>}"
 echo "Base URL:   ${MATRIXHUB_BASE_URL}"
 echo "================================================"
 
@@ -73,21 +74,15 @@ echo ""
 
 export MATRIXHUB_BASE_URL="${MATRIXHUB_BASE_URL}"
 
-case ${TEST_LEVEL} in
-    "smoke")
-        echo "Running smoke tests..."
-        ginkgo -v --timeout=10m ./test/e2e_apiserver/...
-        ;;
-    "all")
-        echo "Running all E2E tests..."
-        ginkgo -v --timeout=20m ./test/e2e_apiserver/...
-        ;;
-    *)
-        echo "Unknown test level: ${TEST_LEVEL}"
-        echo "Supported levels: smoke, all"
-        exit 1
-        ;;
-esac
+# Empty or "all" => run every test (no label filter).
+# Otherwise pass the expression straight to ginkgo's --label-filter.
+if [ -z "${LABEL_FILTER}" ] || [ "${LABEL_FILTER}" = "all" ]; then
+    echo "Running all E2E tests..."
+    ginkgo -v --timeout=20m ./test/e2e_apiserver/...
+else
+    echo "Running E2E tests with label filter: ${LABEL_FILTER}"
+    ginkgo -v --timeout=20m --label-filter "${LABEL_FILTER}" ./test/e2e_apiserver/...
+fi
 
 echo ""
 echo "================================================"

--- a/test/e2e_apiserver/current_user/current_user_test.go
+++ b/test/e2e_apiserver/current_user/current_user_test.go
@@ -75,7 +75,7 @@ var _ = Describe("CurrentUser", Label("current-user"), func() {
 	// 1. GetCurrentUser API
 	// ═══════════════════════════════════════════════════════════
 	Context("GetCurrentUser API", func() {
-		It("should return the correct identity for the logged-in user", Label("CU00001"), func() {
+		It("should return the correct identity for the logged-in user", Label("CU00001", "smoke"), func() {
 			resp, _, err := currentUserApi.CurrentUserGetCurrentUser(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.Username).To(Equal(username))

--- a/test/e2e_apiserver/login/login_test.go
+++ b/test/e2e_apiserver/login/login_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Login", Label("login"), func() {
 	// 1. Login API
 	// ═══════════════════════════════════════════════════════════
 	Context("Login API", func() {
-		It("should login successfully with valid admin credentials", Label("L00001"), func() {
+		It("should login successfully with valid admin credentials", Label("L00001", "smoke"), func() {
 			_, httpResp, err := newLoginApi().LoginLogin(ctx, v1alpha1login.V1alpha1LoginRequest{
 				Username: tools.DefaultAdminUsername,
 				Password: tools.DefaultAdminPassword,

--- a/test/e2e_apiserver/model/model_test.go
+++ b/test/e2e_apiserver/model/model_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Model", Label("model"), func() {
 		})
 
 		// --- CreateModel ---
-		It("should create a model successfully", Label("M00003"), func() {
+		It("should create a model successfully", Label("M00003", "smoke"), func() {
 			modelName := tools.GenerateTestModelName("model")
 
 			_, _, err := modelsApi.ModelsCreateModel(ctx, v1alpha1model.V1alpha1CreateModelRequest{

--- a/test/e2e_apiserver/project/project_test.go
+++ b/test/e2e_apiserver/project/project_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Project", Label("project"), func() {
 	})
 
 	Context("CreateProject API", func() {
-		It("should create a project successfully", Label("L00001"), func() {
+		It("should create a project successfully", Label("L00001", "smoke"), func() {
 			projectName := tools.GenerateTestProjectName("project")
 			projectType := v1alpha1project.PRIVATE_V1alpha1ProjectType
 			GinkgoWriter.Printf("Creating project: %v\n", projectName)

--- a/test/e2e_apiserver/robot/robot_test.go
+++ b/test/e2e_apiserver/robot/robot_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Robot", Label("robot"), func() {
 	// 1. CreateRobotAccount API
 	// ═══════════════════════════════════════════════════════════
 	Context("CreateRobotAccount API", func() {
-		It("should create a robot account and return a non-empty token", Label("R00001"), func() {
+		It("should create a robot account and return a non-empty token", Label("R00001", "smoke"), func() {
 			name := generateRobotName("rb-create")
 			resp, _, err := robotsApi.RobotsCreateRobotAccount(ctx, v1alpha1robot.V1alpha1CreateRobotAccountRequest{
 				Name:        name,

--- a/test/e2e_apiserver/sync_policy/sync_policy_crud_test.go
+++ b/test/e2e_apiserver/sync_policy/sync_policy_crud_test.go
@@ -36,7 +36,7 @@ var _ = Describe("SyncPolicy CRUD APIs", Label("sync-policy"), func() {
 	})
 
 	Context("Create and Get", func() {
-		It("should create a pull-base policy and retrieve it", Label("SP0001"), func() {
+		It("should create a pull-base policy and retrieve it", Label("SP0001", "smoke"), func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 			defer cancel()
 

--- a/test/e2e_apiserver/user/user_test.go
+++ b/test/e2e_apiserver/user/user_test.go
@@ -40,7 +40,7 @@ var _ = Describe("User", Label("user"), func() {
 	// 1. CreateUser API
 	// ═══════════════════════════════════════════════════════════
 	Context("CreateUser API", func() {
-		It("should create a regular user successfully", Label("U00001"), func() {
+		It("should create a regular user successfully", Label("U00001", "smoke"), func() {
 			username := tools.GenerateTestUsername("u-create")
 			_, _, err := usersApi.UsersCreateUser(ctx, v1alpha1user.V1alpha1CreateUserRequest{
 				Username: username,


### PR DESCRIPTION
## Problem

The e2e label (`smoke` / `all`) never reached ginkgo. Whatever level the PR filter or a manual dispatch selected, every run executed the **full** suite — "smoke vs all" was a no-op. Breaks along the chain:

- `e2e-init.yaml` called `make test.e2e.kind` **without** passing `e2e_labels` onward.
- `Makefile` `test.e2e{,.kind}` dropped the value (`level` always defaulted to `smoke`).
- `run-test.sh` ran **identical** ginkgo commands for `smoke` and `all` (only `--timeout` differed), with no `--label-filter` — and no test carried a `smoke` label anyway.

## Fix

Thread the label end to end and adopt ginkgo's label-filter model:

`e2e-init.yaml` → `Makefile` (`E2E_LABELS`) → `run-test.sh` → `ginkgo --label-filter`.

- **Empty or `all` → run every test** (the default requested in #298).
- **Non-empty → `ginkgo --label-filter "<expr>"`.**
- Tag one core happy-path case per module with `Label("smoke")` (login, current-user, user, project, model, robot, sync_policy) so the smoke sweep selects real specs.

## Verification

- `ginkgo --dry-run --label-filter smoke ./test/e2e_apiserver/...` → **7 suites, exactly 1 spec each** (Project 1/39, Robot 1/15, SyncPolicy 1/11, User 1/16, + login/current_user/model).
- Empty and `all` run the full suite.
- `run-test.sh` branching and `Makefile` `E2E_LABELS` threading verified locally with a stub ginkgo and `make -n`.

Refs #298. First of two PRs; the mitmproxy API-coverage harness follows separately.