### PR TITLE
fix(ui): add SSH key documentation link

### DIFF
--- a/ui/src/features/profile/pages/SshKeysPage.tsx
+++ b/ui/src/features/profile/pages/SshKeysPage.tsx
@@ -1,5 +1,14 @@
-import { Button } from '@mantine/core'
+import {
+  Alert,
+  Anchor,
+  Button,
+  Stack,
+} from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
+import {
+  IconExternalLink,
+  IconInfoCircle,
+} from '@tabler/icons-react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -10,6 +19,8 @@ import { SshKeysTable } from '@/features/profile/components/SshKeysTable'
 import { profileKeys, sshKeysQueryOptions } from '@/features/profile/profile.query'
 
 import type { SSHKey } from '@matrixhub/api-ts/v1alpha1/current_user.pb'
+
+const SSH_KEY_DOC_URL = '/docs/operations/profile/ssh-key/'
 
 export function SshKeysPage() {
   const { t } = useTranslation()
@@ -38,7 +49,27 @@ export function SshKeysPage() {
   }
 
   return (
-    <>
+    <Stack gap="sm">
+      <Alert
+        icon={<IconInfoCircle size={20} />}
+        variant="light"
+        color="cyan"
+        styles={{ icon: { marginRight: 6 } }}
+      >
+        {t('profile.sshKey.hint')}
+        {' '}
+        <Anchor
+          href={t('common.docs', { doc: SSH_KEY_DOC_URL })}
+          target="_blank"
+          rel="noopener noreferrer"
+          inherit
+        >
+          {t('profile.sshKey.generateHint')}
+          {' '}
+          <IconExternalLink size={14} />
+        </Anchor>
+      </Alert>
+
       <SshKeysTable
         data={data?.items ?? []}
         onDelete={handleDelete}
@@ -66,6 +97,6 @@ export function SshKeysPage() {
         opened={deleteOpened}
         onClose={handleDeleteClose}
       />
-    </>
+    </Stack>
   )
 }

--- a/ui/src/features/profile/pages/SshKeysPage.tsx
+++ b/ui/src/features/profile/pages/SshKeysPage.tsx
@@ -32,6 +32,7 @@ export function SshKeysPage() {
 
   const [createOpened, createHandlers] = useDisclosure(false)
   const [deleteOpened, deleteHandlers] = useDisclosure(false)
+  const [hintVisible, setHintVisible] = useState(true)
   const [deleteTarget, setDeleteTarget] = useState<SSHKey | null>(null)
 
   const handleDelete = (key: SSHKey) => {
@@ -51,9 +52,12 @@ export function SshKeysPage() {
   return (
     <Stack gap="sm">
       <Alert
+        hidden={!hintVisible}
         icon={<IconInfoCircle size={20} />}
         variant="light"
         color="cyan"
+        withCloseButton
+        onClose={() => setHintVisible(false)}
         styles={{ icon: { marginRight: 6 } }}
       >
         {t('profile.sshKey.hint')}

--- a/ui/src/locales/en/profile.json
+++ b/ui/src/locales/en/profile.json
@@ -9,6 +9,8 @@
     "expireAt": "Expires At",
     "importedAt": "Imported At",
     "emptyTitle": "No SSH public keys",
+    "hint": "Before importing an SSH public key, you need to",
+    "generateHint": "generate an SSH public key",
     "create": {
       "button": "Import SSH Public Key",
       "title": "Import SSH Public Key",

--- a/ui/src/locales/zh/profile.json
+++ b/ui/src/locales/zh/profile.json
@@ -9,6 +9,8 @@
     "expireAt": "过期时间",
     "importedAt": "导入时间",
     "emptyTitle": "暂无 SSH 公钥数据",
+    "hint": "在导入 SSH 公钥前，你需要",
+    "generateHint": "生成 SSH 公钥",
     "create": {
       "button": "导入 SSH 公钥",
       "title": "导入 SSH 公钥",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adds a localized informational alert above the SSH public key table. The alert links users to the SSH public key generation guide in a new tab.

The SSH key page previously rendered the table directly without an entry point to the existing generation instructions, leaving users who did not already have a key without guidance.

#### Which issue(s) this PR fixes:

Fixes #879

#### Special notes for your reviewer:

- The link uses the existing localized `common.docs` URL pattern.
- No UI test runner is configured in the repository. The real page was browser-verified with mocked API responses in English and Chinese, including the localized URL, external-link icon, `target="_blank"`, and safe `rel` attributes.
- Existing documentation content already covers SSH key generation, so no documentation content change was needed.

#### Checklist

- [x] Tests(ut, e2e) added or updated, or not needed and explained
- [x] Docs(tech docs, usage docs) updated, or not needed and explained

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

