### PR TITLE
fix(ui): improve access token hint message

### DIFF
--- a/ui/src/locales/en/profile.json
+++ b/ui/src/locales/en/profile.json
@@ -48,7 +48,7 @@
     "ACCESS_TOKEN_STATUS_UNKNOWN": "Unknown"
   },
   "tokenPermanent": "Never",
-  "tokenHint": "Access tokens can be used to access open APIs and for continuous deployment. A token is only shown once upon creation. If you lose it, please create a new one.",
+  "tokenHint": "Access tokens authenticate CLI and API requests and provide access to repositories your account is authorized to use. Each token is shown only once—store it securely. If a token is lost or exposed, delete it and create a new one.",
   "deleteToken": "Delete Token",
   "deleteTokenConfirm": "Are you sure you want to delete token {{name}}? This action cannot be undone.",
   "tokenCreated": "Token created successfully",

--- a/ui/src/locales/zh/profile.json
+++ b/ui/src/locales/zh/profile.json
@@ -48,7 +48,7 @@
     "ACCESS_TOKEN_STATUS_UNKNOWN": "未知"
   },
   "tokenPermanent": "永久",
-  "tokenHint": "访问密钥可用于访问开放 API 和持续发布，创建后即发布且仅在创建时显示一次。若忘记密钥信息，请重新创建。",
+  "tokenHint": "访问密钥用于 CLI 和 API 身份认证，可访问当前账号有权限的仓库。令牌仅显示一次，请妥善保存；如丢失或泄露，请删除后重新创建。",
   "deleteToken": "删除密钥",
   "deleteTokenConfirm": "确认删除密钥 {{name}} 吗？此操作不可撤销。",
   "tokenCreated": "密钥创建成功",


### PR DESCRIPTION
## Summary
- Rewrites the Access Token page hint to clearly state what tokens are for (authenticating CLI/API requests, scoped to repos the account can access), that each token is shown only once, and to delete+recreate if lost or exposed.
- Updates both English and Chinese locale strings.

Fixes #861

## Test plan
- [ ] Manually verify the updated hint text renders correctly on the Access Key page (en/zh)