### PR TITLE
fix(ui): serve favicon so the browser tab shows the MatrixHub icon

### DIFF
--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -489,6 +489,7 @@ func (server *APIServer) registerRoutersAndHandlers() {
 	staticDir := server.config.UI.StaticDir
 	if staticDir != "" {
 		server.engine.Static("/assets", filepath.Join(staticDir, "assets"))
+		server.engine.StaticFile("/favicon.ico", filepath.Join(staticDir, "favicon.ico"))
 	}
 
 	// SPA fallback - serve index.html for all non-API routes

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="/favicon.ico" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## What changed

- Added `<link rel="icon" href="/favicon.ico" />` to `ui/index.html`.
- The apiserver now serves `staticDir/favicon.ico` via `StaticFile` alongside the existing `/assets` static route.

## Why

Fixes #908. The official MatrixHub favicon was already in `ui/public/favicon.ico` (updated in 9e2fd14), but it never reached the browser:

1. `ui/index.html` had no icon link, so browsers fell back to requesting `/favicon.ico`.
2. The apiserver's SPA `NoRoute` fallback returned `index.html` for that path, so the browser got HTML instead of an icon and showed the default globe.

## Notes for reviewers

- No icon asset changes — the existing `favicon.ico` is the approved logo.
- Vite rewrites the root-relative href against `VITE_UI_BASE_PATH`, so non-root deployments stay correct.
- Verified: `go build` passes, `pnpm build` output contains the icon link and `dist/favicon.ico`. Browsers cache favicons aggressively — hard-reload when verifying on a live deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)