### PR TITLE
fix(ui): validate and clarify resource name format in sync rule form (#854)

### DIFF
--- a/ui/src/features/admin/replications/replications.schema.ts
+++ b/ui/src/features/admin/replications/replications.schema.ts
@@ -98,6 +98,17 @@ export function createReplicationFormSchema() {
       })
     }
 
+    if (
+      data.policyType === SyncPolicyType.SYNC_POLICY_TYPE_PUSH_BASE
+      && !/^[^/]+\/.+$/.test(data.resourceName.trim())
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        message: t('routes.admin.replications.validation.resourceNameProjectRequired'),
+        path: ['resourceName'],
+      })
+    }
+
     if (data.triggerType === TriggerType.TRIGGER_TYPE_SCHEDULED) {
       const cronResult = cronExpressionSchema.safeParse(data.cronExpression)
 

--- a/ui/src/features/admin/replications/replications.schema.ts
+++ b/ui/src/features/admin/replications/replications.schema.ts
@@ -71,9 +71,14 @@ function replicationFormBaseSchema() {
     bandwidth: z.string().trim().optional(),
     bandwidthUnit: z.enum(replicationBandwidthUnitValues),
     isOverwrite: z.boolean(),
-    // Phase 1 backend contract only requires resourceName to be present.
-    // Keep validation limited to "required" for now and defer pattern checks.
-    resourceName: z.string().trim().min(1, t('routes.admin.replications.validation.resourceNameRequired')),
+    resourceName: z
+      .string()
+      .trim()
+      .min(1, t('routes.admin.replications.validation.resourceNameRequired'))
+      .refine(
+        value => !value.startsWith('/') && !value.endsWith('/'),
+        t('routes.admin.replications.validation.resourceNameInvalidSlash'),
+      ),
     resourceTypes: z.array(z.enum(replicationResourceTypeValues)),
     sourceRegistryId: z.number(),
     targetProjectName: z.string().trim().optional(),

--- a/ui/src/locales/en/routes/admin.replications.json
+++ b/ui/src/locales/en/routes/admin.replications.json
@@ -55,8 +55,8 @@
     "sourceRegistryHint": "Create a registry first in Registry Management before selecting it here.",
     "resourceFilter": "Resource Filter",
     "resourceName": "Resource Name",
-    "resourceNamePlaceholder": "e.g., model-name or * for all",
-    "resourceFilterHint": "Filters resources by name. Leave it empty or use \"*\" to match all resources; \"qwen/**\" only matches resources under \"qwen\". See the user guide for more patterns.",
+    "resourceNamePlaceholder": "e.g., model-name or project/model-name (no leading slash)",
+    "resourceFilterHint": "Filters resources by name. Use the format \"model-name\" or \"project/model-name\" without a leading slash. Leave it empty or use \"*\" to match all resources; \"qwen/**\" only matches resources under \"qwen\". See the user guide for more patterns.",
     "resourceTypes": {
       "label": "Resource Types",
       "model": "Model",
@@ -80,6 +80,7 @@
   },
   "validation": {
     "resourceNameRequired": "Resource name is required",
+    "resourceNameInvalidSlash": "Resource name must not start or end with \"/\" (e.g., use \"model-name\" or \"project/model-name\", not \"/model-name\")",
     "resourceTypesRequired": "At least one resource type is required",
     "cronRequired": "Cron expression is required",
     "cronInvalid": "Enter a five-field cron expression",

--- a/ui/src/locales/en/routes/admin.replications.json
+++ b/ui/src/locales/en/routes/admin.replications.json
@@ -55,8 +55,8 @@
     "sourceRegistryHint": "Create a registry first in Registry Management before selecting it here.",
     "resourceFilter": "Resource Filter",
     "resourceName": "Resource Name",
-    "resourceNamePlaceholder": "e.g., model-name or project/model-name (no leading slash)",
-    "resourceFilterHint": "Filters resources by name. Use the format \"model-name\" or \"project/model-name\" without a leading slash. Leave it empty or use \"*\" to match all resources; \"qwen/**\" only matches resources under \"qwen\". See the user guide for more patterns.",
+    "resourceNamePlaceholder": "e.g., my-project/model-name (no leading slash)",
+    "resourceFilterHint": "Filters resources by name. For push rules, use the full \"project/model-name\" path of the local resource — the project part is required. For pull rules, use the remote path such as \"qwen/model-name\"; \"*\" matches all resources and \"qwen/**\" matches all resources under \"qwen\". Do not start with a slash. See the user guide for more patterns.",
     "resourceTypes": {
       "label": "Resource Types",
       "model": "Model",
@@ -80,7 +80,8 @@
   },
   "validation": {
     "resourceNameRequired": "Resource name is required",
-    "resourceNameInvalidSlash": "Resource name must not start or end with \"/\" (e.g., use \"model-name\" or \"project/model-name\", not \"/model-name\")",
+    "resourceNameInvalidSlash": "Resource name must not start or end with \"/\" (e.g., use \"my-project/model-name\", not \"/model-name\")",
+    "resourceNameProjectRequired": "For push rules, include the local project, e.g. \"my-project/model-name\"",
     "resourceTypesRequired": "At least one resource type is required",
     "cronRequired": "Cron expression is required",
     "cronInvalid": "Enter a five-field cron expression",

--- a/ui/src/locales/zh/routes/admin.replications.json
+++ b/ui/src/locales/zh/routes/admin.replications.json
@@ -55,8 +55,8 @@
     "sourceRegistryHint": "需先在“仓库管理”中创建仓库。",
     "resourceFilter": "资源过滤器",
     "resourceName": "资源名称",
-    "resourceNamePlaceholder": "例如：model-name 或 project/model-name（不要以斜杠开头）",
-    "resourceFilterHint": "过滤资源的名字。请使用“model-name”或“project/model-name”格式，不要以斜杠开头。不填或者填写“*”匹配所有资源；“qwen/**”匹配“qwen”下的资源。更多的匹配模式请参考用户手册。",
+    "resourceNamePlaceholder": "例如：my-project/model-name（不要以斜杠开头）",
+    "resourceFilterHint": "过滤资源的名字。推送规则请填写本地资源的完整路径“项目名/模型名”，项目名不能省略。拉取规则填写远端路径，例如“qwen/model-name”；“*”匹配所有资源，“qwen/**”匹配“qwen”下的资源。不要以斜杠开头。更多的匹配模式请参考用户手册。",
     "resourceTypes": {
       "label": "资源类型",
       "model": "模型",
@@ -80,7 +80,8 @@
   },
   "validation": {
     "resourceNameRequired": "请输入资源名称",
-    "resourceNameInvalidSlash": "资源名称不能以“/”开头或结尾（例如应使用“model-name”或“project/model-name”，而不是“/model-name”）",
+    "resourceNameInvalidSlash": "资源名称不能以“/”开头或结尾（例如应使用“my-project/model-name”，而不是“/model-name”）",
+    "resourceNameProjectRequired": "推送规则需包含本地项目名，例如“my-project/model-name”",
     "resourceTypesRequired": "至少需要选择一个资源类型",
     "cronRequired": "请输入 Cron 表达式",
     "cronInvalid": "请输入五段式 Cron 表达式",

--- a/ui/src/locales/zh/routes/admin.replications.json
+++ b/ui/src/locales/zh/routes/admin.replications.json
@@ -55,8 +55,8 @@
     "sourceRegistryHint": "需先在“仓库管理”中创建仓库。",
     "resourceFilter": "资源过滤器",
     "resourceName": "资源名称",
-    "resourceNamePlaceholder": "例如：model-name 或 * 表示全部",
-    "resourceFilterHint": "过滤资源的名字。不填或者填写“*”匹配所有资源；“qwen/**”匹配“qwen”下的资源。更多的匹配模式请参考用户手册。",
+    "resourceNamePlaceholder": "例如：model-name 或 project/model-name（不要以斜杠开头）",
+    "resourceFilterHint": "过滤资源的名字。请使用“model-name”或“project/model-name”格式，不要以斜杠开头。不填或者填写“*”匹配所有资源；“qwen/**”匹配“qwen”下的资源。更多的匹配模式请参考用户手册。",
     "resourceTypes": {
       "label": "资源类型",
       "model": "模型",
@@ -80,6 +80,7 @@
   },
   "validation": {
     "resourceNameRequired": "请输入资源名称",
+    "resourceNameInvalidSlash": "资源名称不能以“/”开头或结尾（例如应使用“model-name”或“project/model-name”，而不是“/model-name”）",
     "resourceTypesRequired": "至少需要选择一个资源类型",
     "cronRequired": "请输入 Cron 表达式",
     "cronInvalid": "请输入五段式 Cron 表达式",


### PR DESCRIPTION
Fixes #854.

The Remote Sync rule form's "Resource Name" field only checked for non-empty input, so values like `/Qwen2.5-0.5B` passed client-side validation but failed on the backend with `local model /Qwen2.5-0.5B not found`.

Backend context: `parseResourcePath` in `internal/apiserver/handler/sync_policy_handler.go` splits `resourceName` on the first `/`. For push rules, a value without a `/` means the local project resolves to empty, and `/Qwen2.5-0.5B` resolves to an empty project + name, so the model lookup (`GetByProjectAndName`) fails — exactly the error in the issue.

Changes:
- Reject resource names starting or ending with `/`, with a localized error (`validation.resourceNameInvalidSlash`, en + zh).
- For **push** rules, require the full `project/model-name` path (`validation.resourceNameProjectRequired`, en + zh), since the backend derives the local project from the segment before the first `/`.
- Rewrite the placeholder and filter hint (en + zh) to describe the push format (`my-project/model-name`) and pull glob patterns (`*`, `qwen/**`) accurately.

No backend payload changes.

**Testing:** `pnpm run typecheck` and eslint pass; pre-commit lint-staged hooks pass. No unit-test harness exists for this schema in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)