### PR TITLE
docs: add demo site operations guide

### DIFF
--- a/deploy/demo-site.md
+++ b/deploy/demo-site.md
@@ -1,0 +1,76 @@
+# Demo Site Operations
+
+This document describes how maintainers deploy and operate the public MatrixHub
+demo at <https://demo.matrixhub.ai/>.
+
+## Ownership and Access
+
+The demo is maintained by repository maintainers who have access to the GitHub
+`demo` environment. The environment must provide these secrets:
+
+- `DEPLOY_HOST`: the demo server address.
+- `DEPLOY_SSH_KEY`: the SSH key used by the deployment workflow.
+
+The workflow connects to the server as `root` and manages the deployment under
+`/root/matrixhub/deploy`.
+
+## Deployment
+
+The [Deploy Demo Site](../.github/workflows/deploy-demosite.yml) workflow is
+started manually with an image tag.
+
+1. Open **Actions** -> **Deploy Demo Site** -> **Run workflow**.
+2. Enter the image tag to deploy. Prefer an immutable release or commit-specific
+   tag so the same version can be deployed again during rollback.
+3. Run the workflow and wait for all steps to complete.
+4. Open <https://demo.matrixhub.ai/> and verify that the login page loads and the
+   documented demo account can sign in.
+
+During deployment, the workflow:
+
+- copies the Compose, MatrixHub, and Nginx configuration to the demo server;
+- creates database passwords on the first deployment and preserves them on
+  later deployments;
+- pulls the selected MatrixHub image and starts the Compose services; and
+- installs or refreshes the scheduled data-reset task.
+
+## Data Reset
+
+The demo is disposable. The deployment workflow installs
+`/root/matrixhub/reset.sh` and runs it every six hours with cron:
+
+```text
+0 */6 * * *
+```
+
+The reset stops the Compose services, removes the MySQL and MatrixHub data
+directories, and starts the services again. It deletes all users, projects,
+models, and other data created through the demo. The `.env` file and the Nginx
+ACME certificate volume are preserved.
+
+Reset output is written to `/root/matrixhub/logs/reset.log`. A maintainer can run
+`/root/matrixhub/reset.sh` manually when an immediate reset is required.
+
+## Routine Maintenance
+
+After a deployment or reset:
+
+1. Confirm that <https://demo.matrixhub.ai/> responds over HTTPS.
+2. Confirm that the documented demo account can sign in.
+3. Check that the `mysql`, `matrixhub`, and `nginx` Compose services are running.
+4. If a scheduled reset fails, inspect `/root/matrixhub/logs/reset.log` and the
+   Compose service logs.
+
+Deployment configuration should be changed in this repository and applied
+through the workflow. Avoid relying on manual edits on the demo server because
+the next deployment can overwrite them.
+
+## Rollback
+
+To roll back the application, rerun **Deploy Demo Site** with the last known-good
+immutable image tag. The workflow updates only the MatrixHub image tag and does
+not reset demo data as part of deployment.
+
+If the older image cannot use the current disposable demo database after a
+schema migration, run `/root/matrixhub/reset.sh` after the rollback. This removes
+all demo data and recreates the database using the selected image.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds a maintainer operations guide for the public MatrixHub demo site.

The guide documents:

- Demo environment ownership and access requirements.
- Image deployment and post-deployment verification.
- Automatic six-hour data reset and manual reset procedures.
- Routine maintenance and troubleshooting.
- Rollback using a known-good image tag.

The deployment and reset automation already exist, but their operational procedures were previously only represented in the workflow implementation.

#### Which issue(s) this PR fixes:

Fixes #489

#### Special notes for your reviewer:

This is a documentation-only change. It describes the existing demo deployment workflow and does not change configuration, runtime behavior, APIs, or deployment automation.

Tests are not needed because no executable code or configuration is changed.

#### Checklist

- [x] Tests(ut, e2e) added or updated, or not needed and explained
- [x] Docs(tech docs, usage docs) updated, or not needed and explained
  - [Other doc]: https://github.com/scydas/matrixhub/blob/docs/demo-site-operations/deploy/demo-site.md

#### Does this PR introduce a user-facing change?

```release-note
NONE
```