### PR TITLE
fix(ui): enlarge create access token button on profile page

### DIFF
--- a/ui/src/features/profile/components/AccessTokenTable.tsx
+++ b/ui/src/features/profile/components/AccessTokenTable.tsx
@@ -22,9 +22,13 @@ import type {
   MRT_ColumnDef,
   MRT_Row,
 } from 'mantine-react-table'
+import type { ReactNode } from 'react'
 
 interface AccessTokenTableProps {
   tokens: AccessToken[]
+  fetching?: boolean
+  onRefresh?: () => void
+  toolbarExtra?: ReactNode
 }
 
 const StatusCell = ({ row }: { row: MRT_Row<AccessToken> }) => {
@@ -66,7 +70,9 @@ const ActionCell = ({
   )
 }
 
-export function AccessTokenTable({ tokens }: AccessTokenTableProps) {
+export function AccessTokenTable({
+  tokens, fetching, onRefresh, toolbarExtra,
+}: AccessTokenTableProps) {
   const { t } = useTranslation()
   const [deleteOpened, {
     open: openDelete, close: closeDelete,
@@ -124,6 +130,9 @@ export function AccessTokenTable({ tokens }: AccessTokenTableProps) {
       <DataTable
         columns={columns}
         data={tokens}
+        fetching={fetching}
+        onRefresh={onRefresh}
+        toolbarExtra={toolbarExtra}
         enableRowActions
         renderRowActions={ActionCell}
         tableOptions={{

--- a/ui/src/features/profile/pages/AccessTokenPage.tsx
+++ b/ui/src/features/profile/pages/AccessTokenPage.tsx
@@ -1,5 +1,4 @@
 import {
-  ActionIcon,
   Alert,
   Button,
   Flex,
@@ -14,7 +13,6 @@ import { CurrentUser, type CreateAccessTokenRequest } from '@matrixhub/api-ts/v1
 import {
   IconInfoCircle,
   IconKey,
-  IconRefresh,
 } from '@tabler/icons-react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import dayjs from 'dayjs'
@@ -114,26 +112,19 @@ export function AccessTokenPage() {
         </Alert>
       )}
 
-      <Group justify="flex-end" gap={16}>
-        <ActionIcon
-          variant="transparent"
-          loading={isFetching}
-          onClick={handleRefresh}
-          aria-label="refresh"
-          c="gray.6"
-          size="lg"
-        >
-          <IconRefresh size={24} />
-        </ActionIcon>
-        <Button
-          leftSection={<IconKey size={16} />}
-          onClick={openCreate}
-        >
-          {t('profile.createToken')}
-        </Button>
-      </Group>
-
-      <AccessTokenTable tokens={tokens} />
+      <AccessTokenTable
+        tokens={tokens}
+        fetching={isFetching}
+        onRefresh={handleRefresh}
+        toolbarExtra={(
+          <Button
+            leftSection={<IconKey size={16} />}
+            onClick={openCreate}
+          >
+            {t('profile.createToken')}
+          </Button>
+        )}
+      />
 
       <ModalWrapper
         title={t('profile.createToken')}

--- a/ui/src/features/profile/pages/AccessTokenPage.tsx
+++ b/ui/src/features/profile/pages/AccessTokenPage.tsx
@@ -121,14 +121,13 @@ export function AccessTokenPage() {
           onClick={handleRefresh}
           aria-label="refresh"
           c="gray.6"
-          size={24}
+          size="lg"
         >
-          <IconRefresh />
+          <IconRefresh size={24} />
         </ActionIcon>
         <Button
           leftSection={<IconKey size={16} />}
           onClick={openCreate}
-          size="xs"
         >
           {t('profile.createToken')}
         </Button>


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The create-token button on the profile page's access token tab used `size="xs"` (24px tall), noticeably smaller than every other create button in the app (SSH keys, projects, registries, users), which use the theme default `size="sm"` (32px).

This PR aligns the access token page with the rest of the app by moving the refresh and create-token controls into the shared `DataTable` built-in toolbar (`onRefresh` / `fetching` / `toolbarExtra`), the same pattern used by the SSH keys, projects, and registries tables — instead of the hand-rolled `Group` that caused the size drift.

#### Which issue(s) this PR fixes:

Fixes #863

#### Special notes for your reviewer:

No logic change — the refresh and create handlers are unchanged, only rendered through DataTable's toolbar so the button sizes come from the shared theme defaults. Verified with `pnpm typecheck` and `eslint`.

#### Checklist

- [ ] Tests(ut, e2e) added or updated, or not needed and explained — not needed: visual-only toolbar change with no logic involved
- [ ] Docs(tech docs, usage docs) updated, or not needed and explained — not needed

#### Does this PR introduce a user-facing change?

```release-note
Enlarged the create access token button on the profile page to match other create buttons.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)