### PR TITLE
docs(development): add E2E authoring guide + fix stale versions

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -255,10 +255,11 @@ MATRIXHUB_BASE_URL=http://localhost:3002 make test.e2e
 In CI the label is chosen automatically: PRs that touch `test/**` run the full
 suite, others run `smoke` (see `.github/workflows/auto-pr-ci.yaml`).
 
-The E2E runner invokes the `ginkgo` CLI. If it is not installed:
+The E2E runner invokes the `ginkgo` CLI. If it is not installed, install the
+version already pinned in `go.mod` (so the CLI and library never drift):
 
 ```bash
-go install github.com/onsi/ginkgo/v2/ginkgo@v2.32.0   # match onsi/ginkgo/v2 in go.mod
+go install github.com/onsi/ginkgo/v2/ginkgo@$(go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2)
 ```
 
 For a KIND-based E2E environment:

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,7 +8,7 @@ For backend package boundaries and dependency rules, see
 
 - Go 1.23+
 - Node.js 18+ for the app UI; Node.js 20+ for the documentation website
-- pnpm 8+
+- pnpm 10.x (the app UI pins `pnpm >=10 <11` via `ui/package.json` engines)
 - Docker
 
 ## Local Development
@@ -258,7 +258,7 @@ suite, others run `smoke` (see `.github/workflows/auto-pr-ci.yaml`).
 The E2E runner invokes the `ginkgo` CLI. If it is not installed:
 
 ```bash
-go install github.com/onsi/ginkgo/v2/ginkgo@v2.22.1
+go install github.com/onsi/ginkgo/v2/ginkgo@v2.32.0   # match onsi/ginkgo/v2 in go.mod
 ```
 
 For a KIND-based E2E environment:

--- a/docs/development.md
+++ b/docs/development.md
@@ -283,12 +283,93 @@ path therefore reaches the service via the non-loopback hostname
 `matrixhub.local` (mapped to the NodePort host); a loopback `MATRIXHUB_BASE_URL`
 records nothing and the runner warns when that happens.
 
-### Writing a new E2E test
+## Development Tips
 
-Everything above is about *running* E2E tests. To *add* one, follow the
-conventions the label selection and coverage report depend on. Mirror an
-existing module (e.g. [`test/e2e_apiserver/login`](../test/e2e_apiserver/login))
-rather than inventing a new layout.
+### Database
+
+1. **First Run**: Setting `database.migrate: true` will automatically create database tables
+2. **Debug Mode**: Setting `debug: true` shows detailed SQL logs
+3. **Data Persistence**: Docker Compose uses named volumes, data persists after container restart
+
+### Frontend
+
+1. **Hot Reload**: Code changes automatically refresh the browser
+2. **API Proxy**: No need to handle CORS in development mode
+3. **TypeScript**: Use `pnpm typecheck` for type checking
+
+### Backend
+
+1. **Code Changes**: Requires manual service restart
+2. **Dependency Management**: Use `go mod tidy` to organize dependencies
+3. **Configuration Validation**: Config file is automatically validated on startup
+
+### Writing Unit Tests
+
+New backend unit tests, and existing unit tests when they need mocks, should follow a single mock/assertion stack:
+
+- **Mocks**: [`go.uber.org/mock`](https://github.com/uber-go/mock) (`gomock`), generated from domain interfaces with `mockgen` (pinned in `go.mod` via the [`tool` directive](https://go.dev/doc/modules/tool)).
+- **Assertions**: [`stretchr/testify/require`](https://github.com/stretchr/testify) (`require` stops the test on the first failed assertion; prefer it over `assert`).
+
+Thanks to the DDD layering, domain services depend only on **interfaces** (ports). To unit-test a service you mock its dependencies and inject them, with **no database or network** involved. Mirror the layout: put external behavior in `internal/repo` adapters so the domain stays mockable.
+
+**Reference example**: [`internal/domain/syncpolicy/sync_policy_service_test.go`](../internal/domain/syncpolicy/sync_policy_service_test.go) (domain service UT with gomock). For background job scheduling, rely on [`internal/jobserver/processor/processor_test.go`](../internal/jobserver/processor/processor_test.go) (poll-loop mechanics) and the e2e [`sync_policy_processor_test.go`](../test/e2e_apiserver/sync_policy/sync_policy_processor_test.go) (full scheduler path with real DB).
+
+#### Basic steps
+
+1. **Mark the interface for generation.** Add a `//go:generate` directive next to the interface (ports live in `internal/domain/...`). Mocks are emitted into a `mocks/` subpackage. Use `go tool mockgen` so the generator version always matches `go.uber.org/mock` in `go.mod`:
+
+```go
+//go:generate go tool mockgen -source=sync_policy.go -destination=mocks/sync_policy_repo_mock.go -package=mocks
+type ISyncPolicyRepo interface {
+    // ...
+}
+```
+
+2. **Generate the mocks** (no separate `mockgen` install needed — Go resolves it from `go.mod`):
+
+```bash
+make generate-mocks   # runs `go generate ./...`
+```
+
+3. **Write the test** in an external `_test` package (e.g. `package syncpolicy_test`) to avoid import cycles with the generated `mocks` package. Construct a controller, inject mocks, set expectations, assert with `require`:
+
+```go
+func TestSyncPolicyService_CreateSyncPolicy(t *testing.T) {
+    ctrl := gomock.NewController(t) // auto-verifies expectations via t.Cleanup
+    repo := mocks.NewMockISyncPolicyRepo(ctrl)
+
+    // Expect exactly one call; gomock fails the test on unexpected/missing calls.
+    repo.EXPECT().CreateSyncPolicy(gomock.Any(), gomock.Any()).Return(nil)
+
+    // Leave unused dependencies nil — only wire what the tested method touches.
+    svc := syncpolicy.NewSyncPolicyService(repo, nil, nil, nil, nil)
+
+    err := svc.CreateSyncPolicy(context.Background(), &syncpolicy.SyncPolicy{
+        TriggerType: syncpolicy.TriggerTypeManual,
+    })
+    require.NoError(t, err)
+}
+```
+
+4. **Run the relevant unit tests.** See [Unit Tests](#unit-tests) for local
+commands.
+
+#### gomock tips
+
+- **Argument matchers**: `gomock.Any()`, `gomock.Eq(v)`, or a literal value. Use literals/`Eq` to assert the exact arguments a method was called with.
+- **Return / capture**: `.Return(...)` for static results; `.DoAndReturn(func(...) {...})` to capture arguments or compute the result dynamically.
+- **Call counts**: expectations default to exactly once. Use `.Times(n)`, `.MinTimes(n)`, `.MaxTimes(n)`, or `.AnyTimes()` — handy for background loops that poll an unpredictable number of times.
+- **Negative assertions**: simply set **no** `EXPECT()` for a method; gomock fails the test if it is called.
+- **Regenerate after changing an interface**: rerun `make generate-mocks` and commit the updated files under `mocks/` (they are generated — never hand-edit).
+- **Dependabot bumps `go.uber.org/mock`**: the `tool` directive keeps `mockgen` in sync automatically. CI re-runs `go generate` and fails if `mocks/` drifts. If that happens, check out the Dependabot branch, run `make generate-mocks`, commit any `mocks/` diff, and push.
+
+### Writing E2E Tests
+
+The [End-to-End Tests](#end-to-end-tests) section covers *running* e2e tests. To
+*add* one, follow the conventions the label selection and coverage report depend
+on. Mirror an existing module
+(e.g. [`test/e2e_apiserver/login`](../test/e2e_apiserver/login)) rather than
+inventing a new layout.
 
 #### Basic steps
 
@@ -370,86 +451,6 @@ rather than inventing a new layout.
 7. **Adding new API surface? Regenerate the client first.** Run
    `make gen_openapi_sdk` (output: `test/client`) after the swagger/OpenAPI
    changes so the typed client methods exist before you write the test.
-
-## Development Tips
-
-### Database
-
-1. **First Run**: Setting `database.migrate: true` will automatically create database tables
-2. **Debug Mode**: Setting `debug: true` shows detailed SQL logs
-3. **Data Persistence**: Docker Compose uses named volumes, data persists after container restart
-
-### Frontend
-
-1. **Hot Reload**: Code changes automatically refresh the browser
-2. **API Proxy**: No need to handle CORS in development mode
-3. **TypeScript**: Use `pnpm typecheck` for type checking
-
-### Backend
-
-1. **Code Changes**: Requires manual service restart
-2. **Dependency Management**: Use `go mod tidy` to organize dependencies
-3. **Configuration Validation**: Config file is automatically validated on startup
-
-### Writing Unit Tests
-
-New backend unit tests, and existing unit tests when they need mocks, should follow a single mock/assertion stack:
-
-- **Mocks**: [`go.uber.org/mock`](https://github.com/uber-go/mock) (`gomock`), generated from domain interfaces with `mockgen` (pinned in `go.mod` via the [`tool` directive](https://go.dev/doc/modules/tool)).
-- **Assertions**: [`stretchr/testify/require`](https://github.com/stretchr/testify) (`require` stops the test on the first failed assertion; prefer it over `assert`).
-
-Thanks to the DDD layering, domain services depend only on **interfaces** (ports). To unit-test a service you mock its dependencies and inject them, with **no database or network** involved. Mirror the layout: put external behavior in `internal/repo` adapters so the domain stays mockable.
-
-**Reference example**: [`internal/domain/syncpolicy/sync_policy_service_test.go`](../internal/domain/syncpolicy/sync_policy_service_test.go) (domain service UT with gomock). For background job scheduling, rely on [`internal/jobserver/processor/processor_test.go`](../internal/jobserver/processor/processor_test.go) (poll-loop mechanics) and the e2e [`sync_policy_processor_test.go`](../test/e2e_apiserver/sync_policy/sync_policy_processor_test.go) (full scheduler path with real DB).
-
-#### Basic steps
-
-1. **Mark the interface for generation.** Add a `//go:generate` directive next to the interface (ports live in `internal/domain/...`). Mocks are emitted into a `mocks/` subpackage. Use `go tool mockgen` so the generator version always matches `go.uber.org/mock` in `go.mod`:
-
-```go
-//go:generate go tool mockgen -source=sync_policy.go -destination=mocks/sync_policy_repo_mock.go -package=mocks
-type ISyncPolicyRepo interface {
-    // ...
-}
-```
-
-2. **Generate the mocks** (no separate `mockgen` install needed — Go resolves it from `go.mod`):
-
-```bash
-make generate-mocks   # runs `go generate ./...`
-```
-
-3. **Write the test** in an external `_test` package (e.g. `package syncpolicy_test`) to avoid import cycles with the generated `mocks` package. Construct a controller, inject mocks, set expectations, assert with `require`:
-
-```go
-func TestSyncPolicyService_CreateSyncPolicy(t *testing.T) {
-    ctrl := gomock.NewController(t) // auto-verifies expectations via t.Cleanup
-    repo := mocks.NewMockISyncPolicyRepo(ctrl)
-
-    // Expect exactly one call; gomock fails the test on unexpected/missing calls.
-    repo.EXPECT().CreateSyncPolicy(gomock.Any(), gomock.Any()).Return(nil)
-
-    // Leave unused dependencies nil — only wire what the tested method touches.
-    svc := syncpolicy.NewSyncPolicyService(repo, nil, nil, nil, nil)
-
-    err := svc.CreateSyncPolicy(context.Background(), &syncpolicy.SyncPolicy{
-        TriggerType: syncpolicy.TriggerTypeManual,
-    })
-    require.NoError(t, err)
-}
-```
-
-4. **Run the relevant unit tests.** See [Unit Tests](#unit-tests) for local
-commands.
-
-#### gomock tips
-
-- **Argument matchers**: `gomock.Any()`, `gomock.Eq(v)`, or a literal value. Use literals/`Eq` to assert the exact arguments a method was called with.
-- **Return / capture**: `.Return(...)` for static results; `.DoAndReturn(func(...) {...})` to capture arguments or compute the result dynamically.
-- **Call counts**: expectations default to exactly once. Use `.Times(n)`, `.MinTimes(n)`, `.MaxTimes(n)`, or `.AnyTimes()` — handy for background loops that poll an unpredictable number of times.
-- **Negative assertions**: simply set **no** `EXPECT()` for a method; gomock fails the test if it is called.
-- **Regenerate after changing an interface**: rerun `make generate-mocks` and commit the updated files under `mocks/` (they are generated — never hand-edit).
-- **Dependabot bumps `go.uber.org/mock`**: the `tool` directive keeps `mockgen` in sync automatically. CI re-runs `go generate` and fails if `mocks/` drifts. If that happens, check out the Dependabot branch, run `make generate-mocks`, commit any `mocks/` diff, and push.
 
 ## Troubleshooting
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -283,6 +283,94 @@ path therefore reaches the service via the non-loopback hostname
 `matrixhub.local` (mapped to the NodePort host); a loopback `MATRIXHUB_BASE_URL`
 records nothing and the runner warns when that happens.
 
+### Writing a new E2E test
+
+Everything above is about *running* E2E tests. To *add* one, follow the
+conventions the label selection and coverage report depend on. Mirror an
+existing module (e.g. [`test/e2e_apiserver/login`](../test/e2e_apiserver/login))
+rather than inventing a new layout.
+
+#### Basic steps
+
+1. **One package per module.** Create `test/e2e_apiserver/<module>/`, package
+   `<module>_test`. Group all cases for an API area in that one package.
+
+2. **Add a suite file** `<module>_suite_test.go` with the standard ginkgo
+   bootstrap — identical across every module, only the names change:
+
+   ```go
+   package project_test
+
+   import (
+       "testing"
+
+       testenv "github.com/matrixhub-ai/matrixhub/test/e2e_apiserver/init"
+
+       . "github.com/onsi/ginkgo/v2"
+       . "github.com/onsi/gomega"
+   )
+
+   func TestProject(t *testing.T) {
+       RegisterFailHandler(Fail)
+       RunSpecs(t, "Project Suite")
+   }
+
+   var _ = BeforeSuite(func() { defer GinkgoRecover(); testenv.InitTestEnvironment() })
+   var _ = AfterSuite(func()  { testenv.CleanupTestEnvironment() })
+   ```
+
+3. **Call the API through the generated client, never raw `net/http`.** Import
+   the module's client under `test/client/v1alpha1/<module>`, take the base URL
+   from `tools.GetBaseURL()`
+   (`github.com/matrixhub-ai/matrixhub/test/tools`), and build the client like:
+
+   ```go
+   cfg := &v1alpha1login.Configuration{
+       BasePath:      tools.GetBaseURL(),
+       DefaultHeader: map[string]string{"Content-Type": "application/json"},
+       HTTPClient: &http.Client{Transport: &http.Transport{
+           TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402
+           Proxy:           http.ProxyFromEnvironment,             // required for coverage
+       }},
+   }
+   api := v1alpha1login.NewAPIClient(cfg).LoginApi
+   ```
+
+   The `E2E_API_COVERAGE` report only records calls that go through this client
+   over the proxy — hand-rolled HTTP requests are invisible to it.
+
+4. **Tag the suite with a module label** (lowercase-kebab). This is the token
+   `E2E_LABELS` filters on:
+
+   ```go
+   var _ = Describe("Project", Label("project"), func() { ... })
+   ```
+
+   Existing labels: `login`, `model`, `project`, `robot`, `sync-policy`,
+   `current-user`, `user`.
+
+5. **Give every `It` a unique case-ID label.** Format is a module prefix plus a
+   zero-padded sequence, `<PREFIX>NNNNN` (five digits):
+
+   ```go
+   It("should create a project", Label("P00001"), func() { ... })
+   ```
+
+   Existing prefixes: `CU` (current-user), `L` (login), `M` (model), `R`
+   (robot), `U` (user), `SP` (sync-policy — legacy four-digit `SPNNNN`). Pick a
+   free prefix for a new module and keep it unique so IDs stay traceable.
+
+6. **Mark exactly one happy-path case per module `smoke`** — the case the fast
+   CI sweep and `E2E_LABELS=smoke` run:
+
+   ```go
+   It("should log in with valid admin credentials", Label("L00001", "smoke"), func() { ... })
+   ```
+
+7. **Adding new API surface? Regenerate the client first.** Run
+   `make gen_openapi_sdk` (output: `test/client`) after the swagger/OpenAPI
+   changes so the typed client methods exist before you write the test.
+
 ## Development Tips
 
 ### Database


### PR DESCRIPTION
Two commits from a review of `docs/development.md`.

## 1. Add a `### Writing a new E2E test` guide
The **End-to-End Tests** section explained how to *run* e2e tests (label selection, `smoke` sweep, `E2E_API_COVERAGE` report) but never how to *author* one — the conventions the CI label filter and coverage report depend on lived only in existing test files. Adds a subsection covering:

1. One package per module under `test/e2e_apiserver/<module>/`
2. Standard `*_suite_test.go` bootstrap (`RunSpecs` + `BeforeSuite`/`AfterSuite` → `testenv`)
3. Calling the generated client (`test/client/v1alpha1/<module>` + `tools.GetBaseURL()`) over the proxy — **required for `E2E_API_COVERAGE` to record the call**
4. Module label (`Describe(..., Label("project"))`) — the token `E2E_LABELS` filters on
5. Per-case ID label `<PREFIX>NNNNN` (documents existing `CU`/`L`/`M`/`R`/`U` and legacy `SP`)
6. Exactly one `smoke` case per module
7. `make gen_openapi_sdk` to regenerate the client when the API surface changes

All conventions verified against the current `test/e2e_apiserver/` suites.

## 2. Fix two stale version claims
- Prerequisites said `pnpm 8+`, but `ui/package.json` engines pins `pnpm >=10 <11` (pnpm 8 fails the engines check).
- The ginkgo CLI install used `@v2.22.1`, but `go.mod` requires `onsi/ginkgo/v2 v2.32.0`.

Docs-only; no code changes.

### Open points for reviewers
- **ID padding is inconsistent today** — most modules use five digits, `sync-policy` uses four (`SPNNNN`). The guide pins `<PREFIX>NNNNN` going forward but does not renumber existing cases.
- No prefix registry exists; the guide just says "pick a free prefix and keep it unique."