### PR TITLE
docs: update maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,27 +1,13 @@
 # Maintainers
 
-This file lists people responsible for the [MatrixHub](https://github.com/matrixhub-ai/matrixhub) project. Governance and decision-making are described in [GOVERNANCE.md](GOVERNANCE.md).
-
-Day-to-day PR review permissions (`/lgtm`, `/approve`) are defined in [OWNERS](OWNERS). This table lists **approvers** (project leadership); keep it aligned with the `approvers` list in `OWNERS`.
-
-## Active maintainers
-
-| Name | GitHub | Email | Organization | Areas |
-|------|--------|-------|--------------|-------|
-| Shiming Zhang | [@wzshiming](https://github.com/wzshiming) | shiming.zhang@daocloud.io | [DaoCloud](https://daocloud.io) | Core platform |
-| Chuanjia Lu | [@samzong](https://github.com/samzong) | samzong.lu@gmail.com | [LangGenius](https://langgenius.ai) | Core platform |
-| Yiting Jiang | [@yitingdc](https://github.com/yitingdc) | yiting.jiang@daocloud.io | [DaoCloud](https://daocloud.io) | Core platform |
-| Henry Liu | [@lsq645599166](https://github.com/lsq645599166) | henry.liu@daocloud.io | [DaoCloud](https://daocloud.io) | Frontend (`ui/`) |
-| Kay Yan | [@yankay](https://github.com/yankay) | kay.yan@daocloud.io | [DaoCloud](https://daocloud.io) | Core platform |
-
-> **How to update:** Open a pull request that updates this table and the `approvers` list in [OWNERS](OWNERS) together. Adding or removing maintainers follows [GOVERNANCE.md](GOVERNANCE.md).
-
-## Emeritus maintainers
-
-None yet.
-
-## Contact
-
-- **General questions:** [GitHub Discussions](https://github.com/matrixhub-ai/matrixhub/discussions) or [issues](https://github.com/matrixhub-ai/matrixhub/issues)
-- **Security issues:** See [SECURITY.md](SECURITY.md) — do not file public issues for vulnerabilities
-- **Community chat:** [CNCF Slack `#matrixhub`](https://cloud-native.slack.com/archives/C0A8UKWR8HG)
+| Name | GitHub | Organization |
+|------|--------|--------------|
+| Shiming Zhang | [@wzshiming](https://github.com/wzshiming) | [DaoCloud](https://daocloud.io) |
+| Chuanjia Lu | [@samzong](https://github.com/samzong) | [LangGenius](https://langgenius.ai) |
+| Yiting Jiang | [@yitingdc](https://github.com/yitingdc) | [DaoCloud](https://daocloud.io) |
+| Henry Liu | [@lsq645599166](https://github.com/lsq645599166) | [DaoCloud](https://daocloud.io) |
+| Kay Yan | [@yankay](https://github.com/yankay) | [DaoCloud](https://daocloud.io) |
+| Tong Zhang | [@setsunakute](https://github.com/setsunakute) | [DaoCloud](https://daocloud.io) |
+| Chenyang Shi | [@scydas](https://github.com/scydas) | [DaoCloud](https://daocloud.io) |
+| Xinyi Sun | [@Phil-OSophy-42](https://github.com/Phil-OSophy-42) | [DaoCloud](https://daocloud.io) |
+| Hai Tang | [@CoderTH](https://github.com/CoderTH) | [xFusion](https://www.xfusion.com) |

--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,10 @@ approvers:
   - yitingdc
   - lsq645599166
   - yankay
+  - setsunakute
+  - scydas
+  - Phil-OSophy-42
+  - CoderTH
 
 # List of usernames who may use /lgtm
 reviewers:


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/kind cleanup

#### What this PR does / why we need it:

Updates `MAINTAINERS.md` with the current MatrixHub maintainer roster and presents it as a concise table of names, GitHub accounts, and organizations.

It also updates the approver list in `OWNERS` to align repository review permissions with the current maintainer roster.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

This PR only changes `MAINTAINERS.md` and `OWNERS`.

#### Checklist

- [x] Tests not needed; documentation and repository ownership metadata only
- [x] Documentation updated

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
