### PR TITLE
fix(ui): clarify target project requirement in sync rule form (#852)

### DIFF
--- a/ui/src/features/admin/replications/replications.schema.ts
+++ b/ui/src/features/admin/replications/replications.schema.ts
@@ -131,6 +131,17 @@ export function createReplicationFormSchema() {
     }
 
     if (
+      data.policyType === SyncPolicyType.SYNC_POLICY_TYPE_PUSH_BASE
+      && !data.targetProjectName
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        message: t('routes.admin.replications.validation.targetProjectNameRequired'),
+        path: ['targetProjectName'],
+      })
+    }
+
+    if (
       data.targetProjectName
       && (!NAME_START_CHAR_REGEX.test(data.targetProjectName) || !NAME_VALID_CHARS_REGEX.test(data.targetProjectName))
     ) {

--- a/ui/src/features/admin/replications/replications.schema.ts
+++ b/ui/src/features/admin/replications/replications.schema.ts
@@ -6,7 +6,9 @@ import {
 import { z } from 'zod'
 
 import i18n from '@/i18n'
-import { withNameStartCharRule, withNameValidCharsRule } from '@/shared/validation'
+import {
+  NAME_START_CHAR_REGEX, NAME_VALID_CHARS_REGEX, withNameStartCharRule, withNameValidCharsRule,
+} from '@/shared/validation'
 
 import { isFiveFieldCronExpression } from './replications.utils'
 
@@ -125,6 +127,17 @@ export function createReplicationFormSchema() {
         code: 'custom',
         message: t('routes.admin.replications.validation.targetRegistryRequired'),
         path: ['targetRegistryId'],
+      })
+    }
+
+    if (
+      data.targetProjectName
+      && (!NAME_START_CHAR_REGEX.test(data.targetProjectName) || !NAME_VALID_CHARS_REGEX.test(data.targetProjectName))
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        message: t('routes.admin.replications.validation.targetProjectNameInvalid'),
+        path: ['targetProjectName'],
       })
     }
   })

--- a/ui/src/locales/en/routes/admin.replications.json
+++ b/ui/src/locales/en/routes/admin.replications.json
@@ -64,7 +64,7 @@
     },
     "targetRegistry": "Target Registry",
     "target": "Target",
-    "targetHint": "Specify the target project. If left empty, resources are placed into a project with the same name as in the source registry.",
+    "targetHint": "Specify the target project. The project must already exist in the target registry, or the sync will fail. If left empty, resources are placed into a project with the same name as in the source registry.",
     "targetProjectName": "Target Project",
     "targetProjectNamePlaceholder": "e.g., my-project",
     "triggerType": "Trigger Mode",
@@ -84,7 +84,8 @@
     "cronRequired": "Cron expression is required",
     "cronInvalid": "Enter a five-field cron expression",
     "sourceRegistryRequired": "Source registry is required",
-    "targetRegistryRequired": "Target registry is required"
+    "targetRegistryRequired": "Target registry is required",
+    "targetProjectNameInvalid": "Enter a valid project name (lowercase letters, numbers, \".\", \"_\", \"-\"; no slashes)"
   },
   "notifications": {
     "createSuccess": "Sync rule created successfully",

--- a/ui/src/locales/en/routes/admin.replications.json
+++ b/ui/src/locales/en/routes/admin.replications.json
@@ -64,7 +64,7 @@
     },
     "targetRegistry": "Target Registry",
     "target": "Target",
-    "targetHint": "Specify the target project. The project must already exist in the target registry, or the sync will fail. If left empty, resources are placed into a project with the same name as in the source registry.",
+    "targetHint": "Specify the target project. For push rules, the project must already exist in the target registry, or the sync will fail. For pull rules, the local project is created automatically if it does not exist.",
     "targetProjectName": "Target Project",
     "targetProjectNamePlaceholder": "e.g., my-project",
     "triggerType": "Trigger Mode",
@@ -85,6 +85,7 @@
     "cronInvalid": "Enter a five-field cron expression",
     "sourceRegistryRequired": "Source registry is required",
     "targetRegistryRequired": "Target registry is required",
+    "targetProjectNameRequired": "Target project is required for push rules",
     "targetProjectNameInvalid": "Enter a valid project name (lowercase letters, numbers, \".\", \"_\", \"-\"; no slashes)"
   },
   "notifications": {

--- a/ui/src/locales/zh/routes/admin.replications.json
+++ b/ui/src/locales/zh/routes/admin.replications.json
@@ -64,7 +64,7 @@
     },
     "targetRegistry": "目标仓库",
     "target": "目标",
-    "targetHint": "指定目标项目。目标项目需已存在于目标仓库中，否则同步会失败。如果不填，资源会被放到和源仓库中名称相同的项目下。",
+    "targetHint": "指定目标项目。推送规则的目标项目需已存在于目标仓库中，否则同步会失败；拉取规则的本地项目不存在时会自动创建。",
     "targetProjectName": "目标项目",
     "targetProjectNamePlaceholder": "例如：my-project",
     "triggerType": "触发模式",
@@ -85,6 +85,7 @@
     "cronInvalid": "请输入五段式 Cron 表达式",
     "sourceRegistryRequired": "请选择源仓库",
     "targetRegistryRequired": "请选择目标仓库",
+    "targetProjectNameRequired": "推送规则必须填写目标项目",
     "targetProjectNameInvalid": "请输入有效的项目名称（小写字母、数字、“.”、“_”、“-”；不能包含斜杠）"
   },
   "notifications": {

--- a/ui/src/locales/zh/routes/admin.replications.json
+++ b/ui/src/locales/zh/routes/admin.replications.json
@@ -64,7 +64,7 @@
     },
     "targetRegistry": "目标仓库",
     "target": "目标",
-    "targetHint": "指定目标项目。如果不填，资源会被放到和源仓库中名称相同的项目下。",
+    "targetHint": "指定目标项目。目标项目需已存在于目标仓库中，否则同步会失败。如果不填，资源会被放到和源仓库中名称相同的项目下。",
     "targetProjectName": "目标项目",
     "targetProjectNamePlaceholder": "例如：my-project",
     "triggerType": "触发模式",
@@ -84,7 +84,8 @@
     "cronRequired": "请输入 Cron 表达式",
     "cronInvalid": "请输入五段式 Cron 表达式",
     "sourceRegistryRequired": "请选择源仓库",
-    "targetRegistryRequired": "请选择目标仓库"
+    "targetRegistryRequired": "请选择目标仓库",
+    "targetProjectNameInvalid": "请输入有效的项目名称（小写字母、数字、“.”、“_”、“-”；不能包含斜杠）"
   },
   "notifications": {
     "createSuccess": "同步规则创建成功",


### PR DESCRIPTION
Fixes #852.

## Summary
The Target Project hint claimed a bare project name was sufficient and that leaving it empty would reuse the source project name. Neither matches the backend for push rules:

- For **push** rules, `RemoteProjectName` is taken verbatim from `targetProjectName` (`internal/apiserver/handler/sync_policy_handler.go`), and `PushToRemote` (`internal/repo/git_repo.go`) pushes to `<registry>/<models|datasets>/<RemoteProjectName>/<name>` with **no auto-create** — the project must already exist in the target registry, and an empty value produces a broken `models//name` path.
- For **pull** rules, the local target project **is** auto-created (`ExecuteSyncTask` in `internal/domain/syncpolicy/sync_policy_service.go` pre-creates it), so no existence requirement applies there.

## Changes
- `targetHint` (en + zh) now states: push rules require the project to already exist in the target registry; pull rules auto-create the local project.
- `targetProjectName` is now **required for push rules** (`validation.targetProjectNameRequired`, en + zh).
- When non-empty, the value is validated against the shared project-name rules (lowercase alnum + `._-`, no slashes) with a localized error.

## Test plan
- [x] pnpm typecheck
- [x] eslint on changed files
- [ ] Manually verify hint text and validation errors in Create/Edit Sync Rule modal (push + pull modes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)