### PR TITLE
feat(website): support HMR dev server for documentation website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,4 @@ go.work.sum
 # config
 config/config-dev.yaml
 
-web/node_modules
-
-website/node_modules
-
 /tmp

--- a/Makefile
+++ b/Makefile
@@ -79,12 +79,9 @@ image-build: ## Build the MatrixHub image
 image-push: ## Build and push the MatrixHub image
 	$(MAKE) image-build PUSH=--push
 
-website/build: website
-	make -C website build
-
 .PHONY: serve-website
-serve-website: ## Serve built documentation website locally
-	make -C website serve
+serve-website: ## Start the dev server with HMR (hot reload).
+	make -C website start
 
 .PHONY: clean
 clean: ## Clean all build artifacts

--- a/website/Makefile
+++ b/website/Makefile
@@ -15,13 +15,21 @@
 node_modules: package.json
 	npm install
 
+# Start the dev server with HMR (hot reload).
+.PHONY: start
+start: node_modules
+	npm run start
+
+# Build the static site (production).
 build: node_modules src
 	npm run build
 
+# Serve the pre-built static site (production).
 .PHONY: serve
-serve: node_modules
+serve: build
 	npm run serve
 
+# Clean build artifacts
 .PHONY: clean
 clean:
-	rm -rf build
+	npm run clear


### PR DESCRIPTION
## Summary

Add a `start` target to `website/Makefile` that runs the Docusaurus dev server with Hot Module Replacement (HMR), enabling a smooth local development experience for the documentation website.

## Usage

```bash
make serve-website
```

This starts the Docusaurus dev server at `http://localhost:3000` with hot reload enabled.
