### PR TITLE
refactor(chart): use StatefulSet for MySQL with volumeClaimTemplates

### DIFF
--- a/deploy/charts/matrixhub/templates/_helpers.tpl
+++ b/deploy/charts/matrixhub/templates/_helpers.tpl
@@ -109,20 +109,6 @@ MySQL secret name
 {{- end }}
 
 {{- /*
-MySQL PVC name
-*/}}
-{{- define "matrixhub.mysql.pvcName" -}}
-{{- printf "%s-mysql-pv-claim" (include "matrixhub.fullname" .) }}
-{{- end }}
-
-{{- /*
-MySQL init ConfigMap name
-*/}}
-{{- define "matrixhub.mysql.initConfigMapName" -}}
-{{- printf "%s-mysql-initdb-config" (include "matrixhub.fullname" .) }}
-{{- end }}
-
-{{- /*
 Image pull secrets
 */}}
 {{- define "matrixhub.imagePullSecrets" -}}
@@ -140,7 +126,5 @@ Database DSN
 {{- .Values.apiserver.database.dsn }}
 {{- else if eq .Values.apiserver.database.driver "mysql" }}
 {{- printf "matrixhub:%s@tcp(%s-mysql:3306)/matrixhub?charset=utf8mb4&multiStatements=true&parseTime=true" .Values.mysql.rootPassword (include "matrixhub.fullname" .) }}
-{{- else if eq .Values.apiserver.database.driver "postgres" }}
-{{- printf "user=matrixhub password=%s host=%s-mysql port=5432 dbname=matrixhub sslmode=disable" .Values.mysql.rootPassword (include "matrixhub.fullname" .) }}
 {{- end }}
 {{- end }}

--- a/deploy/charts/matrixhub/templates/_helpers.tpl
+++ b/deploy/charts/matrixhub/templates/_helpers.tpl
@@ -109,20 +109,6 @@ MySQL secret name
 {{- end }}
 
 {{- /*
-MySQL PVC name
-*/}}
-{{- define "matrixhub.mysql.pvcName" -}}
-{{- printf "%s-mysql-pv-claim" (include "matrixhub.fullname" .) }}
-{{- end }}
-
-{{- /*
-MySQL init ConfigMap name
-*/}}
-{{- define "matrixhub.mysql.initConfigMapName" -}}
-{{- printf "%s-mysql-initdb-config" (include "matrixhub.fullname" .) }}
-{{- end }}
-
-{{- /*
 Image pull secrets
 */}}
 {{- define "matrixhub.imagePullSecrets" -}}
@@ -140,8 +126,6 @@ Database DSN
 {{- .Values.apiserver.database.dsn }}
 {{- else if eq .Values.apiserver.database.driver "mysql" }}
 {{- printf "matrixhub:%s@tcp(%s-mysql:3306)/matrixhub?charset=utf8mb4&multiStatements=true&parseTime=true" .Values.mysql.rootPassword (include "matrixhub.fullname" .) }}
-{{- else if eq .Values.apiserver.database.driver "postgres" }}
-{{- printf "user=matrixhub password=%s host=%s-mysql port=5432 dbname=matrixhub sslmode=disable" .Values.mysql.rootPassword (include "matrixhub.fullname" .) }}
 {{- end }}
 {{- end }}
 

--- a/deploy/charts/matrixhub/templates/mysql.yaml
+++ b/deploy/charts/matrixhub/templates/mysql.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.global.storage.apiserver.builtIn (not .Values.apiserver.database.dsn) }}
+{{- if and .Values.global.storage.apiserver.builtIn (not .Values.apiserver.database.dsn) (eq .Values.apiserver.database.driver "mysql")}}
 ---
 apiVersion: v1
 kind: Secret
@@ -10,37 +10,6 @@ metadata:
 type: Opaque
 data:
   mysql-root-password: {{ .Values.mysql.rootPassword | b64enc | quote }}
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ include "matrixhub.mysql.pvcName" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "matrixhub.labels" . | nindent 4 }}
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: {{ .Values.mysql.persistence.size }}
-  {{- if .Values.mysql.persistence.storageClass }}
-  storageClassName: {{ .Values.mysql.persistence.storageClass }}
-  {{- end }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "matrixhub.mysql.initConfigMapName" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "matrixhub.labels" . | nindent 4 }}
-data:
-  initdb.sql: |
-    CREATE DATABASE IF NOT EXISTS matrixhub CHARACTER SET utf8mb4;
-    CREATE USER IF NOT EXISTS 'matrixhub'@'%' IDENTIFIED BY '{{ .Values.mysql.rootPassword }}';
-    GRANT ALL PRIVILEGES ON matrixhub.* TO 'matrixhub'@'%';
-    FLUSH PRIVILEGES;
 ---
 apiVersion: v1
 kind: Service
@@ -59,23 +28,21 @@ spec:
     app: {{ include "matrixhub.fullname" . }}-mysql
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "matrixhub.fullname" . }}-mysql
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "matrixhub.labels" . | nindent 4 }}
 spec:
+  serviceName: {{ include "matrixhub.fullname" . }}-mysql
   selector:
     matchLabels:
       app: {{ include "matrixhub.fullname" . }}-mysql
-  strategy:
-    type: Recreate
   template:
     metadata:
       labels:
         app: {{ include "matrixhub.fullname" . }}-mysql
-        app.kubernetes.io/name: mysql
     spec:
       {{- include "matrixhub.imagePullSecrets" . | nindent 6 }}
       containers:
@@ -97,19 +64,29 @@ spec:
                   key: mysql-root-password
             - name: MYSQL_DATABASE
               value: matrixhub
+            - name: MYSQL_USER
+              value: matrixhub
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "matrixhub.fullname" . }}-mysql-secret
+                  key: mysql-root-password
           ports:
             - containerPort: 3306
               name: mysql
           volumeMounts:
             - name: mysql-persistent-storage
               mountPath: /var/lib/mysql
-            - name: mysql-initdb
-              mountPath: /docker-entrypoint-initdb.d
-      volumes:
-        - name: mysql-persistent-storage
-          persistentVolumeClaim:
-            claimName: {{ include "matrixhub.mysql.pvcName" . }}
-        - name: mysql-initdb
-          configMap:
-            name: {{ include "matrixhub.mysql.initConfigMapName" . }}
+  volumeClaimTemplates:
+    - metadata:
+        name: mysql-persistent-storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.mysql.persistence.size }}
+        {{- if .Values.mysql.persistence.storageClass }}
+        storageClassName: {{ .Values.mysql.persistence.storageClass }}
+        {{- end }}
 {{- end }}

--- a/deploy/charts/matrixhub/templates/mysql.yaml
+++ b/deploy/charts/matrixhub/templates/mysql.yaml
@@ -12,37 +12,6 @@ data:
   mysql-root-password: {{ .Values.mysql.rootPassword | b64enc | quote }}
 ---
 apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ include "matrixhub.mysql.pvcName" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "matrixhub.labels" . | nindent 4 }}
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: {{ .Values.mysql.persistence.size }}
-  {{- if .Values.mysql.persistence.storageClass }}
-  storageClassName: {{ .Values.mysql.persistence.storageClass }}
-  {{- end }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "matrixhub.mysql.initConfigMapName" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "matrixhub.labels" . | nindent 4 }}
-data:
-  initdb.sql: |
-    CREATE DATABASE IF NOT EXISTS matrixhub CHARACTER SET utf8mb4;
-    CREATE USER IF NOT EXISTS 'matrixhub'@'%' IDENTIFIED BY '{{ .Values.mysql.rootPassword }}';
-    GRANT ALL PRIVILEGES ON matrixhub.* TO 'matrixhub'@'%';
-    FLUSH PRIVILEGES;
----
-apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "matrixhub.fullname" . }}-mysql
@@ -59,23 +28,21 @@ spec:
     app: {{ include "matrixhub.fullname" . }}-mysql
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "matrixhub.fullname" . }}-mysql
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "matrixhub.labels" . | nindent 4 }}
 spec:
+  serviceName: {{ include "matrixhub.fullname" . }}-mysql
   selector:
     matchLabels:
       app: {{ include "matrixhub.fullname" . }}-mysql
-  strategy:
-    type: Recreate
   template:
     metadata:
       labels:
         app: {{ include "matrixhub.fullname" . }}-mysql
-        app.kubernetes.io/name: mysql
     spec:
       {{- include "matrixhub.imagePullSecrets" . | nindent 6 }}
       containers:
@@ -97,19 +64,29 @@ spec:
                   key: mysql-root-password
             - name: MYSQL_DATABASE
               value: matrixhub
+            - name: MYSQL_USER
+              value: matrixhub
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "matrixhub.fullname" . }}-mysql-secret
+                  key: mysql-root-password
           ports:
             - containerPort: 3306
               name: mysql
           volumeMounts:
             - name: mysql-persistent-storage
               mountPath: /var/lib/mysql
-            - name: mysql-initdb
-              mountPath: /docker-entrypoint-initdb.d
-      volumes:
-        - name: mysql-persistent-storage
-          persistentVolumeClaim:
-            claimName: {{ include "matrixhub.mysql.pvcName" . }}
-        - name: mysql-initdb
-          configMap:
-            name: {{ include "matrixhub.mysql.initConfigMapName" . }}
+  volumeClaimTemplates:
+    - metadata:
+        name: mysql-persistent-storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.mysql.persistence.size }}
+        {{- if .Values.mysql.persistence.storageClass }}
+        storageClassName: {{ .Values.mysql.persistence.storageClass }}
+        {{- end }}
 {{- end }}

--- a/deploy/charts/matrixhub/templates/secret.yaml
+++ b/deploy/charts/matrixhub/templates/secret.yaml
@@ -7,11 +7,4 @@ metadata:
     {{- include "matrixhub.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- if and .Values.global.storage.apiserver.builtIn .Values.mysql.rootPassword }}
   matrixhub.dsn: {{ include "matrixhub.database.dsn" . | b64enc | quote }}
-  {{- else }}
-  matrixhub.dsn: {{ .Values.apiserver.database.dsn | b64enc | quote }}
-  {{- end }}
-  {{- if and .Values.global.storage.apiserver.builtIn .Values.mysql.rootPassword }}
-  mysql-root-password: {{ .Values.mysql.rootPassword | b64enc | quote }}
-  {{- end }}

--- a/deploy/charts/matrixhub/templates/secret.yaml
+++ b/deploy/charts/matrixhub/templates/secret.yaml
@@ -8,6 +8,3 @@ metadata:
 type: Opaque
 data:
   matrixhub.dsn: {{ include "matrixhub.database.dsn" . | b64enc | quote }}
-  {{- if and .Values.global.storage.apiserver.builtIn (eq .Values.apiserver.database.driver "mysql") (not .Values.apiserver.database.dsn) .Values.mysql.rootPassword }}
-  mysql-root-password: {{ .Values.mysql.rootPassword | b64enc | quote }}
-  {{- end }}


### PR DESCRIPTION
Replace the MySQL Deployment with a StatefulSet that manages its own persistent storage via `volumeClaimTemplates`, removing the separate PVC and initdb ConfigMap. Simplify the database DSN and secret handling by dropping the postgres branch and the builtIn storage conditionals. 


```release-note
refactor(chart): use StatefulSet for MySQL with volumeClaimTemplates
```