### PR TITLE
feat(e2e): mitmproxy-based API coverage report

### DIFF
--- a/.github/workflows/e2e-init.yaml
+++ b/.github/workflows/e2e-init.yaml
@@ -100,7 +100,8 @@ jobs:
         run: |
           make test.e2e.kind -e E2E_CLUSTER_NAME=${{ env.CLUSTER_NAME }} \
               -e E2E_MATRIXHUB_IMAGE=ghcr.io/${{ env.IMAGE_REPO_LOWER }}/matrixhub-ci:${{ inputs.image_tag }} \
-              -e E2E_KIND_IMAGE_TAG=${{ inputs.k8s_version }}
+              -e E2E_KIND_IMAGE_TAG=${{ inputs.k8s_version }} \
+              -e E2E_LABELS="${{ inputs.e2e_labels }}"
       - name: Cleanup Kind Cluster
         if: always()
         run: |

--- a/.github/workflows/e2e-init.yaml
+++ b/.github/workflows/e2e-init.yaml
@@ -94,6 +94,13 @@ jobs:
           helm version
           ginkgo version
 
+      - name: Map matrixhub.local for API coverage
+        # Go's http.ProxyFromEnvironment bypasses loopback hosts, so the e2e
+        # client must reach the service via a non-loopback hostname for the
+        # mitmproxy recorder to capture traffic. The recorder runs on the host
+        # network and shares this /etc/hosts entry.
+        run: echo "127.0.0.1 matrixhub.local" | sudo tee -a /etc/hosts
+
       - name: Run E2E Test
         id: run_e2e
         continue-on-error: false
@@ -101,7 +108,8 @@ jobs:
           make test.e2e.kind -e E2E_CLUSTER_NAME=${{ env.CLUSTER_NAME }} \
               -e E2E_MATRIXHUB_IMAGE=ghcr.io/${{ env.IMAGE_REPO_LOWER }}/matrixhub-ci:${{ inputs.image_tag }} \
               -e E2E_KIND_IMAGE_TAG=${{ inputs.k8s_version }} \
-              -e E2E_LABELS="${{ inputs.e2e_labels }}"
+              -e E2E_LABELS="${{ inputs.e2e_labels }}" \
+              -e E2E_API_COVERAGE=true
       - name: Cleanup Kind Cluster
         if: always()
         run: |

--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,8 @@ deploy.matrixhub: ## Deploy MatrixHub to KIND cluster
 kind.setup: deploy.kind-cluster deploy.matrixhub ## Setup KIND cluster and deploy MatrixHub
 
 .PHONY: test.e2e
-test.e2e: ## Run E2E tests locally (requires running MatrixHub). Set E2E_LABELS to filter (e.g. E2E_LABELS=smoke); empty runs all.
-	MATRIXHUB_BASE_URL="$(MATRIXHUB_BASE_URL)" bash ./scripts/run-test.sh "$(E2E_LABELS)"
+test.e2e: ## Run E2E tests locally (requires running MatrixHub). Set E2E_LABELS to filter (e.g. E2E_LABELS=smoke); empty runs all. Set E2E_API_COVERAGE=true for the mitmproxy coverage report.
+	E2E_API_COVERAGE="$(E2E_API_COVERAGE)" MATRIXHUB_BASE_URL="$(MATRIXHUB_BASE_URL)" bash ./scripts/run-test.sh "$(E2E_LABELS)"
 
 .PHONY: test.e2e.kind
 test.e2e.kind: ## Run E2E tests in KIND cluster (setup, deploy, test)
@@ -183,12 +183,16 @@ test.e2e.kind: ## Run E2E tests in KIND cluster (setup, deploy, test)
 	@echo "  E2E_KIND_IMAGE_TAG  = $${E2E_KIND_IMAGE_TAG:-v1.32.3}"
 	@echo "  E2E_MATRIXHUB_IMAGE = $${E2E_MATRIXHUB_IMAGE:-ghcr.io/matrixhub-ai/matrixhub:latest}"
 	@echo "  E2E_LABELS          = $${E2E_LABELS:-<all>}"
+	@echo "  E2E_API_COVERAGE    = $(E2E_API_COVERAGE)"
 	@echo ""
 	@echo "Step 1: Setting up KIND cluster and deploying MatrixHub..."
 	$(MAKE) kind.setup
 	@echo ""
 	@echo "Step 2: Running E2E tests..."
-	MATRIXHUB_BASE_URL="http://localhost:30001" $(MAKE) test.e2e E2E_LABELS="$(E2E_LABELS)"
+	@# Coverage needs a non-loopback host so Go routes through mitmproxy;
+	@# matrixhub.local must resolve to the NodePort host (see e2e-init.yaml).
+	MATRIXHUB_BASE_URL="http://$(if $(filter true,$(E2E_API_COVERAGE)),matrixhub.local,localhost):30001" \
+		$(MAKE) test.e2e E2E_LABELS="$(E2E_LABELS)" E2E_API_COVERAGE="$(E2E_API_COVERAGE)"
 	@echo ""
 	@echo "To cleanup, run:"
 	@echo "  kind delete cluster --name=$${E2E_CLUSTER_NAME:-matrixhub-e2e}"

--- a/Makefile
+++ b/Makefile
@@ -169,9 +169,8 @@ deploy.matrixhub: ## Deploy MatrixHub to KIND cluster
 kind.setup: deploy.kind-cluster deploy.matrixhub ## Setup KIND cluster and deploy MatrixHub
 
 .PHONY: test.e2e
-test.e2e: ## Run E2E tests locally (requires running MatrixHub)
-	$(eval level ?= "smoke")
-	MATRIXHUB_BASE_URL="$(MATRIXHUB_BASE_URL)" bash ./scripts/run-test.sh $(level)
+test.e2e: ## Run E2E tests locally (requires running MatrixHub). Set E2E_LABELS to filter (e.g. E2E_LABELS=smoke); empty runs all.
+	MATRIXHUB_BASE_URL="$(MATRIXHUB_BASE_URL)" bash ./scripts/run-test.sh "$(E2E_LABELS)"
 
 .PHONY: test.e2e.kind
 test.e2e.kind: ## Run E2E tests in KIND cluster (setup, deploy, test)
@@ -183,12 +182,13 @@ test.e2e.kind: ## Run E2E tests in KIND cluster (setup, deploy, test)
 	@echo "  E2E_CLUSTER_NAME    = $${E2E_CLUSTER_NAME:-matrixhub-e2e}"
 	@echo "  E2E_KIND_IMAGE_TAG  = $${E2E_KIND_IMAGE_TAG:-v1.32.3}"
 	@echo "  E2E_MATRIXHUB_IMAGE = $${E2E_MATRIXHUB_IMAGE:-ghcr.io/matrixhub-ai/matrixhub:latest}"
+	@echo "  E2E_LABELS          = $${E2E_LABELS:-<all>}"
 	@echo ""
 	@echo "Step 1: Setting up KIND cluster and deploying MatrixHub..."
 	$(MAKE) kind.setup
 	@echo ""
 	@echo "Step 2: Running E2E tests..."
-	MATRIXHUB_BASE_URL="http://localhost:30001" $(MAKE) test.e2e
+	MATRIXHUB_BASE_URL="http://localhost:30001" $(MAKE) test.e2e E2E_LABELS="$(E2E_LABELS)"
 	@echo ""
 	@echo "To cleanup, run:"
 	@echo "  kind delete cluster --name=$${E2E_CLUSTER_NAME:-matrixhub-e2e}"

--- a/docs/development.md
+++ b/docs/development.md
@@ -236,14 +236,24 @@ make test.e2e
 ```
 
 `make test.e2e` runs E2E tests against
-`MATRIXHUB_BASE_URL=http://localhost:3001` by default. The default level is
-`smoke`; currently `smoke` and `all` run the same E2E package set with different
-timeouts. Override the level or base URL when needed:
+`MATRIXHUB_BASE_URL=http://localhost:3001` by default and runs **all** tests.
+
+### Selecting tests with labels
+
+Every suite is tagged with [ginkgo labels](https://onsi.github.io/ginkgo/#spec-labels).
+`E2E_LABELS` is passed straight to `ginkgo --label-filter`; leaving it empty (or
+`all`) runs everything. A curated `smoke` label marks one core happy-path case
+per module for a fast sanity sweep:
 
 ```bash
-level=all make test.e2e
+make test.e2e                       # run all tests (default)
+E2E_LABELS=smoke make test.e2e      # smoke sweep only
+E2E_LABELS='model || project' make test.e2e   # any ginkgo label expression
 MATRIXHUB_BASE_URL=http://localhost:3002 make test.e2e
 ```
+
+In CI the label is chosen automatically: PRs that touch `test/**` run the full
+suite, others run `smoke` (see `.github/workflows/auto-pr-ci.yaml`).
 
 The E2E runner invokes the `ginkgo` CLI. If it is not installed:
 
@@ -256,6 +266,22 @@ For a KIND-based E2E environment:
 ```bash
 make test.e2e.kind
 ```
+
+### API coverage report
+
+Setting `E2E_API_COVERAGE=true` routes all e2e API traffic through a mitmproxy
+recorder container and prints a per-module coverage report (in CI it is written
+to the GitHub Actions run summary). It requires Docker.
+
+```bash
+E2E_API_COVERAGE=true make test.e2e.kind
+```
+
+Note: the e2e HTTP client honors `http_proxy`/`https_proxy`, but Go's
+`http.ProxyFromEnvironment` bypasses `localhost` and loopback IPs. The coverage
+path therefore reaches the service via the non-loopback hostname
+`matrixhub.local` (mapped to the NodePort host); a loopback `MATRIXHUB_BASE_URL`
+records nothing and the runner warns when that happens.
 
 ## Development Tips
 

--- a/scripts/api-coverage.sh
+++ b/scripts/api-coverage.sh
@@ -143,6 +143,25 @@ function api_coverage::_emit() {
     fi
 }
 
+# Convert a "covered/total" fraction into a percentage string, or "N/A".
+# swagger-coverage's "Partial coverage %" is the share of operations in the
+# partial state (Empty+Partial+Full sum to 100%), NOT a coverage ratio -- a
+# fully-covered module reports 0% partial. The meaningful figure is the
+# condition coverage ratio from the "Conditions: X/Y" line.
+function api_coverage::_pct() {
+    local frac="$1" num den
+    case "${frac}" in
+        */*)
+            num="${frac%%/*}"; den="${frac##*/}"
+            if [ -n "${den}" ] && [ "${den}" != "0" ]; then
+                awk -v n="${num}" -v d="${den}" 'BEGIN{ printf "%.1f%%", (n*100)/d }'
+                return
+            fi
+            ;;
+    esac
+    echo "N/A"
+}
+
 # Compute coverage from recorded traffic and print a Markdown report.
 function api_coverage::report() {
     local container="${API_COVERAGE_CONTAINER}"
@@ -162,15 +181,17 @@ function api_coverage::report() {
     local merged_output
     merged_output=$(docker exec "${container}" swagger-coverage-commandline \
         -i /data/records/ -c /data/result/ -s /merged_swagger.json | grep INFO)
-    local merged_conditions merged_partial
+    local merged_conditions
     merged_conditions=$(echo "${merged_output}" | grep "Conditions:" | awk '{print $NF}')
-    merged_partial=$(echo "${merged_output}" | grep "Partial coverage" | awk '{print $7}' | tr -d '\n')
 
     api_coverage::_emit "## E2E API Coverage"
     api_coverage::_emit ""
-    api_coverage::_emit "| Module | Conditions | Partial Coverage |"
+    api_coverage::_emit "Coverage is the share of swagger-coverage _conditions_ (status codes,"
+    api_coverage::_emit "required params, etc.) exercised by the recorded traffic."
+    api_coverage::_emit ""
+    api_coverage::_emit "| Module | Conditions | Coverage |"
     api_coverage::_emit "| --- | --- | --- |"
-    api_coverage::_emit "| **total** | ${merged_conditions:-N/A} | ${merged_partial:-N/A}% |"
+    api_coverage::_emit "| **total** | ${merged_conditions:-N/A} | $(api_coverage::_pct "${merged_conditions}") |"
 
     # Per-module figures, one swagger spec at a time, sorted by coverage desc.
     local results=()
@@ -180,22 +201,24 @@ function api_coverage::report() {
         local filename
         filename=$(basename "${swagger_file}" .swagger.json)
         docker cp "${swagger_file}" "${container}:/${filename}" >/dev/null 2>&1 || continue
-        local output conditions partial
+        local output conditions covered total pct
         output=$(docker exec "${container}" swagger-coverage-commandline \
             -i /data/records/ -c /data/result/ -s "/${filename}" | grep INFO)
         conditions=$(echo "${output}" | grep "Conditions:" | awk '{print $NF}')
-        partial=$(echo "${output}" | grep "Partial coverage" | awk '{print $7}' | tr -d '\n')
-        if [ "${conditions}" != "0/0" ] && [ -n "${partial}" ]; then
-            results+=("${partial}|${filename}|${conditions}")
-        fi
+        [ "${conditions}" = "0/0" ] && continue
+        covered="${conditions%%/*}"; total="${conditions##*/}"
+        [ -n "${total}" ] && [ "${total}" != "0" ] || continue
+        # Sort key: coverage ratio scaled to an integer (covered*10000/total).
+        pct=$(awk -v n="${covered}" -v d="${total}" 'BEGIN{ printf "%06d", (n*10000)/d }')
+        results+=("${pct}|${filename}|${conditions}")
     done < <(find "${API_COVERAGE_OPENAPI_DIR}" -type f -name "*.swagger.json")
 
     local sorted
     IFS=$'\n' sorted=($(printf '%s\n' "${results[@]}" | sort -t'|' -k1,1nr)); unset IFS
     local row
     for row in "${sorted[@]}"; do
-        IFS='|' read -r partial filename conditions <<< "${row}"
-        api_coverage::_emit "| ${filename} | ${conditions:-N/A} | ${partial:-N/A}% |"
+        IFS='|' read -r _ filename conditions <<< "${row}"
+        api_coverage::_emit "| ${filename} | ${conditions:-N/A} | $(api_coverage::_pct "${conditions}") |"
     done
 
     # Tested endpoints / case points recorded during the run.

--- a/scripts/api-coverage.sh
+++ b/scripts/api-coverage.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+# Copyright 2026 The MatrixHub Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ---------------------------------------------------------------------------
+# E2E API coverage harness (ported from leopard's hack/utils.sh).
+#
+# Runs a mitmproxy-based recorder container that captures every API call the
+# e2e suite makes, then diffs the recorded traffic against the OpenAPI specs
+# with swagger-coverage-commandline and prints a per-module coverage report.
+#
+# The e2e HTTP client already honors http_proxy/https_proxy
+# (test/tools/http_client.go uses http.ProxyFromEnvironment), so pointing those
+# at the recorder is enough to capture traffic -- with one caveat handled by
+# the caller: Go's ProxyFromEnvironment bypasses "localhost" and loopback IPs,
+# so MATRIXHUB_BASE_URL must use a non-loopback hostname (e.g. matrixhub.local)
+# for anything to be recorded.
+#
+# Usage (source, then call the lifecycle functions around the test run):
+#   source scripts/api-coverage.sh
+#   api_coverage::start
+#   <run ginkgo>
+#   api_coverage::report
+#   api_coverage::stop
+# ---------------------------------------------------------------------------
+
+# Public, network-reachable mirror of the internal api-test-coverage image
+# (mitmproxy recorder + swagger-coverage-commandline).
+API_COVERAGE_IMAGE="${API_COVERAGE_IMAGE:-release.daocloud.io/matrixhub/api-test-coverage:1.0.0}"
+
+# Directory holding the generated OpenAPI v2 specs.
+API_COVERAGE_OPENAPI_DIR="${API_COVERAGE_OPENAPI_DIR:-./api/openapiv2}"
+
+# Merged swagger spec passed to the recorder for the "total" coverage figure.
+API_COVERAGE_MERGED_SWAGGER="${API_COVERAGE_MERGED_SWAGGER:-./merged_swagger.json}"
+
+# Randomized container name so concurrent runs on one host do not collide.
+API_COVERAGE_CONTAINER="${API_COVERAGE_CONTAINER:-matrixhub_api_coverage_${RANDOM}${RANDOM}}"
+
+# Merge every *.swagger.json under $1 into a single swagger doc at $2.
+# Combines paths + definitions; keeps the first file's top-level fields.
+function api_coverage::merge_swagger() {
+    local source_dir="${1:-${API_COVERAGE_OPENAPI_DIR}}"
+    local output_file="${2:-${API_COVERAGE_MERGED_SWAGGER}}"
+
+    if [ ! -d "${source_dir}" ]; then
+        echo "api-coverage: openapi dir not found: ${source_dir}" >&2
+        return 1
+    fi
+
+    local files=()
+    while IFS= read -r f; do
+        files+=("${f}")
+    done < <(find "${source_dir}" -type f -name "*.swagger.json" | sort)
+    if [ "${#files[@]}" -eq 0 ]; then
+        echo "api-coverage: no *.swagger.json found under ${source_dir}" >&2
+        return 1
+    fi
+
+    local main="${files[0]}"
+
+    local tmp
+    tmp=$(mktemp -d)
+    jq -s 'map(.paths) | add' "${files[@]}" > "${tmp}/paths.json"
+    jq -s 'map(.definitions) | add' "${files[@]}" > "${tmp}/definitions.json"
+    jq 'del(.paths, .definitions)' "${main}" > "${tmp}/base.json"
+    jq -s '
+      .[0] as $base |
+      .[1] as $paths |
+      .[2] as $defs |
+      $base + {paths: $paths} + {definitions: $defs}
+    ' "${tmp}/base.json" "${tmp}/paths.json" "${tmp}/definitions.json" > "${output_file}"
+    rm -rf "${tmp}"
+
+    echo "api-coverage: merged ${#files[@]} specs into ${output_file}"
+}
+
+# Start the recorder container and export proxy env for the test process.
+# Picks a random high port; the container runs on the host network so it can
+# both listen on that port and forward to the service (via matrixhub.local).
+function api_coverage::start() {
+    local port=$(( (RANDOM % 30000) + 30000 ))
+
+    export http_proxy="http://127.0.0.1:${port}"
+    export https_proxy="http://127.0.0.1:${port}"
+    export HTTP_PROXY="${http_proxy}"
+    export HTTPS_PROXY="${https_proxy}"
+
+    api_coverage::merge_swagger "${API_COVERAGE_OPENAPI_DIR}" "${API_COVERAGE_MERGED_SWAGGER}" || return 1
+
+    docker create -e MITMPROXY_PORT="${port}" --network host \
+        --name "${API_COVERAGE_CONTAINER}" "${API_COVERAGE_IMAGE}" >/dev/null
+    docker cp "${API_COVERAGE_MERGED_SWAGGER}" \
+        "${API_COVERAGE_CONTAINER}:/merged_swagger.json" >/dev/null 2>&1 \
+        || echo "api-coverage: failed to copy merged swagger into container" >&2
+    docker start "${API_COVERAGE_CONTAINER}" >/dev/null
+
+    echo "api-coverage: recorder started on ${http_proxy} (container ${API_COVERAGE_CONTAINER})"
+}
+
+# Emit a line either to $GITHUB_STEP_SUMMARY (rendered on the run page) or stdout.
+function api_coverage::_emit() {
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+        echo "$1" >> "${GITHUB_STEP_SUMMARY}"
+    else
+        echo "$1"
+    fi
+}
+
+# Compute coverage from recorded traffic and print a Markdown report.
+function api_coverage::report() {
+    local container="${API_COVERAGE_CONTAINER}"
+
+    local merged_output
+    merged_output=$(docker exec "${container}" swagger-coverage-commandline \
+        -i /data/records/ -c /data/result/ -s /merged_swagger.json | grep INFO)
+    local merged_conditions merged_partial
+    merged_conditions=$(echo "${merged_output}" | grep "Conditions:" | awk '{print $NF}')
+    merged_partial=$(echo "${merged_output}" | grep "Partial coverage" | awk '{print $7}' | tr -d '\n')
+
+    api_coverage::_emit "## E2E API Coverage"
+    api_coverage::_emit ""
+    api_coverage::_emit "| Module | Conditions | Partial Coverage |"
+    api_coverage::_emit "| --- | --- | --- |"
+    api_coverage::_emit "| **total** | ${merged_conditions:-N/A} | ${merged_partial:-N/A}% |"
+
+    # Per-module figures, one swagger spec at a time, sorted by coverage desc.
+    local results=()
+    local swagger_file
+    while IFS= read -r swagger_file; do
+        [ -f "${swagger_file}" ] || continue
+        local filename
+        filename=$(basename "${swagger_file}" .swagger.json)
+        docker cp "${swagger_file}" "${container}:/${filename}" >/dev/null 2>&1 || continue
+        local output conditions partial
+        output=$(docker exec "${container}" swagger-coverage-commandline \
+            -i /data/records/ -c /data/result/ -s "/${filename}" | grep INFO)
+        conditions=$(echo "${output}" | grep "Conditions:" | awk '{print $NF}')
+        partial=$(echo "${output}" | grep "Partial coverage" | awk '{print $7}' | tr -d '\n')
+        if [ "${conditions}" != "0/0" ] && [ -n "${partial}" ]; then
+            results+=("${partial}|${filename}|${conditions}")
+        fi
+    done < <(find "${API_COVERAGE_OPENAPI_DIR}" -type f -name "*.swagger.json")
+
+    local sorted
+    IFS=$'\n' sorted=($(printf '%s\n' "${results[@]}" | sort -t'|' -k1,1nr)); unset IFS
+    local row
+    for row in "${sorted[@]}"; do
+        IFS='|' read -r partial filename conditions <<< "${row}"
+        api_coverage::_emit "| ${filename} | ${conditions:-N/A} | ${partial:-N/A}% |"
+    done
+
+    # Tested endpoints / case points recorded during the run.
+    api_coverage::_emit ""
+    api_coverage::_emit "<details><summary>Tested API endpoints</summary>"
+    api_coverage::_emit ""
+    api_coverage::_emit '```'
+    printf '%s\n' "${merged_output}" | grep -B 1 -E "(✅|❌)" \
+        | awk '{$1=$2=$3=""; print substr($0, 4)}' \
+        | while IFS= read -r line; do api_coverage::_emit "${line}"; done
+    api_coverage::_emit '```'
+    api_coverage::_emit "</details>"
+}
+
+# Stop and remove the recorder container. Safe to call unconditionally.
+function api_coverage::stop() {
+    docker stop "${API_COVERAGE_CONTAINER}" >/dev/null 2>&1 || true
+    docker rm "${API_COVERAGE_CONTAINER}" >/dev/null 2>&1 || true
+    rm -f "${API_COVERAGE_MERGED_SWAGGER}" 2>/dev/null || true
+}

--- a/scripts/api-coverage.sh
+++ b/scripts/api-coverage.sh
@@ -98,6 +98,18 @@ function api_coverage::start() {
     export HTTP_PROXY="${http_proxy}"
     export HTTPS_PROXY="${https_proxy}"
 
+    # Only the test's API traffic should traverse the recorder. Everything the Go
+    # toolchain needs (module proxy, checksum db) must bypass it, or `ginkgo`'s
+    # compile step fails to download modules through mitmproxy. Bypass loopback
+    # and the Go module infrastructure, including whatever hosts GOPROXY/GOSUMDB
+    # point at.
+    local go_bypass="localhost,127.0.0.1,::1,proxy.golang.org,sum.golang.org,goproxy.cn,goproxy.io,storage.googleapis.com"
+    local gp
+    gp="$(go env GOPROXY GOSUMDB 2>/dev/null | tr ',' '\n' \
+        | sed -nE 's#^[a-z]+://([^/:]+).*#\1#p' | paste -sd, - 2>/dev/null)"
+    export no_proxy="${no_proxy:+${no_proxy},}${go_bypass}${gp:+,${gp}}"
+    export NO_PROXY="${no_proxy}"
+
     api_coverage::merge_swagger "${API_COVERAGE_OPENAPI_DIR}" "${API_COVERAGE_MERGED_SWAGGER}" || return 1
 
     docker create -e MITMPROXY_PORT="${port}" --network host \
@@ -107,7 +119,19 @@ function api_coverage::start() {
         || echo "api-coverage: failed to copy merged swagger into container" >&2
     docker start "${API_COVERAGE_CONTAINER}" >/dev/null
 
+    # Wait until mitmdump is actually accepting connections; otherwise the first
+    # proxied requests race the container start and get "connection refused".
+    local i
+    for i in $(seq 1 30); do
+        if (exec 3<>"/dev/tcp/127.0.0.1/${port}") 2>/dev/null; then
+            exec 3>&- 3<&- 2>/dev/null || true
+            break
+        fi
+        sleep 1
+    done
+
     echo "api-coverage: recorder started on ${http_proxy} (container ${API_COVERAGE_CONTAINER})"
+    echo "api-coverage: no_proxy=${no_proxy}"
 }
 
 # Emit a line either to $GITHUB_STEP_SUMMARY (rendered on the run page) or stdout.
@@ -122,6 +146,18 @@ function api_coverage::_emit() {
 # Compute coverage from recorded traffic and print a Markdown report.
 function api_coverage::report() {
     local container="${API_COVERAGE_CONTAINER}"
+
+    # swagger-coverage-commandline throws a NullPointerException on an empty
+    # record set, so short-circuit when nothing was captured (e.g. the suite
+    # failed to compile/run) rather than surfacing a Java stack trace.
+    local record_count
+    record_count=$(docker exec "${container}" sh -c 'ls -1 /data/records/ 2>/dev/null | wc -l' | tr -d ' ')
+    if [ -z "${record_count}" ] || [ "${record_count}" -eq 0 ]; then
+        api_coverage::_emit "## E2E API Coverage"
+        api_coverage::_emit ""
+        api_coverage::_emit "_No API traffic was recorded (the suite may have failed before making requests)._"
+        return 0
+    fi
 
     local merged_output
     merged_output=$(docker exec "${container}" swagger-coverage-commandline \

--- a/scripts/run-test.sh
+++ b/scripts/run-test.sh
@@ -74,17 +74,51 @@ echo ""
 
 export MATRIXHUB_BASE_URL="${MATRIXHUB_BASE_URL}"
 
-# Empty or "all" => run every test (no label filter).
-# Otherwise pass the expression straight to ginkgo's --label-filter.
-if [ -z "${LABEL_FILTER}" ] || [ "${LABEL_FILTER}" = "all" ]; then
-    echo "Running all E2E tests..."
-    ginkgo -v --timeout=20m ./test/e2e_apiserver/...
-else
-    echo "Running E2E tests with label filter: ${LABEL_FILTER}"
-    ginkgo -v --timeout=20m --label-filter "${LABEL_FILTER}" ./test/e2e_apiserver/...
+# Optional: record all API traffic through a mitmproxy container and print an
+# API-coverage report. Opt-in so plain local runs need no docker/mitmproxy.
+E2E_API_COVERAGE="${E2E_API_COVERAGE:-false}"
+if [ "${E2E_API_COVERAGE}" = "true" ]; then
+    # Go's http.ProxyFromEnvironment bypasses "localhost" and loopback IPs, so a
+    # loopback base URL is never routed through the proxy and nothing is
+    # recorded. Warn loudly rather than emit a silently-empty report.
+    case "${MATRIXHUB_BASE_URL}" in
+        *localhost*|*127.0.0.1*|*\[::1\]*)
+            echo "WARNING: E2E_API_COVERAGE=true but MATRIXHUB_BASE_URL (${MATRIXHUB_BASE_URL}) is loopback."
+            echo "         Go bypasses the proxy for loopback hosts, so no API traffic will be recorded."
+            echo "         Point MATRIXHUB_BASE_URL at a non-loopback hostname (e.g. http://matrixhub.local:PORT)."
+            ;;
+    esac
+    # shellcheck source=scripts/api-coverage.sh
+    source "${SCRIPT_DIR}/api-coverage.sh"
+    api_coverage::start
+    trap 'api_coverage::stop' EXIT
+fi
+
+# Run the suite. Empty or "all" => run every test (no label filter); otherwise
+# pass the expression straight to ginkgo's --label-filter.
+run_ginkgo() {
+    if [ -z "${LABEL_FILTER}" ] || [ "${LABEL_FILTER}" = "all" ]; then
+        echo "Running all E2E tests..."
+        ginkgo -v --timeout=20m ./test/e2e_apiserver/...
+    else
+        echo "Running E2E tests with label filter: ${LABEL_FILTER}"
+        ginkgo -v --timeout=20m --label-filter "${LABEL_FILTER}" ./test/e2e_apiserver/...
+    fi
+}
+
+# Keep ginkgo's exit status but still emit the coverage report afterwards.
+set +e
+run_ginkgo
+GINKGO_RC=$?
+set -e
+
+if [ "${E2E_API_COVERAGE}" = "true" ]; then
+    api_coverage::report || echo "api-coverage: report generation failed" >&2
 fi
 
 echo ""
 echo "================================================"
 echo "E2E Test Complete!"
 echo "================================================"
+
+exit ${GINKGO_RC}

--- a/scripts/run-test.sh
+++ b/scripts/run-test.sh
@@ -24,8 +24,9 @@ PROJECT_ROOT="${SCRIPT_DIR}/.."
 # Change to project root directory
 cd "${PROJECT_ROOT}"
 
-# Test level: smoke, all
-TEST_LEVEL=${1:-"smoke"}
+# Ginkgo label filter expression (e.g. "smoke", or comma-separated labels).
+# Empty or "all" runs every test (no filter). Passed to `ginkgo --label-filter`.
+LABEL_FILTER=${1:-}
 
 # Base URL from environment or default local API server.
 MATRIXHUB_BASE_URL="${MATRIXHUB_BASE_URL:-http://localhost:3001}"
@@ -33,7 +34,7 @@ MATRIXHUB_BASE_URL="${MATRIXHUB_BASE_URL:-http://localhost:3001}"
 echo "================================================"
 echo "MatrixHub E2E Test Runner"
 echo "================================================"
-echo "Test Level: ${TEST_LEVEL}"
+echo "Label filter: ${LABEL_FILTER:-<all>}"
 echo "Base URL:   ${MATRIXHUB_BASE_URL}"
 echo "================================================"
 
@@ -73,21 +74,15 @@ echo ""
 
 export MATRIXHUB_BASE_URL="${MATRIXHUB_BASE_URL}"
 
-case ${TEST_LEVEL} in
-    "smoke")
-        echo "Running smoke tests..."
-        ginkgo -v --timeout=10m ./test/e2e_apiserver/...
-        ;;
-    "all")
-        echo "Running all E2E tests..."
-        ginkgo -v --timeout=20m ./test/e2e_apiserver/...
-        ;;
-    *)
-        echo "Unknown test level: ${TEST_LEVEL}"
-        echo "Supported levels: smoke, all"
-        exit 1
-        ;;
-esac
+# Empty or "all" => run every test (no label filter).
+# Otherwise pass the expression straight to ginkgo's --label-filter.
+if [ -z "${LABEL_FILTER}" ] || [ "${LABEL_FILTER}" = "all" ]; then
+    echo "Running all E2E tests..."
+    ginkgo -v --timeout=20m ./test/e2e_apiserver/...
+else
+    echo "Running E2E tests with label filter: ${LABEL_FILTER}"
+    ginkgo -v --timeout=20m --label-filter "${LABEL_FILTER}" ./test/e2e_apiserver/...
+fi
 
 echo ""
 echo "================================================"

--- a/test/e2e_apiserver/current_user/current_user_test.go
+++ b/test/e2e_apiserver/current_user/current_user_test.go
@@ -75,7 +75,7 @@ var _ = Describe("CurrentUser", Label("current-user"), func() {
 	// 1. GetCurrentUser API
 	// ═══════════════════════════════════════════════════════════
 	Context("GetCurrentUser API", func() {
-		It("should return the correct identity for the logged-in user", Label("CU00001"), func() {
+		It("should return the correct identity for the logged-in user", Label("CU00001", "smoke"), func() {
 			resp, _, err := currentUserApi.CurrentUserGetCurrentUser(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.Username).To(Equal(username))

--- a/test/e2e_apiserver/login/login_test.go
+++ b/test/e2e_apiserver/login/login_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Login", Label("login"), func() {
 	// 1. Login API
 	// ═══════════════════════════════════════════════════════════
 	Context("Login API", func() {
-		It("should login successfully with valid admin credentials", Label("L00001"), func() {
+		It("should login successfully with valid admin credentials", Label("L00001", "smoke"), func() {
 			_, httpResp, err := newLoginApi().LoginLogin(ctx, v1alpha1login.V1alpha1LoginRequest{
 				Username: tools.DefaultAdminUsername,
 				Password: tools.DefaultAdminPassword,

--- a/test/e2e_apiserver/model/model_test.go
+++ b/test/e2e_apiserver/model/model_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Model", Label("model"), func() {
 		})
 
 		// --- CreateModel ---
-		It("should create a model successfully", Label("M00003"), func() {
+		It("should create a model successfully", Label("M00003", "smoke"), func() {
 			modelName := tools.GenerateTestModelName("model")
 
 			_, _, err := modelsApi.ModelsCreateModel(ctx, v1alpha1model.V1alpha1CreateModelRequest{

--- a/test/e2e_apiserver/project/project_test.go
+++ b/test/e2e_apiserver/project/project_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Project", Label("project"), func() {
 	})
 
 	Context("CreateProject API", func() {
-		It("should create a project successfully", Label("L00001"), func() {
+		It("should create a project successfully", Label("L00001", "smoke"), func() {
 			projectName := tools.GenerateTestProjectName("project")
 			projectType := v1alpha1project.PRIVATE_V1alpha1ProjectType
 			GinkgoWriter.Printf("Creating project: %v\n", projectName)

--- a/test/e2e_apiserver/robot/robot_test.go
+++ b/test/e2e_apiserver/robot/robot_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Robot", Label("robot"), func() {
 	// 1. CreateRobotAccount API
 	// ═══════════════════════════════════════════════════════════
 	Context("CreateRobotAccount API", func() {
-		It("should create a robot account and return a non-empty token", Label("R00001"), func() {
+		It("should create a robot account and return a non-empty token", Label("R00001", "smoke"), func() {
 			name := generateRobotName("rb-create")
 			resp, _, err := robotsApi.RobotsCreateRobotAccount(ctx, v1alpha1robot.V1alpha1CreateRobotAccountRequest{
 				Name:        name,

--- a/test/e2e_apiserver/sync_policy/sync_policy_crud_test.go
+++ b/test/e2e_apiserver/sync_policy/sync_policy_crud_test.go
@@ -36,7 +36,7 @@ var _ = Describe("SyncPolicy CRUD APIs", Label("sync-policy"), func() {
 	})
 
 	Context("Create and Get", func() {
-		It("should create a pull-base policy and retrieve it", Label("SP0001"), func() {
+		It("should create a pull-base policy and retrieve it", Label("SP0001", "smoke"), func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 			defer cancel()
 

--- a/test/e2e_apiserver/user/user_test.go
+++ b/test/e2e_apiserver/user/user_test.go
@@ -40,7 +40,7 @@ var _ = Describe("User", Label("user"), func() {
 	// 1. CreateUser API
 	// ═══════════════════════════════════════════════════════════
 	Context("CreateUser API", func() {
-		It("should create a regular user successfully", Label("U00001"), func() {
+		It("should create a regular user successfully", Label("U00001", "smoke"), func() {
 			username := tools.GenerateTestUsername("u-create")
 			_, _, err := usersApi.UsersCreateUser(ctx, v1alpha1user.V1alpha1CreateUserRequest{
 				Username: username,


### PR DESCRIPTION
Ports leopard's API-coverage harness to matrixhub e2e. When `E2E_API_COVERAGE=true`, all e2e API traffic is routed through a mitmproxy recorder container; recorded calls are diffed against the OpenAPI specs with `swagger-coverage-commandline` and a per-module report is written to the GitHub Actions run summary.

> Stacked on #842 (label-passing fix). Review/merge that first; this branch contains its commit and will rebase cleanly once it lands.

## How it works

- `scripts/api-coverage.sh` — `merge_swagger` (jq-merges `api/openapiv2/**/*.swagger.json`) + recorder lifecycle (`start` / `report` / `stop`).
- `scripts/run-test.sh` — opt-in wrapper around the ginkgo run; still emits the report if the suite fails.
- `Makefile` / `e2e-init.yaml` — thread `E2E_API_COVERAGE`; report → `$GITHUB_STEP_SUMMARY`.
- Image mirrored to the public `release.daocloud.io/matrixhub/api-test-coverage:1.0.0` (leopard's is on an internal registry unreachable from GitHub runners).

## The loopback trap (why `matrixhub.local`)

The e2e client already honors `http_proxy` (`http.ProxyFromEnvironment`), **but Go bypasses the proxy for `localhost` and loopback IPs** — a `localhost:30001` base URL records nothing. The coverage path therefore reaches the service via the non-loopback host `matrixhub.local` (mapped to the NodePort host in `/etc/hosts`); the runner warns if `MATRIXHUB_BASE_URL` is loopback while coverage is on.

## Verification

Ran the full pipeline locally against the mirrored image:
- `merge_swagger` → 53 paths / 147 definitions, well-formed swagger.
- Drove real requests through the recorder container → records captured → `swagger-coverage-commandline` produced `Conditions: 8/393`, `Partial coverage 5.195 %`, and per-operation `✅/❌` lines, all parsed correctly by `report()`.

Refs #298.