### PR TITLE
fix: record manually triggered sync tasks as manual

### DIFF
--- a/internal/domain/syncpolicy/sync_policy_service.go
+++ b/internal/domain/syncpolicy/sync_policy_service.go
@@ -180,10 +180,12 @@ func (sps *SyncPolicyService) CreatePendingSyncTask(ctx context.Context, policyI
 }
 
 // CreateSyncTaskAsync creates a pending sync task for async processing by syncTaskProcessor.
+// It only serves the user-initiated "sync now" API, so the task is always recorded as
+// manually triggered, regardless of the trigger type configured on the policy.
 func (sps *SyncPolicyService) CreateSyncTaskAsync(ctx context.Context, policy *SyncPolicy) (*SyncTask, error) {
 	task := &SyncTask{
 		SyncPolicyID: policy.ID,
-		TriggerType:  policy.TriggerType,
+		TriggerType:  TriggerTypeManual,
 		Status:       SyncTaskStatusPending,
 	}
 	return sps.syncTaskRepo.CreateSyncTask(ctx, task)

--- a/internal/domain/syncpolicy/sync_policy_service_test.go
+++ b/internal/domain/syncpolicy/sync_policy_service_test.go
@@ -129,3 +129,33 @@ func TestSyncPolicyService_ClaimDueSyncPolicies(t *testing.T) {
 		require.Nil(t, jobs)
 	})
 }
+
+func TestSyncPolicyService_CreateSyncTaskAsync(t *testing.T) {
+	ctx := context.Background()
+
+	// A user-initiated sync must be recorded as manually triggered even when the
+	// policy itself is configured to run on a schedule.
+	t.Run("task on a scheduled policy is recorded as manually triggered", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		taskRepo := mocks.NewMockISyncTaskRepo(ctrl)
+
+		taskRepo.EXPECT().
+			CreateSyncTask(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, task *syncpolicy.SyncTask) (*syncpolicy.SyncTask, error) {
+				require.Equal(t, syncpolicy.TriggerTypeManual, task.TriggerType)
+				require.Equal(t, syncpolicy.SyncTaskStatusPending, task.Status)
+				require.Equal(t, 7, task.SyncPolicyID)
+				return task, nil
+			})
+
+		svc := syncpolicy.NewSyncPolicyService(nil, taskRepo, nil, nil, nil)
+		task, err := svc.CreateSyncTaskAsync(ctx, &syncpolicy.SyncPolicy{
+			ID:          7,
+			TriggerType: syncpolicy.TriggerTypeScheduled,
+			Cron:        "0 * * * *",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, syncpolicy.TriggerTypeManual, task.TriggerType)
+	})
+}


### PR DESCRIPTION
## What

A manually triggered replication sync was recorded with the policy's configured trigger type instead of `Manual`, so the executions list showed **Scheduled** for runs the user started by clicking **Sync**.

## Root cause

`CreateSyncTaskAsync` is reached only from the user-initiated `SyncPolicy/CreateSyncTask` RPC, but it copied `policy.TriggerType` onto the new task row:

```go
task := &SyncTask{
    SyncPolicyID: policy.ID,
    TriggerType:  policy.TriggerType, // scheduled policy => task stamped scheduled
    Status:       SyncTaskStatusPending,
}
```

`policy.TriggerType` describes how the policy is scheduled, not who started a given run. The bug only surfaced when the policy was configured as scheduled — for a manual policy the copied value happened to be correct.

Scheduled runs never reach this function: they go through `CreatePendingSyncTask`, whose trigger type comes from the cron scheduler, so they are unaffected.

The UI simply renders `task.triggerType`, so no frontend change is needed.

## Change

- Stamp `TriggerTypeManual` in `CreateSyncTaskAsync`.
- Add a regression test: a scheduled policy synced through this path must produce a task with `TriggerTypeManual`.

## Testing

```
go test ./internal/domain/syncpolicy/... ./internal/jobserver/...
ok  github.com/matrixhub-ai/matrixhub/internal/domain/syncpolicy
ok  github.com/matrixhub-ai/matrixhub/internal/jobserver/processor
```

Reverting the one-line fix makes the new test fail, confirming it covers the reported behavior.

Fixes #656

#### Does this PR introduce a user-facing, API-facing, or operator-facing change?

```release-note
Manually triggered replication runs are now recorded and displayed with the Manual trigger type, even when the policy is scheduled.
```