### PR TITLE
fix(model): derive parameter count before LFS weights are fetched

### DIFF
--- a/internal/domain/git/git.go
+++ b/internal/domain/git/git.go
@@ -99,7 +99,11 @@ type RepoMetadataFiles struct {
 	ConfigJSON           []byte
 	SafetensorsIndexJSON []byte
 	SafetensorsFiles     map[string][]byte
-	Size                 int64
+	// SafetensorsSizes holds LFS pointer sizes for safetensors files whose
+	// headers could not be read. It lets the model domain fall back to a
+	// size-based estimate instead of reporting no parameter count at all.
+	SafetensorsSizes map[string]int64
+	Size             int64
 }
 
 // OrphanedRepo represents an orphaned Git repository on disk

--- a/internal/domain/model/metadata_analyzer.go
+++ b/internal/domain/model/metadata_analyzer.go
@@ -110,14 +110,16 @@ func AnalyzeRepoMetadata(files *git.RepoMetadataFiles) (*RepoMetadata, error) {
 			metadata.ParameterCount = estimateParameterCount(index.Metadata.TotalSize, parameterBytes)
 		}
 	}
-	if metadata.ParameterCount == 0 && len(files.SafetensorsFiles) > 0 {
-		metadata.ParameterCount = countSafetensorsParameters(files.SafetensorsFiles)
-	}
-	if metadata.ParameterCount == 0 && len(files.SafetensorsSizes) > 0 {
-		// Last resort: the weights themselves were unreachable, so estimate from
-		// the sizes recorded in their LFS pointers. Same arithmetic as the index
-		// path above, just a different source for the total byte count.
-		metadata.ParameterCount = estimateParameterCount(sumSafetensorsSizes(files.SafetensorsSizes), parameterBytes)
+	if metadata.ParameterCount == 0 {
+		// Header scans are exact but only cover files whose weights were readable.
+		// Files that fell back to the size recorded in their LFS pointer are
+		// estimated from that size instead, using the same arithmetic as the index
+		// path above. The two sets are disjoint — the git layer records each file
+		// as one or the other — so counting both is what keeps a partly-fetched
+		// sharded model from reporting only the shards it could read.
+		exact := countSafetensorsParameters(files.SafetensorsFiles)
+		estimated := estimateParameterCount(sumSafetensorsSizes(files.SafetensorsSizes), parameterBytes)
+		metadata.ParameterCount = addParameterCounts(exact, estimated)
 	}
 
 	metadata.Tags = deduplicateClassifiedTags(tags)
@@ -203,6 +205,15 @@ func estimateParameterCount(totalSize, parameterBytes int64) int64 {
 		return 0
 	}
 	return totalSize / parameterBytes
+}
+
+// addParameterCounts adds two parameter counts, returning 0 when either is
+// invalid or the sum would overflow. 0 means "unknown" throughout this file.
+func addParameterCounts(a, b int64) int64 {
+	if a < 0 || b < 0 || a > math.MaxInt64-b {
+		return 0
+	}
+	return a + b
 }
 
 func sumSafetensorsSizes(sizes map[string]int64) int64 {

--- a/internal/domain/model/metadata_analyzer.go
+++ b/internal/domain/model/metadata_analyzer.go
@@ -113,6 +113,12 @@ func AnalyzeRepoMetadata(files *git.RepoMetadataFiles) (*RepoMetadata, error) {
 	if metadata.ParameterCount == 0 && len(files.SafetensorsFiles) > 0 {
 		metadata.ParameterCount = countSafetensorsParameters(files.SafetensorsFiles)
 	}
+	if metadata.ParameterCount == 0 && len(files.SafetensorsSizes) > 0 {
+		// Last resort: the weights themselves were unreachable, so estimate from
+		// the sizes recorded in their LFS pointers. Same arithmetic as the index
+		// path above, just a different source for the total byte count.
+		metadata.ParameterCount = estimateParameterCount(sumSafetensorsSizes(files.SafetensorsSizes), parameterBytes)
+	}
 
 	metadata.Tags = deduplicateClassifiedTags(tags)
 	return metadata, nil
@@ -197,6 +203,17 @@ func estimateParameterCount(totalSize, parameterBytes int64) int64 {
 		return 0
 	}
 	return totalSize / parameterBytes
+}
+
+func sumSafetensorsSizes(sizes map[string]int64) int64 {
+	var total int64
+	for _, size := range sizes {
+		if size <= 0 || size > math.MaxInt64-total {
+			return 0
+		}
+		total += size
+	}
+	return total
 }
 
 func countSafetensorsParameters(files map[string][]byte) int64 {

--- a/internal/domain/model/metadata_analyzer_test.go
+++ b/internal/domain/model/metadata_analyzer_test.go
@@ -115,17 +115,20 @@ func TestAnalyzeRepoMetadataEstimatesFromSafetensorsSizes(t *testing.T) {
 	}
 }
 
-func TestAnalyzeRepoMetadataPrefersHeadersOverSafetensorsSizes(t *testing.T) {
+func TestAnalyzeRepoMetadataCombinesHeadersAndSafetensorsSizes(t *testing.T) {
+	// A partly-fetched sharded model with no index total_size: one shard's header
+	// was readable, the other only yielded its LFS pointer size. Counting just the
+	// readable shard would report a fraction of the real parameter count.
 	files := &git.RepoMetadataFiles{
 		ConfigJSON: []byte(`{"torch_dtype": "bfloat16"}`),
 		SafetensorsFiles: map[string][]byte{
-			"model.safetensors": buildSafetensorsFile(t, map[string][]int64{
+			"model-00001-of-00002.safetensors": buildSafetensorsFile(t, map[string][]int64{
 				"model.embed_tokens.weight": {2, 3},
 				"lm_head.weight":            {4, 5},
 			}),
 		},
 		SafetensorsSizes: map[string]int64{
-			"model.safetensors": 988097824,
+			"model-00002-of-00002.safetensors": 1024,
 		},
 	}
 
@@ -134,9 +137,9 @@ func TestAnalyzeRepoMetadataPrefersHeadersOverSafetensorsSizes(t *testing.T) {
 		t.Fatalf("AnalyzeRepoMetadata() error = %v", err)
 	}
 
-	// The exact header scan wins; the pointer-size estimate is only a fallback.
-	if metadata.ParameterCount != 26 {
-		t.Fatalf("ParameterCount = %d, want 26", metadata.ParameterCount)
+	// 26 exact from the header, plus 1024 bytes of bfloat16 weights.
+	if metadata.ParameterCount != 26+512 {
+		t.Fatalf("ParameterCount = %d, want %d", metadata.ParameterCount, 26+512)
 	}
 }
 

--- a/internal/domain/model/metadata_analyzer_test.go
+++ b/internal/domain/model/metadata_analyzer_test.go
@@ -95,6 +95,51 @@ func TestAnalyzeRepoMetadataPrefersSafetensorsIndexTotalSize(t *testing.T) {
 	}
 }
 
+func TestAnalyzeRepoMetadataEstimatesFromSafetensorsSizes(t *testing.T) {
+	// No index and no readable header: all that is left is the size recorded in
+	// the LFS pointer. Sizes are Qwen2.5-0.5B's, whose real count is 494032768.
+	files := &git.RepoMetadataFiles{
+		ConfigJSON: []byte(`{"torch_dtype": "bfloat16"}`),
+		SafetensorsSizes: map[string]int64{
+			"model.safetensors": 988097824,
+		},
+	}
+
+	metadata, err := AnalyzeRepoMetadata(files)
+	if err != nil {
+		t.Fatalf("AnalyzeRepoMetadata() error = %v", err)
+	}
+
+	if metadata.ParameterCount != 494048912 {
+		t.Fatalf("ParameterCount = %d, want 494048912", metadata.ParameterCount)
+	}
+}
+
+func TestAnalyzeRepoMetadataPrefersHeadersOverSafetensorsSizes(t *testing.T) {
+	files := &git.RepoMetadataFiles{
+		ConfigJSON: []byte(`{"torch_dtype": "bfloat16"}`),
+		SafetensorsFiles: map[string][]byte{
+			"model.safetensors": buildSafetensorsFile(t, map[string][]int64{
+				"model.embed_tokens.weight": {2, 3},
+				"lm_head.weight":            {4, 5},
+			}),
+		},
+		SafetensorsSizes: map[string]int64{
+			"model.safetensors": 988097824,
+		},
+	}
+
+	metadata, err := AnalyzeRepoMetadata(files)
+	if err != nil {
+		t.Fatalf("AnalyzeRepoMetadata() error = %v", err)
+	}
+
+	// The exact header scan wins; the pointer-size estimate is only a fallback.
+	if metadata.ParameterCount != 26 {
+		t.Fatalf("ParameterCount = %d, want 26", metadata.ParameterCount)
+	}
+}
+
 func buildSafetensorsFile(t *testing.T, tensors map[string][]int64) []byte {
 	t.Helper()
 

--- a/internal/repo/git_repo.go
+++ b/internal/repo/git_repo.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	stdpath "path"
 	"strings"
+	"sync"
+	"time"
 
 	hfdlfs "github.com/matrixhub-ai/hfd/pkg/lfs"
 	"github.com/matrixhub-ai/hfd/pkg/mirror"
@@ -40,7 +42,16 @@ type gitRepo struct {
 
 const maxSafetensorsHeaderBytes uint64 = 64 * 1024 * 1024
 
+// safetensorsHeaderReadTimeout bounds a single safetensors header read. A read
+// served by the mirror tee cache blocks until the upstream download reaches the
+// header bytes, so metadata extraction must not wait on it indefinitely: it runs
+// inline on the proxy sync path that git and Hugging Face clients wait for.
+const safetensorsHeaderReadTimeout = 10 * time.Second
+
 type safetensorsIndexFiles struct {
+	Metadata struct {
+		TotalSize int64 `json:"total_size"`
+	} `json:"metadata"`
 	WeightMap map[string]string `json:"weight_map"`
 }
 
@@ -528,31 +539,105 @@ func (g *gitRepo) openBlobContent(repo *repository.Repository, rev, path string)
 		return nil, err
 	}
 
-	if ptr, err := blob.LFSPointer(); err == nil && ptr != nil {
-		store := hfdlfs.NewLocal(g.storage.LFSDir())
-		getter, ok := store.(hfdlfs.Getter)
-		if !ok {
-			return nil, fmt.Errorf("lfs storage does not support reads")
-		}
-		rc, _, err := getter.Get(ptr.OID())
-		return rc, err
+	ptr, err := blob.LFSPointer()
+	if err != nil || ptr == nil {
+		return blob.NewReader()
 	}
 
-	return blob.NewReader()
+	store := hfdlfs.NewLocal(g.storage.LFSDir())
+	if getter, ok := store.(hfdlfs.Getter); ok {
+		if rc, _, err := getter.Get(ptr.OID()); err == nil {
+			return rc, nil
+		}
+	}
+
+	// The object is not on disk yet. On proxy repositories PullFromRemote only
+	// queues LFS objects for background fetching, so fall back to the mirror tee
+	// cache, which serves in-flight content while the download is still running.
+	// Callers that only need a file prefix, such as a safetensors header, do not
+	// have to wait for the whole object.
+	if g.mirror != nil {
+		if b := g.mirror.Get(ptr.OID()); b != nil {
+			return b.NewReadSeeker(), nil
+		}
+	}
+
+	return nil, fmt.Errorf("lfs object %s is not available locally", ptr.OID())
 }
 
-func (g *gitRepo) readSafetensorsHeader(repo *repository.Repository, rev, path string) ([]byte, error) {
+// collectSafetensorsFile records the header of a safetensors file, falling back
+// to the size recorded in its LFS pointer when the header cannot be read. The
+// fallback keeps a parameter count derivable for proxy repositories whose
+// weights have not been fetched yet.
+func (g *gitRepo) collectSafetensorsFile(ctx context.Context, repo *repository.Repository, rev, path string, metadata *git.RepoMetadataFiles) {
+	if header, err := g.readSafetensorsHeader(ctx, repo, rev, path); err == nil {
+		metadata.SafetensorsFiles[path] = header
+		return
+	}
+	if size, ok := lfsPointerSize(repo, rev, path); ok {
+		metadata.SafetensorsSizes[path] = size
+	}
+}
+
+// lfsPointerSize returns the object size recorded in the file's LFS pointer.
+// The pointer is a regular git blob, so this stays cheap even when the object
+// content itself has not been fetched.
+func lfsPointerSize(repo *repository.Repository, rev, path string) (int64, bool) {
+	blob, err := repo.Blob(rev, path)
+	if err != nil {
+		return 0, false
+	}
+	ptr, err := blob.LFSPointer()
+	if err != nil || ptr == nil {
+		return 0, false
+	}
+	size := ptr.Size()
+	if size <= 0 {
+		return 0, false
+	}
+	return size, true
+}
+
+func (g *gitRepo) readSafetensorsHeader(ctx context.Context, repo *repository.Repository, rev, path string) ([]byte, error) {
 	rc, err := g.openBlobContent(repo, rev, path)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = rc.Close()
+
+	var closeOnce sync.Once
+	closeReader := func() {
+		closeOnce.Do(func() {
+			_ = rc.Close()
+		})
+	}
+	defer closeReader()
+
+	ctx, cancel := context.WithTimeout(ctx, safetensorsHeaderReadTimeout)
+	defer cancel()
+
+	// A tee cache reader blocks until the upstream download produces the bytes
+	// and does not observe ctx on its own, so closing it is what unblocks a read
+	// that is waiting on a stalled download.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			closeReader()
+		case <-done:
+		}
 	}()
+
+	readErr := func(err error) error {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("read safetensors header %s: %w", path, ctxErr)
+		}
+		return err
+	}
 
 	var lengthPrefix [8]byte
 	if _, err := io.ReadFull(rc, lengthPrefix[:]); err != nil {
-		return nil, err
+		return nil, readErr(err)
 	}
 
 	headerLength := binary.LittleEndian.Uint64(lengthPrefix[:])
@@ -563,9 +648,19 @@ func (g *gitRepo) readSafetensorsHeader(repo *repository.Repository, rev, path s
 	content := make([]byte, 8+int(headerLength))
 	copy(content[:8], lengthPrefix[:])
 	if _, err := io.ReadFull(rc, content[8:]); err != nil {
-		return nil, err
+		return nil, readErr(err)
 	}
 	return content, nil
+}
+
+// indexTotalSize returns the metadata.total_size recorded in a safetensors
+// index, or 0 when the index does not carry one.
+func indexTotalSize(indexJSON []byte) int64 {
+	var index safetensorsIndexFiles
+	if err := json.Unmarshal(indexJSON, &index); err != nil {
+		return 0
+	}
+	return index.Metadata.TotalSize
 }
 
 func loadSafetensorsPathsFromIndex(indexJSON []byte) []string {
@@ -622,7 +717,10 @@ func (g *gitRepo) PushToRemote(ctx context.Context, gitRepository *git.GitReposi
 
 // ExtractMetadata reads raw metadata-related files from a Git repository.
 func (g *gitRepo) ExtractMetadata(ctx context.Context, repoType, project, name string) (*git.RepoMetadataFiles, error) {
-	metadata := &git.RepoMetadataFiles{SafetensorsFiles: make(map[string][]byte)}
+	metadata := &git.RepoMetadataFiles{
+		SafetensorsFiles: make(map[string][]byte),
+		SafetensorsSizes: make(map[string]int64),
+	}
 
 	// Open Git repository
 	gitPath := g.gitPath(repoType, project, name)
@@ -646,13 +744,17 @@ func (g *gitRepo) ExtractMetadata(ctx context.Context, repoType, project, name s
 	// Read model.safetensors.index.json raw content
 	if content, err := g.readBlobBytes(repo, rev, "model.safetensors.index.json"); err == nil {
 		metadata.SafetensorsIndexJSON = content
-		for _, path := range loadSafetensorsPathsFromIndex(content) {
-			if header, err := g.readSafetensorsHeader(repo, rev, path); err == nil {
-				metadata.SafetensorsFiles[path] = header
+		// An index that carries metadata.total_size is enough on its own, and the
+		// model domain prefers it over scanning shards. Reading shard headers
+		// anyway would promote every shard to a foreground LFS download to
+		// produce a result that is never used.
+		if indexTotalSize(content) <= 0 {
+			for _, path := range loadSafetensorsPathsFromIndex(content) {
+				g.collectSafetensorsFile(ctx, repo, rev, path, metadata)
 			}
 		}
-	} else if header, err := g.readSafetensorsHeader(repo, rev, "model.safetensors"); err == nil {
-		metadata.SafetensorsFiles["model.safetensors"] = header
+	} else {
+		g.collectSafetensorsFile(ctx, repo, rev, "model.safetensors", metadata)
 	}
 
 	// Compute model content size from the default branch tree. DiskUsage

--- a/internal/repo/git_repo.go
+++ b/internal/repo/git_repo.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	stdpath "path"
 	"strings"
-	"sync"
 	"time"
 
 	hfdlfs "github.com/matrixhub-ai/hfd/pkg/lfs"
@@ -42,11 +41,13 @@ type gitRepo struct {
 
 const maxSafetensorsHeaderBytes uint64 = 64 * 1024 * 1024
 
-// safetensorsHeaderReadTimeout bounds a single safetensors header read. A read
+// safetensorsHeaderReadBudget bounds the time one metadata extraction may spend
+// reading safetensors headers, across all files rather than per file. A read
 // served by the mirror tee cache blocks until the upstream download reaches the
-// header bytes, so metadata extraction must not wait on it indefinitely: it runs
-// inline on the proxy sync path that git and Hugging Face clients wait for.
-const safetensorsHeaderReadTimeout = 10 * time.Second
+// header bytes, so extraction must not wait on it indefinitely: it runs inline on
+// the proxy sync path that git and Hugging Face clients wait for. A shared budget
+// also keeps a sharded model from multiplying the wait by its shard count.
+const safetensorsHeaderReadBudget = 10 * time.Second
 
 type safetensorsIndexFiles struct {
 	Metadata struct {
@@ -569,10 +570,16 @@ func (g *gitRepo) openBlobContent(repo *repository.Repository, rev, path string)
 // to the size recorded in its LFS pointer when the header cannot be read. The
 // fallback keeps a parameter count derivable for proxy repositories whose
 // weights have not been fetched yet.
+//
+// Once the read budget is spent the header read is skipped entirely: opening a
+// tee cache blob promotes it to a foreground download, which is not worth paying
+// for a read that is about to time out anyway.
 func (g *gitRepo) collectSafetensorsFile(ctx context.Context, repo *repository.Repository, rev, path string, metadata *git.RepoMetadataFiles) {
-	if header, err := g.readSafetensorsHeader(ctx, repo, rev, path); err == nil {
-		metadata.SafetensorsFiles[path] = header
-		return
+	if ctx.Err() == nil {
+		if header, err := g.readSafetensorsHeader(ctx, repo, rev, path); err == nil {
+			metadata.SafetensorsFiles[path] = header
+			return
+		}
 	}
 	if size, ok := lfsPointerSize(repo, rev, path); ok {
 		metadata.SafetensorsSizes[path] = size
@@ -598,46 +605,43 @@ func lfsPointerSize(repo *repository.Repository, rev, path string) (int64, bool)
 	return size, true
 }
 
+type safetensorsHeaderResult struct {
+	header []byte
+	err    error
+}
+
+// readSafetensorsHeader reads the header of a safetensors file, giving up when ctx
+// is done. A tee cache reader blocks until the upstream download produces the
+// bytes and observes neither ctx nor Close, so the read runs on its own goroutine
+// and is abandoned rather than cancelled. That goroutine owns rc and closes it
+// when the read returns, which happens at the latest when the download ends.
 func (g *gitRepo) readSafetensorsHeader(ctx context.Context, repo *repository.Repository, rev, path string) ([]byte, error) {
 	rc, err := g.openBlobContent(repo, rev, path)
 	if err != nil {
 		return nil, err
 	}
 
-	var closeOnce sync.Once
-	closeReader := func() {
-		closeOnce.Do(func() {
-			_ = rc.Close()
-		})
-	}
-	defer closeReader()
-
-	ctx, cancel := context.WithTimeout(ctx, safetensorsHeaderReadTimeout)
-	defer cancel()
-
-	// A tee cache reader blocks until the upstream download produces the bytes
-	// and does not observe ctx on its own, so closing it is what unblocks a read
-	// that is waiting on a stalled download.
-	done := make(chan struct{})
-	defer close(done)
+	result := make(chan safetensorsHeaderResult, 1)
 	go func() {
-		select {
-		case <-ctx.Done():
-			closeReader()
-		case <-done:
-		}
+		defer func() {
+			_ = rc.Close()
+		}()
+		header, err := readSafetensorsHeaderFrom(rc)
+		result <- safetensorsHeaderResult{header: header, err: err}
 	}()
 
-	readErr := func(err error) error {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return fmt.Errorf("read safetensors header %s: %w", path, ctxErr)
-		}
-		return err
+	select {
+	case res := <-result:
+		return res.header, res.err
+	case <-ctx.Done():
+		return nil, fmt.Errorf("read safetensors header %s: %w", path, ctx.Err())
 	}
+}
 
+func readSafetensorsHeaderFrom(r io.Reader) ([]byte, error) {
 	var lengthPrefix [8]byte
-	if _, err := io.ReadFull(rc, lengthPrefix[:]); err != nil {
-		return nil, readErr(err)
+	if _, err := io.ReadFull(r, lengthPrefix[:]); err != nil {
+		return nil, err
 	}
 
 	headerLength := binary.LittleEndian.Uint64(lengthPrefix[:])
@@ -647,28 +651,23 @@ func (g *gitRepo) readSafetensorsHeader(ctx context.Context, repo *repository.Re
 
 	content := make([]byte, 8+int(headerLength))
 	copy(content[:8], lengthPrefix[:])
-	if _, err := io.ReadFull(rc, content[8:]); err != nil {
-		return nil, readErr(err)
+	if _, err := io.ReadFull(r, content[8:]); err != nil {
+		return nil, err
 	}
 	return content, nil
 }
 
-// indexTotalSize returns the metadata.total_size recorded in a safetensors
-// index, or 0 when the index does not carry one.
-func indexTotalSize(indexJSON []byte) int64 {
+// parseSafetensorsIndex decodes a safetensors index, returning the zero value
+// when the JSON cannot be read.
+func parseSafetensorsIndex(indexJSON []byte) safetensorsIndexFiles {
 	var index safetensorsIndexFiles
 	if err := json.Unmarshal(indexJSON, &index); err != nil {
-		return 0
+		return safetensorsIndexFiles{}
 	}
-	return index.Metadata.TotalSize
+	return index
 }
 
-func loadSafetensorsPathsFromIndex(indexJSON []byte) []string {
-	var index safetensorsIndexFiles
-	if err := json.Unmarshal(indexJSON, &index); err != nil {
-		return nil
-	}
-
+func (index safetensorsIndexFiles) safetensorsPaths() []string {
 	seen := make(map[string]struct{})
 	paths := make([]string, 0, len(index.WeightMap))
 	for _, path := range index.WeightMap {
@@ -741,6 +740,11 @@ func (g *gitRepo) ExtractMetadata(ctx context.Context, repoType, project, name s
 		metadata.ConfigJSON = content
 	}
 
+	// Header reads share one deadline: they can block on an upstream download, and
+	// this runs inline on the sync path that git and Hugging Face clients wait for.
+	headerCtx, cancelHeaderReads := context.WithTimeout(ctx, safetensorsHeaderReadBudget)
+	defer cancelHeaderReads()
+
 	// Read model.safetensors.index.json raw content
 	if content, err := g.readBlobBytes(repo, rev, "model.safetensors.index.json"); err == nil {
 		metadata.SafetensorsIndexJSON = content
@@ -748,13 +752,13 @@ func (g *gitRepo) ExtractMetadata(ctx context.Context, repoType, project, name s
 		// model domain prefers it over scanning shards. Reading shard headers
 		// anyway would promote every shard to a foreground LFS download to
 		// produce a result that is never used.
-		if indexTotalSize(content) <= 0 {
-			for _, path := range loadSafetensorsPathsFromIndex(content) {
-				g.collectSafetensorsFile(ctx, repo, rev, path, metadata)
+		if index := parseSafetensorsIndex(content); index.Metadata.TotalSize <= 0 {
+			for _, path := range index.safetensorsPaths() {
+				g.collectSafetensorsFile(headerCtx, repo, rev, path, metadata)
 			}
 		}
 	} else {
-		g.collectSafetensorsFile(ctx, repo, rev, "model.safetensors", metadata)
+		g.collectSafetensorsFile(headerCtx, repo, rev, "model.safetensors", metadata)
 	}
 
 	// Compute model content size from the default branch tree. DiskUsage

--- a/internal/repo/git_repo_metadata_test.go
+++ b/internal/repo/git_repo_metadata_test.go
@@ -119,6 +119,41 @@ func TestExtractMetadataReadsSingleSafetensorsHeader(t *testing.T) {
 	}
 }
 
+func TestCollectSafetensorsFileSkipsReadWhenBudgetSpent(t *testing.T) {
+	ctx := context.Background()
+	store := hfdstorage.NewStorage(hfdstorage.WithRootDir(t.TempDir()))
+	repo := initRepoTestRepository(t, ctx, store)
+
+	lfsPointer := []byte("version https://git-lfs.github.com/spec/v1\n" +
+		"oid sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n" +
+		"size 1024\n")
+
+	if _, err := repo.CreateCommit(ctx, "main", "add model", "Test", "test@example.com", []repository.CommitOperation{
+		{Type: repository.CommitOperationAdd, Path: "model.safetensors", Content: lfsPointer},
+	}, ""); err != nil {
+		t.Fatalf("CreateCommit() error = %v", err)
+	}
+
+	// A spent budget means an earlier read already blocked on an upstream
+	// download. Opening another tee cache blob would promote it to a foreground
+	// download for a read that cannot finish, so only the pointer size is taken.
+	spentCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	metadata := &git.RepoMetadataFiles{
+		SafetensorsFiles: make(map[string][]byte),
+		SafetensorsSizes: make(map[string]int64),
+	}
+	NewGitDB(store, nil).(*gitRepo).collectSafetensorsFile(spentCtx, repo, "main", "model.safetensors", metadata)
+
+	if len(metadata.SafetensorsFiles) != 0 {
+		t.Fatalf("SafetensorsFiles = %v, want no header read", metadata.SafetensorsFiles)
+	}
+	if got := metadata.SafetensorsSizes["model.safetensors"]; got != 1024 {
+		t.Fatalf("SafetensorsSizes[model.safetensors] = %d, want 1024", got)
+	}
+}
+
 func TestExtractMetadataFallsBackToLFSPointerSize(t *testing.T) {
 	ctx := context.Background()
 	store := hfdstorage.NewStorage(hfdstorage.WithRootDir(t.TempDir()))

--- a/internal/repo/git_repo_metadata_test.go
+++ b/internal/repo/git_repo_metadata_test.go
@@ -119,6 +119,110 @@ func TestExtractMetadataReadsSingleSafetensorsHeader(t *testing.T) {
 	}
 }
 
+func TestExtractMetadataFallsBackToLFSPointerSize(t *testing.T) {
+	ctx := context.Background()
+	store := hfdstorage.NewStorage(hfdstorage.WithRootDir(t.TempDir()))
+	repo := initRepoTestRepository(t, ctx, store)
+
+	// The pointer stands in for a proxied repository whose weights have not been
+	// fetched yet: the blob is a pointer, and no LFS object exists on disk.
+	lfsPointer := []byte("version https://git-lfs.github.com/spec/v1\n" +
+		"oid sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n" +
+		"size 1024\n")
+
+	if _, err := repo.CreateCommit(ctx, "main", "add model", "Test", "test@example.com", []repository.CommitOperation{
+		{Type: repository.CommitOperationAdd, Path: "config.json", Content: []byte(`{"torch_dtype":"bfloat16"}`)},
+		{Type: repository.CommitOperationAdd, Path: "model.safetensors", Content: lfsPointer},
+	}, ""); err != nil {
+		t.Fatalf("CreateCommit() error = %v", err)
+	}
+
+	files, err := NewGitDB(store, nil).ExtractMetadata(ctx, "models", "test-project", "test-model")
+	if err != nil {
+		t.Fatalf("ExtractMetadata() error = %v", err)
+	}
+
+	if len(files.SafetensorsFiles) != 0 {
+		t.Fatalf("SafetensorsFiles = %v, want no readable headers", files.SafetensorsFiles)
+	}
+	if got := files.SafetensorsSizes["model.safetensors"]; got != 1024 {
+		t.Fatalf("SafetensorsSizes[model.safetensors] = %d, want 1024", got)
+	}
+
+	metadata, err := modeldomain.AnalyzeRepoMetadata(files)
+	if err != nil {
+		t.Fatalf("AnalyzeRepoMetadata() error = %v", err)
+	}
+	// 1024 bytes of bfloat16 weights.
+	if metadata.ParameterCount != 512 {
+		t.Fatalf("ParameterCount = %d, want 512", metadata.ParameterCount)
+	}
+}
+
+func TestExtractMetadataSkipsShardHeadersWhenIndexHasTotalSize(t *testing.T) {
+	ctx := context.Background()
+	store := hfdstorage.NewStorage(hfdstorage.WithRootDir(t.TempDir()))
+	repo := initRepoTestRepository(t, ctx, store)
+
+	index, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{"total_size": 2048},
+		"weight_map": map[string]string{
+			"model.embed_tokens.weight": "model-00001-of-00002.safetensors",
+			"lm_head.weight":            "model-00002-of-00002.safetensors",
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	shard := buildRepoTestSafetensorsFile(t, map[string][]int64{"lm_head.weight": {4, 5}}, 1024)
+	if _, err := repo.CreateCommit(ctx, "main", "add sharded model", "Test", "test@example.com", []repository.CommitOperation{
+		{Type: repository.CommitOperationAdd, Path: "config.json", Content: []byte(`{"torch_dtype":"bfloat16"}`)},
+		{Type: repository.CommitOperationAdd, Path: "model.safetensors.index.json", Content: index},
+		{Type: repository.CommitOperationAdd, Path: "model-00001-of-00002.safetensors", Content: shard},
+		{Type: repository.CommitOperationAdd, Path: "model-00002-of-00002.safetensors", Content: shard},
+	}, ""); err != nil {
+		t.Fatalf("CreateCommit() error = %v", err)
+	}
+
+	files, err := NewGitDB(store, nil).ExtractMetadata(ctx, "models", "test-project", "test-model")
+	if err != nil {
+		t.Fatalf("ExtractMetadata() error = %v", err)
+	}
+
+	// total_size alone answers the question, so no shard may be opened. Reading
+	// them would promote every shard to a foreground LFS download on proxy repos.
+	if len(files.SafetensorsFiles) != 0 {
+		t.Fatalf("SafetensorsFiles = %v, want no shard headers read", files.SafetensorsFiles)
+	}
+	if len(files.SafetensorsSizes) != 0 {
+		t.Fatalf("SafetensorsSizes = %v, want no shard sizes recorded", files.SafetensorsSizes)
+	}
+
+	metadata, err := modeldomain.AnalyzeRepoMetadata(files)
+	if err != nil {
+		t.Fatalf("AnalyzeRepoMetadata() error = %v", err)
+	}
+	// 2048 bytes of bfloat16 weights.
+	if metadata.ParameterCount != 1024 {
+		t.Fatalf("ParameterCount = %d, want 1024", metadata.ParameterCount)
+	}
+}
+
+func initRepoTestRepository(t *testing.T, ctx context.Context, store *hfdstorage.Storage) *repository.Repository {
+	t.Helper()
+
+	repoPath := store.ResolvePath("test-project/test-model")
+	if err := os.MkdirAll(filepath.Dir(repoPath), 0750); err != nil {
+		t.Fatalf("os.MkdirAll() error = %v", err)
+	}
+	repo, err := repository.Init(ctx, repoPath, "main")
+	if err != nil {
+		t.Fatalf("repository.Init() error = %v", err)
+	}
+	return repo
+}
+
 func buildRepoTestSafetensorsFile(t *testing.T, tensors map[string][]int64, payloadSize int) []byte {
 	t.Helper()
 


### PR DESCRIPTION
## Problem

fix https://github.com/matrixhub-ai/matrixhub/issues/909

Proxied single-file safetensors models report `parameterCount: 0` indefinitely. Reproduced on `Qwen2.5-0.5B`, whose real count is 494,032,768.

## Root cause

On a proxy project, `CheckOrSyncFromRemote` runs `PullFromRemote` and then calls `SyncMetadata` inline. But `PullFromRemote` only *queues* LFS objects — hfd's `teeCache.Queue` documents that "No HTTP calls or downloads are started; actual fetching is deferred". So when `SyncMetadata` runs milliseconds later:

- `README.md` / `config.json` are plain git blobs → read fine (labels and cardData were always correct)
- `model.safetensors` is an LFS pointer → the object is not on disk yet, `os.Open` fails, the header cannot be read

Sharded models are unaffected: they carry `model.safetensors.index.json`, a plain git blob whose `metadata.total_size` answers the question without touching LFS. Only single-file models (roughly, under 5GB) fall through to the header scan and end up at 0.

Nothing ever recomputes afterwards. The background worker eventually fetches the object, but no mechanism revisits the metadata, and the UI's `GetModel` reads straight from the DB without triggering a sync — so the value stays 0 until some git/hf/ssh access happens to re-run `SyncMetadata`.

## Changes

**Read the header before the object lands.** `openBlobContent` falls back to the mirror tee cache when the LFS object is not on disk. `Blob.NewReadSeeker` serves in-flight content, and a safetensors header sits at the very start of the file, so this returns as soon as the download begins — no waiting for the full object.

**Bound the wait, and make the bound work.** Header reads share a single 10s budget per extraction, because this runs inline on the path git and Hugging Face clients wait for. A tee cache reader blocks on the upstream download and observes neither `ctx` nor `Close`: `ioswmr`'s reader `Close` only unregisters its notify channel without closing it, which also means a closed reader can no longer be woken by the download finishing. So the read runs on its own goroutine and is *abandoned* on timeout rather than cancelled; the goroutine owns the reader and closes it when the read returns, which happens at the latest when the download ends. A spent budget also skips further header reads entirely — opening a tee cache blob promotes it to a foreground download, which is not worth paying for a read that is about to time out.

**Don't read what isn't used.** `ExtractMetadata` skips shard headers when the index already carries `total_size`. Previously it read them unconditionally even though the analyzer never used them — harmless before, but with the tee cache fallback it would promote every shard to a foreground download for a result that is discarded.

**Estimate from pointer sizes when the weights are unreachable.** `RepoMetadataFiles` gains `SafetensorsSizes`, recorded from the LFS pointer (a plain git blob, so it is cheap) for every safetensors file whose header could not be read. `AnalyzeRepoMetadata` turns those sizes into a count using the same arithmetic as the index path. For `Qwen2.5-0.5B`: `988097824 / 2 = 494,048,912`, within 0.003% of exact.

Exact header counts and pointer-size estimates **add up** rather than the first non-zero result winning. The two sets are disjoint — the git layer records each file as one or the other — so a partly-fetched sharded model with no index `total_size` reports its full count instead of only the shards it could read.

Priority is unchanged where it already worked: index `total_size` → header scan (+ pointer-size estimate for any file left unread).

No changes to hfd, the API, the DB schema, or the `IGitRepo` interface.

## Tests

- `TestExtractMetadataFallsBackToLFSPointerSize` — pointer present, object absent → size recorded, estimate produced
- `TestExtractMetadataSkipsShardHeadersWhenIndexHasTotalSize` — no shard is opened when `total_size` is available
- `TestCollectSafetensorsFileSkipsReadWhenBudgetSpent` — a spent budget takes the pointer size instead of opening the blob
- `TestAnalyzeRepoMetadataEstimatesFromSafetensorsSizes` — the fallback produces a count
- `TestAnalyzeRepoMetadataCombinesHeadersAndSafetensorsSizes` — a partly-fetched sharded model sums both sources

`go build ./...`, `go vet`, `go test -race` on the touched packages, and `golangci-lint` are clean. The full suite has 8 failing packages (`internal/apiserver/handler/hf` and the `test/e2e_apiserver/*` set), but the failing set is byte-identical on `upstream/main` and unrelated to this change.

The tee cache branch itself is not unit-tested — reaching it needs a live mirror with an upstream LFS endpoint. It was verified manually against a proxy deployment: triggering a re-sync on a model stuck at 0 produced the exact 494,032,768.

## Note

This does not backfill existing rows. Models already stored at 0 need one git/hf/ssh access to re-run `SyncMetadata`; the UI path alone will not do it.
