### PR TITLE
docs: refine JobServer design doc and fix Quick Start link

### DIFF
--- a/docs/design/jobserver-design.md
+++ b/docs/design/jobserver-design.md
@@ -1,88 +1,139 @@
-# Jobserver Design
+# JobServer Technical Design
 
-## Context
+## Goals
 
-MatrixHub uses the jobserver to run background work in-process with the API
-server. The current sync policy scheduler follows a delayed-job style design
-for a single API server replica.
+JobServer runs cron-scheduled or manually triggered background jobs without
+blocking API requests. Model synchronization is the first use case; cleanup and
+other jobs can reuse the same framework.
 
-This document captures the current runtime behavior. It can be expanded as the
-jobserver design evolves.
+- Add each job type as an independent processor with its own concurrency and
+  timeout limits.
+- Persist and claim jobs in the database with compare-and-swap (CAS); no
+  external queue is needed.
+- Run with the API server to keep phase-one deployment simple.
 
-## Sync Policy Scheduling
+## Delayed-job architecture
 
-Sync scheduling uses `sync_policies.next_run_at`, stored in milliseconds. The
-jobserver runs in-process with the API server under `internal/jobserver`; there
-is no separate cron daemon process.
+All processors use the same delayed-job pattern. The following diagram uses
+`syncPolicy processor` as the example.
 
-The sync policy flow is:
+```mermaid
+%%{init: {"flowchart": {"nodeSpacing": 80, "rankSpacing": 90, "padding": 24}, "themeVariables": {"fontSize": "20px"}}}%%
+flowchart TB
+  subgraph API["API Server"]
+    direction TB
 
-1. The `sync_policy` processor polls due policies.
-2. It CAS-advances `next_run_at`.
-3. It calls `CreatePendingSyncTask` to insert a `sync_tasks` row with pending
-   status.
-4. The `sync_task` processor claims pending tasks.
-5. It calls `ExecuteSyncTask` to generate `sync_jobs` rows.
-6. The `sync_job` processor runs the git work.
+    subgraph JS["JobServer"]
+      direction LR
+      Timer["Immediate poll<br/>and periodic ticker"]
+      Processor["Sync Policy<br/>Processor"]
+      Timer -->|Trigger| Processor
+    end
+
+    Service["SyncPolicyService"]
+    Processor -->|Find and claim due policies| Service
+  end
+
+  subgraph DB["Database"]
+    direction LR
+    Policies[("sync_policies<br/>Schedule and claim")]
+    Tasks[("sync_tasks<br/>Pending task")]
+  end
+
+  Service -->|Select and CAS<br/>next_run_at| Policies
+  Service -->|Create| Tasks
+
+  classDef trigger fill:#DBEAFE,stroke:#2563EB,stroke-width:2px,color:#172554,font-size:20px
+  classDef processor fill:#EDE9FE,stroke:#7C3AED,stroke-width:3px,color:#2E1065,font-size:22px
+  classDef service fill:#DCFCE7,stroke:#16A34A,stroke-width:2px,color:#14532D,font-size:20px
+  classDef storage fill:#FFEDD5,stroke:#EA580C,stroke-width:2px,color:#7C2D12,font-size:20px
+
+  class Timer trigger
+  class Processor processor
+  class Service service
+  class Policies,Tasks storage
+```
+
+1. JobServer triggers the Sync Policy Processor at startup and on each tick.
+2. The processor asks `SyncPolicyService` for policies that are due to run.
+3. The service claims each policy by atomically advancing its `next_run_at`.
+4. For every claimed policy, the service creates a Pending sync task for the
+   next processor.
+
+### Detailed sequence
+
+```mermaid
+sequenceDiagram
+  participant Timer
+  participant Processor
+  participant Service
+  participant Database
+
+  Timer->>Processor: Poll
+  Processor->>Service: Find due policies
+  Service->>Database: Select due policy rows
+  Database-->>Service: Candidates
+
+  loop For each candidate
+    Service->>Database: CAS advance next run time
+    alt CAS succeeds
+      Database-->>Service: Claimed
+    else CAS fails
+      Database-->>Service: Skipped
+    end
+  end
+
+  Service-->>Processor: Claimed policies
+
+  loop For each claimed policy
+    Processor->>Service: Create Pending task
+    Service->>Database: Insert Pending sync task
+    Database-->>Service: Created
+    Service-->>Processor: Done
+  end
+
+  Processor-->>Timer: Wait for next tick
+```
+
+The other processors reuse the same structure:
+
+| Processor | Poll and claim | Execute |
+|---|---|---|
+| `syncPolicy` | Due `next_run_at`; CAS advances the schedule | Create a Pending task |
+| `syncTask` | Pending task; CAS to Running | Generate Pending jobs |
+| `syncJob` | Pending job; CAS to Running | Run Git synchronization |
+
+Manual synchronization skips `syncPolicy` and creates a Pending task directly.
+
+### Processing pipeline
+
+**Three-stage pipeline:** policy scheduling, job generation, and transfer
+execution can be tuned independently.
+
+```mermaid
+flowchart LR
+  Policy["Sync Policy Processor<br/>Schedule"]
+  Task["Sync Task Processor<br/>Generate jobs"]
+  Job["Sync Job Processor<br/>Synchronize model"]
+
+  Policy -->|"Pending sync task"| Task
+  Task -->|"Pending sync jobs"| Job
+
+  classDef processor fill:#EDE9FE,stroke:#7C3AED,stroke-width:2px,color:#2E1065,font-size:18px
+  class Policy,Task,Job processor
+```
 
 ## Configuration
 
-The relevant config block is `jobServer` in `config.yaml`.
+JobServer settings and defaults are defined under
+[`jobServer` in `values.yaml`](../../deploy/charts/matrixhub/values.yaml).
 
-- Set `jobServer.enabled: false` to disable inserting pending `sync_tasks` from
-  the poller. Manual API `CreateSyncTask` will only bump `next_run_at`.
-- Per-sync-policy tuning lives under `jobServer.syncPolicy`, including
-  `pollInterval`, `maxConcurrent`, and `taskMaxDuration`.
+## Phase-one boundaries
 
-## Database Schema
-
-Scheduling columns are in `0_init.up.sql`:
-
-- `cron`
-- `last_run_at`
-- `next_run_at`
-- `idx_due`
-
-Apply migrations with `database.migrate: true` or run the SQL under
-`db/migrations/sql/mysql/`.
-
-## Cron Syntax
-
-Cron expressions are validated with `github.com/robfig/cron/v3`.
-
-The scheduler supports five-field cron expressions and descriptors such as
-`@daily`.
-
-Example:
-
-```text
-0 * * * *
-```
-
-This runs hourly.
-
-## Current Limitations
-
-The current design is single-replica oriented. These capabilities are not part
-of the current release:
-
-- Stop task
-- Heartbeat
-- Reaper
-- Multi-replica fencing with `running_by` / `running_until`
-
-## Verification
-
-Verify jobserver logic without a database:
-
-```bash
-go test -v -count=1 ./internal/jobserver/...
-```
-
-Verify the full scheduler path end to end with MySQL and a migrated schema:
-
-1. Start MatrixHub with the jobserver enabled.
-2. Create or trigger a sync policy, either by scheduled cron or manual
-   `CreateSyncTask`.
-3. Confirm that pending `sync_tasks` rows are created.
-4. Watch logs for `jobserver: processor loop start`.
+- Run one JobServer-enabled API replica.
+- CAS prevents duplicate claim winners but does not provide execution leases.
+- Detected failures are recorded but not retried; abandoned work is not
+  recovered.
+- Cancellation and job logs are local to the API server process.
+- Multi-replica recovery, shared logs, retry policies, and worker metrics are
+  future improvements.

--- a/website/docs/guides/mirror-from-huggingface.md
+++ b/website/docs/guides/mirror-from-huggingface.md
@@ -132,3 +132,8 @@ The download took approximately 15 seconds, showing that the model was cached in
 ## Conclusion
 
 The first on-demand download depends on upstream network speed. Later downloads come directly from the MatrixHub cache and are much faster.
+
+## Next step
+
+Follow [Load a model into vLLM from MatrixHub](./use-with-vllm.md) to run an
+inference request with the cached model.

--- a/website/docs/guides/use-with-vllm.md
+++ b/website/docs/guides/use-with-vllm.md
@@ -24,7 +24,7 @@ Load a model into vLLM from MatrixHub and run a simple inference request.
 
 ## Deploy vLLM
 
-### Option 1: Deploy vLLM in a container with nerdctl or Docker
+### Option 1: Deploy vLLM in a container with nerdctl or docker
 
 - To install the GPU driver, see [Install NVIDIA Container Toolkit for Docker deployment](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
 - To deploy vLLM, see [deploy vLLM using Docker](https://docs.vllm.ai/en/latest/deployment/docker/).

--- a/website/docs/installation/index.md
+++ b/website/docs/installation/index.md
@@ -121,3 +121,8 @@ helm uninstall matrixhub --namespace "$NAMESPACE"
 ```
 
 This removes resources including the default PVCs created by the chart. To preserve data, use an existing PVC for MatrixHub data and an external database.
+
+## Get started
+
+After installation, start with
+[Cache models through a proxy project](../guides/mirror-from-huggingface.md).

--- a/website/i18n/zh-CN/code.json
+++ b/website/i18n/zh-CN/code.json
@@ -439,13 +439,7 @@
     "message": "使用 Docker Compose 或 Helm 在几分钟内即可部署 MatrixHub。完全开源，对社区免费。"
   },
   "homepage.cta.button": {
-    "message": "阅读文档"
-  },
-  "homepage.cta.copied": {
-    "message": "已复制！"
-  },
-  "homepage.cta.copy": {
-    "message": "复制"
+    "message": "安装指南"
   },
   "changelog.title": {
     "message": "更新日志"

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/guides/mirror-from-huggingface.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/guides/mirror-from-huggingface.md
@@ -134,3 +134,7 @@ time hf download Qwen/Qwen3-0.6B
 ## 结论
 
 首次按需下载依赖外网网速，再次下载直接从 MatrixHub 缓存下载，速度大幅提升。
+
+## 下一步
+
+参考 [vLLM 从 MatrixHub 加载模型](./use-with-vllm.md)，使用已缓存的模型完成一次推理。

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/guides/use-with-vllm.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/guides/use-with-vllm.md
@@ -24,7 +24,7 @@ vLLM 从 MatrixHub 加载模型并进行简单推理问答。
 
 ## 部署 vLLM
 
-### 方法一：用 nerdctl 或 Docker 命令启动容器来部署 vLLM
+### 方法一：用 nerdctl 或 docker 命令启动容器来部署 vLLM
 
 - 安装 GPU 驱动，详见 [Install NVIDIA Container Toolkit for Docker deployment](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
 - 部署 vLLM，详见 [deploy vLLM using Docker](https://docs.vllm.ai/en/latest/deployment/docker/)

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/installation/index.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/installation/index.md
@@ -123,3 +123,7 @@ helm uninstall matrixhub --namespace "$NAMESPACE"
 ```
 
 此命令会删除 Chart 创建的资源，包括默认 PVC。如需保留数据，请为 MatrixHub 数据使用已有 PVC，并使用外部数据库。
+
+## 开始使用
+
+安装完成后，可以从 [通过代理项目缓存模型](../guides/mirror-from-huggingface.md) 开始。

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -375,6 +375,11 @@ html:not([data-scroll='0']) .navbar {
   font-size: 1.125rem;
 }
 
+.homepage-quick-start,
+.homepage-quick-start:hover {
+  color: #000000;
+}
+
 /* ==========================================
    Link Styles
    ========================================== */

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -16,8 +16,6 @@ import {
   Globe
 } from 'lucide-react';
 
-
-
 // Intersection Observer Hook for scroll animations
 const useIntersectionObserver = (options = {}) => {
   const ref = useRef<HTMLDivElement>(null);
@@ -114,14 +112,7 @@ const TechLogo = ({ logo, name, index }: { logo: React.ReactNode, name: string, 
 };
 
 export default function Home(): React.ReactElement {
-  const [copied, setCopied] = useState(false);
   const [terminalLines, setTerminalLines] = useState<number[]>([]);
-
-  const handleCopy = () => {
-    navigator.clipboard.writeText("curl -fsSL https://bit.ly/4qqSZIG | docker compose -f - up -d");
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
 
   // Terminal typing animation
   useEffect(() => {
@@ -184,8 +175,8 @@ export default function Home(): React.ReactElement {
 
                 <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start animate-fade-in-up" style={{ animationDelay: '0.3s' }}>
                   <Link
-                    to="/blog/deepseek-v4-distribution"
-                    className="px-6 sm:px-8 py-3 sm:py-4 bg-green-600 hover:bg-green-500 text-black rounded-lg font-bold text-base sm:text-lg transition-all shadow-[0_0_20px_rgba(22,163,74,0.4)] hover:shadow-[0_0_30px_rgba(22,163,74,0.6)] flex items-center justify-center gap-2 hover:text-black hover:no-underline hover:scale-105 transform"
+                    to="/docs/getting-started"
+                    className="homepage-quick-start px-6 sm:px-8 py-3 sm:py-4 bg-green-600 hover:bg-green-500 rounded-lg font-bold text-base sm:text-lg transition-all shadow-[0_0_20px_rgba(22,163,74,0.4)] hover:shadow-[0_0_30px_rgba(22,163,74,0.6)] flex items-center justify-center gap-2 hover:no-underline hover:scale-105 transform"
                   >
                     <Translate id="homepage.hero.quickStart">Quick Start</Translate> <ArrowRight size={20} />
                   </Link>
@@ -391,24 +382,13 @@ export default function Home(): React.ReactElement {
             <p className="text-base sm:text-lg lg:text-xl text-slate-400 mb-8 sm:mb-10">
               <Translate id="homepage.cta.subtitle">Deploy MatrixHub in minutes using Docker Compose or Helm. Open source and free for the community.</Translate>
             </p>
-            <div className="flex flex-col sm:flex-row justify-center gap-4">
+            <div className="flex justify-center">
                <Link
-                 to="/docs/intro"
+                 to="/docs/installation"
                  className="px-6 sm:px-8 py-3 sm:py-4 bg-white text-black hover:bg-slate-200 rounded-lg font-bold text-base sm:text-lg transition-all hover:text-black hover:no-underline hover:scale-105 transform"
                >
-                  <Translate id="homepage.cta.button">Read the Docs</Translate>
+                  <Translate id="homepage.cta.button">Installation Guide</Translate>
                </Link>
-               <div className="flex items-center bg-[#0d1117] border border-slate-700 rounded-lg p-1 pr-2 sm:pr-4 hover:border-slate-600 transition-colors">
-                 <div className="px-3 sm:px-4 py-2 sm:py-3 text-slate-400 font-mono text-xs sm:text-sm truncate max-w-[200px] sm:max-w-none">
-                   curl -fsSL https://bit.ly/4qqSZIG | docker compose -f - up -d
-                 </div>
-                 <button
-                  onClick={handleCopy}
-                  className="ml-1 sm:ml-2 p-2 hover:bg-slate-800 rounded text-slate-400 hover:text-white transition-colors relative border-none cursor-pointer bg-transparent flex-shrink-0"
-                 >
-                   {copied ? <span className="text-green-500 font-bold text-xs"><Translate id="homepage.cta.copied">Copied!</Translate></span> : <span className="text-xs font-bold border border-slate-600 px-2 py-1 rounded hover:border-green-500 transition-colors"><Translate id="homepage.cta.copy">COPY</Translate></span>}
-                 </button>
-               </div>
             </div>
           </AnimatedSection>
         </section>


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/kind bug

#### What this PR does / why we need it:

- Fix the homepage **Quick Start** button so it opens `/docs/getting-started` instead of an unrelated blog page.
- Refine the JobServer technical design into a concise architecture document.
- Document the reusable delayed-job pattern, the sync policy example, the three-stage processing pipeline, configuration source, and phase-one boundaries.

The homepage CTA used an incorrect placeholder target. The previous JobServer document mixed implementation details with architecture and did not clearly show the delayed-job flow.

#### Which issue(s) this PR fixes:

#138 
#142 
#595

#### Special notes for your reviewer:

Validation:

- `pnpm --dir website build` — passed for English and Chinese locales; `/docs/getting-started` was generated.
- `git diff --check` — passed.
- `pnpm --dir website typecheck` — blocked by the existing TypeScript 7 configuration because `tsconfig.json` still uses the removed `baseUrl` option; this PR does not change that configuration.

#### Checklist

- [x] Tests are not needed for this documentation and link-only change; the production website build passed.
- [x] Technical documentation was updated.

#### Does this PR introduce a user-facing change?

```release-note
Fix the homepage Quick Start link so it opens the Getting Started guide.
```