### PR TITLE
docs(blog): drop invalid container-start-to-Ready metric

### DIFF
--- a/website/blog/2026-07-29-llmd-qwen3-32b-matrixhub-cache.md
+++ b/website/blog/2026-07-29-llmd-qwen3-32b-matrixhub-cache.md
@@ -116,7 +116,6 @@ And the corresponding `metrics.md`:
 The runner records:
 
 - time from manifest application to Pod creation;
-- time from container start to Pod Ready as the closest model-loading interval;
 - time to Pod Ready;
 - total Deployment rollout time;
 - inference verification through the EPP Service;
@@ -149,10 +148,10 @@ The following results come from one actual execution. Each scenario ran three ti
 
 Values below are averages over three runs per scenario.
 
-| Source | Pod created (s) | Weight download (s) | Download rate (MB/s) | Container start to Ready (s) | Pod Ready (s) | Rollout completed (s) | Inference |
-|---|---:|---:|---:|---:|---:|---:|---|
-| Hugging Face direct | 1 | 521.4 | 118.9 | 738 | 722 | 751 | passed |
-| MatrixHub cache hit | 1 | 144.6 | 428.8 | 385 | 373 | 397 | passed |
+| Source | Pod created (s) | Weight download (s) | Download rate (MB/s) | Pod Ready (s) | Rollout completed (s) | Inference |
+|---|---:|---:|---:|---:|---:|---|
+| Hugging Face direct | 1 | 521.4 | 118.9 | 722 | 751 | passed |
+| MatrixHub cache hit | 1 | 144.6 | 428.8 | 373 | 397 | passed |
 
 Comparison:
 
@@ -160,7 +159,6 @@ Comparison:
 |---|---:|---:|---|
 | Weight download | 521.4 s | 144.6 s | −376.8 s (3.6× faster) |
 | Download rate | 118.9 MB/s | 428.8 MB/s | 3.6× |
-| Container start to Ready | 738 s | 385 s | −353 s (47.8%) |
 | Pod Ready | 722 s | 373 s | −349 s (48.3%) |
 | Total rollout time | 751 s | 397 s | −354 s (47.1%) |
 

--- a/website/i18n/zh-CN/docusaurus-plugin-content-blog/2026-07-29-llmd-qwen3-32b-matrixhub-cache.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-blog/2026-07-29-llmd-qwen3-32b-matrixhub-cache.md
@@ -116,7 +116,6 @@ vLLM 日志确认本次运行的下载权重下载耗时：
 运行脚本记录以下内容：
 
 - 从提交部署清单到 Pod 创建的时间；
-- 从容器启动到 Pod Ready 的时间，作为最接近模型加载阶段的指标；
 - Pod Ready 时间；
 - Deployment 完成滚动发布的总时间；
 - 经 EPP Service 的推理请求验证结果；
@@ -147,10 +146,10 @@ INFO [weight_utils.py:922] Filesystem type for checkpoints: OVERLAY. Checkpoint 
 
 下表为每个场景三次运行的平均值。
 
-| 来源 | Pod 创建 (s) | 权重下载 (s) | 下载速率 (MB/s) | 容器启动到 Ready (s) | Pod Ready (s) | 滚动发布完成 (s) | 推理验证 |
-|---|---:|---:|---:|---:|---:|---:|---|
-| Hugging Face 直连 | 1 | 521.4 | 118.9 | 738 | 722 | 751 | 通过 |
-| MatrixHub 缓存命中 | 1 | 144.6 | 428.8 | 385 | 373 | 397 | 通过 |
+| 来源 | Pod 创建 (s) | 权重下载 (s) | 下载速率 (MB/s) | Pod Ready (s) | 滚动发布完成 (s) | 推理验证 |
+|---|---:|---:|---:|---:|---:|---|
+| Hugging Face 直连 | 1 | 521.4 | 118.9 | 722 | 751 | 通过 |
+| MatrixHub 缓存命中 | 1 | 144.6 | 428.8 | 373 | 397 | 通过 |
 
 对比：
 
@@ -158,7 +157,6 @@ INFO [weight_utils.py:922] Filesystem type for checkpoints: OVERLAY. Checkpoint 
 |---|---:|---:|---|
 | 权重下载耗时 | 521.4 s | 144.6 s | 减少 376.8 s（3.6× 加速） |
 | 下载速率 | 118.9 MB/s | 428.8 MB/s | 提升 3.6× |
-| 容器启动到 Ready | 738 s | 385 s | 减少 353 s（47.8%） |
 | Pod Ready | 722 s | 373 s | 减少 349 s（48.3%） |
 | 滚动发布总时长 | 751 s | 397 s | 减少 354 s（47.1%） |
 


### PR DESCRIPTION
## What

Removes the `Container start to Ready` column and comparison row from the llm-d Qwen3-32B blog post, in both the English post and the zh-CN translation, along with the metric's bullet in the "Metrics" section.

## Why

The metric is not measurable from the data the runner collects, because the two reported intervals are anchored to different clocks.

In `examples/llm-d-qwen3-32b/scripts/run.sh`:

```bash
pod_ready_seconds="$(( pod_ready_epoch - started_epoch ))"
model_load_seconds="$(( pod_ready_epoch - container_started_epoch ))"
```

- `started_epoch` is `date +%s` on the machine running the script.
- `container_started_at` (`.status.containerStatuses[modelserver].state.running.startedAt`) and `pod_ready_at` (`.status.conditions[Ready].lastTransitionTime`) are written by the kubelet on the node.

The two expressions share `pod_ready_epoch`, so their difference is exactly `container_started_at - started_epoch` — a cross-clock subtraction. Any skew between the script host and the node lands entirely there.

The published numbers show that skew directly:

| Source | Container start to Ready | Pod Ready | Implied gap |
|---|---:|---:|---:|
| Hugging Face direct | 738 s | 722 s | −16 s |
| MatrixHub cache hit | 385 s | 373 s | −12 s |

Container start to Ready is larger than Pod Ready in both rows, which cannot happen: the container starts after the manifest is applied, so that interval must be the shorter of the two. The values imply the container started ~12–16 s before the script did.

`Pod created (s)` stays at 1 s in both rows because `.metadata.creationTimestamp` is set by the apiserver, whose clock tracks the script host — so the skew only surfaces in the kubelet-written timestamps.

## Why removed rather than corrected

The per-run `metrics.md` files with the raw timestamps were not committed (`examples/llm-d-qwen3-32b/artifacts/` holds only `.gitkeep`), so no corrected value can be recomputed. Publishing a recomputed number would mean inventing one.

## Impact on the post's conclusions

None. The conclusions rest on the vLLM weight-download duration (521.4 s → 144.6 s, from vLLM's own log line) and total rollout time (751 s → 397 s, measured start-to-end on the script host alone). Both are single-clock measurements and are unaffected. `Pod Ready` is left in place as-is; it carries the same skew as a constant offset, but it remains internally consistent between the two scenarios.

## Follow-up (not in this PR)

`run.sh` should anchor `pod_ready_seconds` to `pod_created_at` instead of `started_epoch` so future runs report both intervals on the Kubernetes clock.