### PR TITLE
docs: update system integration guides

### DIFF
--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -4,87 +4,50 @@ sidebar_position: 1
 
 # Integrations
 
-MatrixHub is built to integrate seamlessly with standard ML systems, high-performance inference engines, cloud object storages, and Kubernetes deployment workflows.
+MatrixHub is built to integrate seamlessly with standard ML systems and high-performance inference frameworks.
 
 ---
 
 ## 🚀 GPU Inference Engines
 
-MatrixHub acts as a private, high-speed cache endpoint for your serving nodes. By simply injecting the environment redirect, your serving engines load weights instantly.
+MatrixHub acts as a private, high-speed cache endpoint for your serving nodes. Set the `HF_ENDPOINT` redirect when starting an inference engine. For detailed integration instructions, see:
 
-### 1. vLLM Integration
-To load cached model parameters into a vLLM serving instance, run the startup script with the redirected endpoint:
-```bash
-# Inject proxy endpoint and launch OpenAI compatible API server
-HF_ENDPOINT=http://your-matrixhub-ip:3001 \
-vllm serve Qwen/Qwen2.5-7B-Instruct \
-  --port 8000 \
-  --api-key my-secure-api-key
-```
+- **vLLM**
 
-### 2. SGLang Integration
-Similarly, route SGLang requests through MatrixHub to enjoy rapid cache-hit load times:
-```bash
-# Start SGLang engine with private caching endpoint
-HF_ENDPOINT=http://your-matrixhub-ip:3001 \
-python3 -m sglang.launch_server \
-  --model-path Qwen/Qwen2.5-7B-Instruct \
-  --port 30000
-```
+  Set `HF_ENDPOINT` in the vLLM runtime environment to load models through MatrixHub.
 
----
+  [View the detailed vLLM integration guide](../guides/use-with-vllm.md)
 
-## 🪣 Object Storage Backends
+- **SGLang**
 
-MatrixHub is storage agnostic. In production, we highly recommend storing cached large models and private weights inside highly durable, distributed object storage clusters rather than local host folders.
+  Set `HF_ENDPOINT` in the SGLang runtime environment to load models from the MatrixHub cache.
 
-Configure the storage parameters inside your `config/config.yaml`:
+  [View the detailed SGLang integration guide](../../blog/sglang-matrixhub-cache-acceleration)
 
-```yaml
-# MatrixHub Production Storage Configuration
-storage:
-  mode: s3
-  s3:
-    endpoint: "play.min.io"             # MinIO or AWS S3 endpoint
-    bucket: "matrixhub-model-registry"
-    accessKey: "my-s3-access-key"
-    secretKey: "my-s3-secret-key"
-    secure: true                        # Use HTTPS
-    region: "us-east-1"
-```
+- **llm-d**
+
+  Inject `HF_ENDPOINT` into the llm-d model server to distribute models through MatrixHub inside the cluster.
+
+  [View the detailed llm-d integration guide](../../blog/llmd-qwen3-32b-matrixhub-cache)
+
+- **Dynamo**
+
+  Set `HF_ENDPOINT` in the Dynamo deployment so the inference runtime retrieves models through MatrixHub.
+
+  [View the detailed Dynamo integration guide](../../blog/dynamo-matrixhub-integration)
 
 ---
 
-## ☸️ Cloud-Native & GitOps Integrations
+## Model Distribution and P2P Acceleration
 
-MatrixHub provides first-class support for Kubernetes deployment and GitOps configuration workflows.
+- **ModelExpress cache reuse**
 
-### 1. ArgoCD / Helm Integration
-Manage your registry deployment declaratively. Create an ArgoCD application manifest pointing to our official Helm chart parameters:
+  Use MatrixHub as the model source while ModelExpress caches model downloads for reuse across Dynamo workers.
 
-```yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: matrixhub-registry
-  namespace: argocd
-spec:
-  project: default
-  source:
-    chart: matrixhub
-    repoURL: oci://ghcr.io/matrixhub-ai/matrixhub
-    targetRevision: 0.1.0
-    helm:
-      parameters:
-        - name: apiserver.service.type
-          value: NodePort
-        - name: apiserver.storage.pvc.size
-          value: 500Gi
-  destination:
-    server: "https://kubernetes.default.svc"
-    namespace: matrixhub
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-```
+  [View the ModelExpress cache integration guide](../../blog/dynamo-modelexpress-dedup)
+
+- **Dynamo GPU P2P**
+
+  Use MatrixHub for model-file distribution and ModelExpress to transfer loaded GPU weights between Dynamo workers over NIXL, UCX, and RDMA.
+
+  [View the Dynamo P2P integration guide](../../blog/matrixhub-modelexpress-dynamo-p2p)

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/integrations/index.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/integrations/index.md
@@ -5,87 +5,50 @@ sidebar_position: 1
 
 # 系统集成
 
-MatrixHub 采用标准云原生协议设计，旨在无缝融入企业级 AI 基础设施生态，支持主流高性能推理引擎、高可用分布式对象存储底座以及 Kubernetes 云原生 CI/CD & GitOps 工作流。
+MatrixHub 采用标准云原生协议设计，旨在无缝融入企业级 AI 基础设施生态，支持主流高性能推理框架。
 
 ---
 
 ## 🚀 高性能 GPU 推理引擎集成
 
-MatrixHub 作为高性能代理缓存，可以直接拦截并拦截内网 GPU 节点的权重加载请求。在启动主流推理框架时，仅需注入重定向环境变量即可：
+MatrixHub 作为高性能代理缓存，可以接收内网 GPU 节点的权重加载请求。在启动主流推理框架时，仅需注入重定向环境变量 `HF_ENDPOINT` 即可。详细集成方式请参阅：
 
-### 1. 与 vLLM 对接
-将环境变量注入您的 vLLM 服务启动脚本，即可让推理算力节点直接拉取 MatrixHub 中的模型文件：
-```bash
-# 注入本地代理地址，启动兼容 OpenAI 规范的 vLLM 接口服务
-HF_ENDPOINT=http://your-matrixhub-ip:3001 \
-vllm serve Qwen/Qwen2.5-7B-Instruct \
-  --port 8000 \
-  --api-key my-secure-api-key
-```
+- **vLLM**
 
-### 2. 与 SGLang 对接
-同样地，SGLang 实例在启动时可以无缝拦截公网下载，享受高速局域网（10Gbps+）的缓存载入速度：
-```bash
-# 注入环境变量启动 SGLang 推理底座
-HF_ENDPOINT=http://your-matrixhub-ip:3001 \
-python3 -m sglang.launch_server \
-  --model-path Qwen/Qwen2.5-7B-Instruct \
-  --port 30000
-```
+  在 vLLM 启动环境中设置 `HF_ENDPOINT`，通过 MatrixHub 加载模型。
 
----
+  [查看 vLLM 详细集成文档](../guides/use-with-vllm.md)
 
-## 🪣 分布式对象存储集成
+- **SGLang**
 
-MatrixHub 本身是存储解耦的。在生产部署中，我们强烈推荐您将模型权重和代理缓存持久化存储在具备多机冗余的对象存储集群（如 AWS S3、MinIO）中，而不是直接依赖单机磁盘或 NFS。
+  在 SGLang 启动环境中设置 `HF_ENDPOINT`，从 MatrixHub 缓存加载模型。
 
-编辑您的主配置文件 `config/config.yaml` 引入 S3 存储引擎：
+  [查看 SGLang 详细集成文档](../../blog/sglang-matrixhub-cache-acceleration)
 
-```yaml
-# MatrixHub 生产存储连接配置
-storage:
-  mode: s3
-  s3:
-    endpoint: "play.min.io"             # MinIO 或 AWS S3 的访问地址
-    bucket: "matrixhub-model-registry"  # 存储桶名称
-    accessKey: "my-s3-access-key"       # 秘钥 ID
-    secretKey: "my-s3-secret-key"       # 秘钥值
-    secure: true                        # 启用 HTTPS 安全传输
-    region: "us-east-1"
-```
+- **llm-d**
+
+  将 `HF_ENDPOINT` 注入 llm-d 的模型服务，在集群内通过 MatrixHub 分发模型。
+
+  [查看 llm-d 详细集成文档](../../blog/llmd-qwen3-32b-matrixhub-cache)
+
+- **Dynamo**
+
+  在 Dynamo 部署中设置 `HF_ENDPOINT`，让推理运行时通过 MatrixHub 获取模型。
+
+  [查看 Dynamo 详细集成文档](../../blog/dynamo-matrixhub-integration)
 
 ---
 
-## ☸️ 云原生编排与 GitOps 集成
+## 模型分发与 P2P 加速
 
-为了满足企业级“基础设施即代码 (IaC)”的自动化部署规范，MatrixHub 提供了官方 Helm Chart，完美适配各种主流 GitOps 管理软件。
+- **ModelExpress 缓存复用**
 
-### 1. 与 ArgoCD 的持续集成集成
-您可以配置声明式的 ArgoCD Application 清单，一键同步与更新您的 MatrixHub 注册表集群：
+  以 MatrixHub 作为模型源，通过 ModelExpress 缓存模型下载，供多个 Dynamo Worker 复用。
 
-```yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: matrixhub-registry
-  namespace: argocd
-spec:
-  project: default
-  source:
-    chart: matrixhub
-    repoURL: oci://ghcr.io/matrixhub-ai/matrixhub
-    targetRevision: 0.1.0
-    helm:
-      parameters:
-        - name: apiserver.service.type
-          value: NodePort
-        - name: apiserver.storage.pvc.size
-          value: 500Gi
-  destination:
-    server: "https://kubernetes.default.svc"
-    namespace: matrixhub
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-```
+  [查看 ModelExpress 缓存集成文档](../../blog/dynamo-modelexpress-dedup)
+
+- **Dynamo GPU P2P**
+
+  由 MatrixHub 负责模型文件分发，并通过 ModelExpress、NIXL、UCX 和 RDMA 在 Dynamo Worker 之间传输已加载的 GPU 权重。
+
+  [查看 Dynamo P2P 集成文档](../../blog/matrixhub-modelexpress-dynamo-p2p)


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

- Replaces inline integration examples with links to the maintained vLLM, SGLang, llm-d, and Dynamo guides.
- Adds ModelExpress cache reuse and Dynamo GPU P2P integration resources.
- Removes object storage and GitOps examples that do not reflect the current product scope.
- Keeps the English and Simplified Chinese integration pages aligned.

This makes the integration page a concise, accurate entry point and directs readers to complete guides for each supported workflow.

#### Which issue(s) this PR fixes:

#492

#### Checklist

- [x] Tests(ut, e2e) added or updated, or not needed and explained
- [x] Docs(tech docs, usage docs) updated, or not needed and explained

Documentation-only change. Verified with `npm run build` in `website` for both English and Simplified Chinese locales.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
