### PR TITLE
feat(ui): add length and complexity validation for manual robot token

### DIFF
--- a/ui/src/features/admin/robots/components/RefreshRobotTokenModal.tsx
+++ b/ui/src/features/admin/robots/components/RefreshRobotTokenModal.tsx
@@ -16,6 +16,8 @@ import { fieldError } from '@/shared/utils/form.ts'
 
 import { refreshRobotAccountTokenMutationOptions } from '../robot.mutation.ts'
 import {
+  ROBOT_TOKEN_MAX_LENGTH,
+  ROBOT_TOKEN_MIN_LENGTH,
   refreshRobotTokenFormDefaults,
   refreshRobotTokenSchema,
   type RefreshRobotTokenFormValues,
@@ -153,7 +155,12 @@ export function RefreshRobotTokenModal({
                   <PasswordInput
                     required
                     autoComplete="new-password"
+                    maxLength={ROBOT_TOKEN_MAX_LENGTH}
                     label={t('routes.admin.robots.refreshTokenModal.token')}
+                    description={t('routes.admin.robots.refreshTokenModal.tokenHint', {
+                      min: ROBOT_TOKEN_MIN_LENGTH,
+                      max: ROBOT_TOKEN_MAX_LENGTH,
+                    })}
                     value={field.state.value ?? ''}
                     onChange={event => field.handleChange(event.currentTarget.value)}
                     onBlur={field.handleBlur}
@@ -182,6 +189,7 @@ export function RefreshRobotTokenModal({
                   <PasswordInput
                     required
                     autoComplete="new-password"
+                    maxLength={ROBOT_TOKEN_MAX_LENGTH}
                     label={t('routes.admin.robots.refreshTokenModal.confirmToken')}
                     value={field.state.value ?? ''}
                     onChange={event => field.handleChange(event.currentTarget.value)}

--- a/ui/src/features/admin/robots/robot.schema.ts
+++ b/ui/src/features/admin/robots/robot.schema.ts
@@ -47,9 +47,7 @@ export const createRobotAccountFormSchema = (t: TFunction) => z.object({
 
 export const ROBOT_TOKEN_MIN_LENGTH = 8
 export const ROBOT_TOKEN_MAX_LENGTH = 20
-export const ROBOT_TOKEN_PATTERN = new RegExp(
-  `^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).{${ROBOT_TOKEN_MIN_LENGTH},${ROBOT_TOKEN_MAX_LENGTH}}$`,
-)
+export const ROBOT_TOKEN_COMPLEXITY_PATTERN = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).*$/
 
 export const refreshRobotTokenFormDefaults = {
   autoGenerate: true,
@@ -60,6 +58,23 @@ export const refreshRobotTokenFormDefaults = {
 function t(key: string, args: Record<string, unknown> = {}) {
   return i18n.getFixedT(i18n.resolvedLanguage ?? i18n.language)(key, args)
 }
+
+export const robotTokenSchema = z.string()
+  .min(ROBOT_TOKEN_MIN_LENGTH, {
+    error: () => t('common.validation.minLength', {
+      min: ROBOT_TOKEN_MIN_LENGTH,
+      field: t('routes.admin.robots.refreshTokenModal.token'),
+    }),
+  })
+  .max(ROBOT_TOKEN_MAX_LENGTH, {
+    error: () => t('common.validation.maxLength', {
+      max: ROBOT_TOKEN_MAX_LENGTH,
+      field: t('routes.admin.robots.refreshTokenModal.token'),
+    }),
+  })
+  .regex(ROBOT_TOKEN_COMPLEXITY_PATTERN, {
+    error: () => t('routes.admin.robots.refreshTokenModal.validation.tokenComplexity'),
+  })
 
 export const refreshRobotTokenSchema = z.object({
   autoGenerate: z.boolean(),
@@ -76,15 +91,16 @@ export const refreshRobotTokenSchema = z.object({
       message: t('routes.admin.robots.refreshTokenModal.validation.tokenRequired'),
       path: ['token'],
     })
-  } else if (!ROBOT_TOKEN_PATTERN.test(value.token)) {
-    ctx.addIssue({
-      code: 'custom',
-      message: t('routes.admin.robots.refreshTokenModal.validation.tokenFormat', {
-        min: ROBOT_TOKEN_MIN_LENGTH,
-        max: ROBOT_TOKEN_MAX_LENGTH,
-      }),
-      path: ['token'],
-    })
+  } else {
+    const result = robotTokenSchema.safeParse(value.token)
+
+    if (!result.success) {
+      result.error.issues.forEach(issue => ctx.addIssue({
+        code: 'custom',
+        message: issue.message,
+        path: ['token'],
+      }))
+    }
   }
 
   if (!value.confirmToken) {

--- a/ui/src/features/admin/robots/robot.schema.ts
+++ b/ui/src/features/admin/robots/robot.schema.ts
@@ -45,6 +45,12 @@ export const createRobotAccountFormSchema = (t: TFunction) => z.object({
   }
 })
 
+export const ROBOT_TOKEN_MIN_LENGTH = 8
+export const ROBOT_TOKEN_MAX_LENGTH = 20
+export const ROBOT_TOKEN_PATTERN = new RegExp(
+  `^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).{${ROBOT_TOKEN_MIN_LENGTH},${ROBOT_TOKEN_MAX_LENGTH}}$`,
+)
+
 export const refreshRobotTokenFormDefaults = {
   autoGenerate: true,
   token: '',
@@ -68,6 +74,15 @@ export const refreshRobotTokenSchema = z.object({
     ctx.addIssue({
       code: 'custom',
       message: t('routes.admin.robots.refreshTokenModal.validation.tokenRequired'),
+      path: ['token'],
+    })
+  } else if (!ROBOT_TOKEN_PATTERN.test(value.token)) {
+    ctx.addIssue({
+      code: 'custom',
+      message: t('routes.admin.robots.refreshTokenModal.validation.tokenFormat', {
+        min: ROBOT_TOKEN_MIN_LENGTH,
+        max: ROBOT_TOKEN_MAX_LENGTH,
+      }),
       path: ['token'],
     })
   }

--- a/ui/src/locales/en/routes/admin.robots.json
+++ b/ui/src/locales/en/routes/admin.robots.json
@@ -61,6 +61,7 @@
     "copyDescription": "The new token is shown only once. Copy it now and store it safely.",
     "validation": {
       "tokenRequired": "New token is required",
+      "tokenFormat": "Token must be {{min}}-{{max}} characters and contain at least 1 uppercase letter, 1 lowercase letter and 1 number",
       "confirmTokenRequired": "Please confirm the new token",
       "tokenMismatch": "The two tokens do not match"
     }

--- a/ui/src/locales/en/routes/admin.robots.json
+++ b/ui/src/locales/en/routes/admin.robots.json
@@ -56,12 +56,13 @@
     "description": "You can click confirm to randomly generate a new token, or manually specify a new token.",
     "manualSwitch": "Enable this to manually specify the new token",
     "token": "New Token",
+    "tokenHint": "{{min}}-{{max}} characters, with at least 1 uppercase letter, 1 lowercase letter and 1 number",
     "confirmToken": "Confirm Token",
     "submit": "Refresh Token",
     "copyDescription": "The new token is shown only once. Copy it now and store it safely.",
     "validation": {
       "tokenRequired": "New token is required",
-      "tokenFormat": "Token must be {{min}}-{{max}} characters and contain at least 1 uppercase letter, 1 lowercase letter and 1 number",
+      "tokenComplexity": "Token must contain at least 1 uppercase letter, 1 lowercase letter and 1 number",
       "confirmTokenRequired": "Please confirm the new token",
       "tokenMismatch": "The two tokens do not match"
     }

--- a/ui/src/locales/zh/routes/admin.robots.json
+++ b/ui/src/locales/zh/routes/admin.robots.json
@@ -56,12 +56,13 @@
     "description": "您可以直接点击确定按钮来随机生成新的令牌，或者手动为其指定一个新的令牌。",
     "manualSwitch": "开启此项以便手动指定新令牌",
     "token": "新令牌",
+    "tokenHint": "长度 {{min}}-{{max}} 个字符，且至少包含一个大写字母、一个小写字母和一个数字",
     "confirmToken": "确认令牌",
     "submit": "刷新令牌",
     "copyDescription": "新令牌仅展示一次，请立即复制并妥善保存。",
     "validation": {
       "tokenRequired": "请输入新令牌",
-      "tokenFormat": "令牌长度需在 {{min}} 到 {{max}} 之间，且至少包含一个大写字母、一个小写字母和一个数字",
+      "tokenComplexity": "令牌至少需包含一个大写字母、一个小写字母和一个数字",
       "confirmTokenRequired": "请再次输入新令牌",
       "tokenMismatch": "两次输入的令牌不一致"
     }

--- a/ui/src/locales/zh/routes/admin.robots.json
+++ b/ui/src/locales/zh/routes/admin.robots.json
@@ -61,6 +61,7 @@
     "copyDescription": "新令牌仅展示一次，请立即复制并妥善保存。",
     "validation": {
       "tokenRequired": "请输入新令牌",
+      "tokenFormat": "令牌长度需在 {{min}} 到 {{max}} 之间，且至少包含一个大写字母、一个小写字母和一个数字",
       "confirmTokenRequired": "请再次输入新令牌",
       "tokenMismatch": "两次输入的令牌不一致"
     }


### PR DESCRIPTION
## What

Adds frontend validation for manually specified robot account tokens in the "Refresh Token" modal.

- Token must be 8–20 characters (`z.string().min()` / `.max()`, reusing the shared `common.validation.minLength` / `maxLength` messages)
- Must contain at least 1 uppercase letter, 1 lowercase letter and 1 number (`.regex()`, message `refreshTokenModal.validation.tokenComplexity`)
- Both token inputs get `maxLength={20}` so over-long input is truncated at the source
- The rule is surfaced inline as the input's `description` (`refreshTokenModal.tokenHint`), matching the existing hint pattern in `RobotAccountForm`

New i18n keys (`en` + `zh`): `refreshTokenModal.tokenHint`, `refreshTokenModal.validation.tokenComplexity`.

## Why

Closes #653 — previously a 1-character or 300-character token was accepted.

## Test

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- Manually verified in dev against a live API

🤖 Generated with [Claude Code](https://claude.com/claude-code)