### PR TITLE
fix(ui): improve project selector usability

### DIFF
--- a/ui/src/shared/components/ProjectSelect.tsx
+++ b/ui/src/shared/components/ProjectSelect.tsx
@@ -7,11 +7,12 @@ import {
   Text,
   useCombobox,
 } from '@mantine/core'
-import { type ComponentProps } from 'react'
+import { type ComponentProps, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ProjectTypeBadge } from '@/shared/components/badges/ProjectTypeBadge'
 import { FieldHintLabel } from '@/shared/components/FieldHintLabel.tsx'
+import { filterByKeyword } from '@/shared/utils'
 
 export interface ProjectSelectOption {
   name?: string
@@ -74,10 +75,19 @@ export function ProjectSelect({
   inputProps,
 }: ProjectSelectProps) {
   const { t } = useTranslation()
-  const combobox = useCombobox()
+  const [search, setSearch] = useState('')
+  const combobox = useCombobox({
+    onDropdownClose: () => {
+      combobox.resetSelectedOption()
+      combobox.focusTarget()
+      setSearch('')
+    },
+    onDropdownOpen: () => combobox.focusSearchInput(),
+  })
   const restInputProps = inputProps
 
   const selectedProjectOption = data.find(option => option.name === value)
+  const filteredOptions = filterByKeyword(data, search)
 
   return (
     <Combobox
@@ -120,6 +130,14 @@ export function ProjectSelect({
       </Combobox.Target>
 
       <Combobox.Dropdown>
+        <Combobox.Search
+          value={search}
+          placeholder={t('shared.search')}
+          onChange={(event) => {
+            combobox.updateSelectedOptionIndex()
+            setSearch(event.currentTarget.value)
+          }}
+        />
         <Combobox.Options>
           <ScrollArea.Autosize
             mah={220}
@@ -127,11 +145,13 @@ export function ProjectSelect({
             scrollbarSize="var(--combobox-padding)"
             offsetScrollbars="y"
           >
-            {data.map(option => (
-              <Combobox.Option value={option.name as string} key={option.name}>
-                <SelectedProjectDisplay name={option.name} type={option.type} />
-              </Combobox.Option>
-            ))}
+            {filteredOptions.length
+              ? filteredOptions.map(option => (
+                  <Combobox.Option value={option.name as string} key={option.name}>
+                    <SelectedProjectDisplay name={option.name} type={option.type} />
+                  </Combobox.Option>
+                ))
+              : <Combobox.Empty>{t('common.noResults')}</Combobox.Empty>}
           </ScrollArea.Autosize>
         </Combobox.Options>
       </Combobox.Dropdown>

--- a/ui/src/shared/components/ProjectSelect.tsx
+++ b/ui/src/shared/components/ProjectSelect.tsx
@@ -3,6 +3,7 @@ import {
   Group,
   InputBase,
   type InputBaseProps,
+  ScrollArea,
   Text,
   useCombobox,
 } from '@mantine/core'
@@ -120,11 +121,18 @@ export function ProjectSelect({
 
       <Combobox.Dropdown>
         <Combobox.Options>
-          {data.map(option => (
-            <Combobox.Option value={option.name as string} key={option.name}>
-              <SelectedProjectDisplay name={option.name} type={option.type} />
-            </Combobox.Option>
-          ))}
+          <ScrollArea.Autosize
+            mah={220}
+            type="auto"
+            scrollbarSize="var(--combobox-padding)"
+            offsetScrollbars="y"
+          >
+            {data.map(option => (
+              <Combobox.Option value={option.name as string} key={option.name}>
+                <SelectedProjectDisplay name={option.name} type={option.type} />
+              </Combobox.Option>
+            ))}
+          </ScrollArea.Autosize>
         </Combobox.Options>
       </Combobox.Dropdown>
     </Combobox>

--- a/ui/src/shared/components/ProjectSelect.tsx
+++ b/ui/src/shared/components/ProjectSelect.tsx
@@ -1,4 +1,5 @@
 import {
+  CheckIcon,
   Combobox,
   Group,
   InputBase,
@@ -82,7 +83,10 @@ export function ProjectSelect({
       combobox.focusTarget()
       setSearch('')
     },
-    onDropdownOpen: () => combobox.focusSearchInput(),
+    onDropdownOpen: () => {
+      combobox.updateSelectedOptionIndex('active', { scrollIntoView: true })
+      combobox.focusSearchInput()
+    },
   })
   const restInputProps = inputProps
 
@@ -146,11 +150,25 @@ export function ProjectSelect({
             offsetScrollbars="y"
           >
             {filteredOptions.length
-              ? filteredOptions.map(option => (
-                  <Combobox.Option value={option.name as string} key={option.name}>
-                    <SelectedProjectDisplay name={option.name} type={option.type} />
-                  </Combobox.Option>
-                ))
+              ? filteredOptions.map((option) => {
+                  const isSelected = option.name === value
+
+                  return (
+                    <Combobox.Option
+                      value={option.name as string}
+                      key={option.name}
+                      active={isSelected}
+                      aria-selected={isSelected}
+                      bg={isSelected ? 'var(--mantine-primary-color-light)' : undefined}
+                      c={isSelected ? 'var(--mantine-primary-color-light-color)' : undefined}
+                    >
+                      <Group justify="space-between" gap="xs" wrap="nowrap">
+                        <SelectedProjectDisplay name={option.name} type={option.type} />
+                        {isSelected && <CheckIcon size={12} />}
+                      </Group>
+                    </Combobox.Option>
+                  )
+                })
               : <Combobox.Empty>{t('common.noResults')}</Combobox.Empty>}
           </ScrollArea.Autosize>
         </Combobox.Options>


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The project selector on the model creation page rendered every option without a bounded scroll area, causing long project lists to extend beyond the viewport. It also offered no way to narrow a large list or clearly identify the current selection.

This PR:

- constrains the project options to a Mantine `ScrollArea.Autosize` with a visible scrollbar;
- adds a focused `Combobox.Search` field with case-insensitive project-name filtering;
- highlights the committed project and displays a check icon without conflicting with keyboard navigation;
- preserves pointer and keyboard selection, resets search when the dropdown closes, and shows the existing empty-result state.

#### Which issue(s) this PR fixes:

Fixes #943

#### Special notes for your reviewer:

- Browser verification used a temporary 40-project harness and covered viewport bounds, scrolling, case-insensitive filtering, empty results, pointer and keyboard selection, search reset, Escape/reopen, and the selected marker during uncommitted Arrow navigation.
- The UI currently has no checked-in unit/E2E test runner, so no automated UI test was added.
- No documentation change is needed because this fixes the expected behavior of an existing selector.

#### Checklist

- [x] Tests(ut, e2e) added or updated, or not needed and explained
- [x] Docs(tech docs, usage docs) updated, or not needed and explained

#### Does this PR introduce a user-facing change?

```release-note
Made project selection dropdowns scrollable and searchable, with a clear selected-project indicator.
```
