### PR TITLE
fix(ui): guide empty model repositories

### DIFF
--- a/ui/src/features/models/components/AllModelList.tsx
+++ b/ui/src/features/models/components/AllModelList.tsx
@@ -1,13 +1,18 @@
 import {
+  Alert,
+  Anchor,
   Box,
+  Button,
+  Center,
   Group,
+  Paper,
   Space,
   Stack,
   Text,
 } from '@mantine/core'
-import { IconClock } from '@tabler/icons-react'
+import { IconClock, IconCube } from '@tabler/icons-react'
 import { useQuery } from '@tanstack/react-query'
-import { getRouteApi } from '@tanstack/react-router'
+import { getRouteApi, Link } from '@tanstack/react-router'
 import { startTransition } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -38,7 +43,14 @@ export function AllModelList() {
     } = {},
     isLoading,
     isPending,
+    isLoadingError,
+    refetch,
   } = useQuery(catalogModelsQueryOptions(search))
+
+  const hasActiveFilters = Boolean(search.q || search.task || search.library || search.project)
+  const modelCount = pagination?.total ?? items.length
+  const showCreatePrompt = !isLoading && !isPending && !isLoadingError
+    && !hasActiveFilters && modelCount === 0
 
   const sortFieldOptions: SortDropdownOption[] = [
     {
@@ -117,12 +129,56 @@ export function AllModelList() {
         <Space h="lg" />
 
         <Box miw={780} maw={1380}>
-          <ResourceCardGrid
-            loading={isLoading || isPending}
-            skeletonCount={DEFAULT_PAGE_SIZE}
-          >
-            {cardElements}
-          </ResourceCardGrid>
+          {isLoadingError
+            ? (
+                <Alert color="red" title={t('model.list.loadFailed')}>
+                  <Button
+                    mt="sm"
+                    size="xs"
+                    variant="light"
+                    onClick={() => void refetch()}
+                  >
+                    {t('model.list.retry')}
+                  </Button>
+                </Alert>
+              )
+            : showCreatePrompt
+              ? (
+                  <Paper withBorder radius="md">
+                    <Center py="xl">
+                      <Stack align="center" gap="xs">
+                        <IconCube
+                          size={48}
+                          stroke={1.25}
+                          color="var(--mantine-primary-color-filled)"
+                        />
+                        <Text fw={600}>{t('model.list.emptyTitle')}</Text>
+                        <Text size="sm" c="dimmed">
+                          {t('model.list.emptyDescription')}
+                        </Text>
+                        <Button component={Link} to="/models/new" mt="xs">
+                          {t('model.list.create')}
+                        </Button>
+                        <Anchor
+                          href={t('common.docs', { doc: '/docs/operations/model-repo/upload-download/' })}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          size="sm"
+                        >
+                          {t('model.list.uploadGuide')}
+                        </Anchor>
+                      </Stack>
+                    </Center>
+                  </Paper>
+                )
+              : (
+                  <ResourceCardGrid
+                    loading={isLoading || isPending}
+                    skeletonCount={DEFAULT_PAGE_SIZE}
+                  >
+                    {cardElements}
+                  </ResourceCardGrid>
+                )}
 
           <Pagination
             total={pagination?.total ?? 0}

--- a/ui/src/features/models/components/HotModelList.tsx
+++ b/ui/src/features/models/components/HotModelList.tsx
@@ -1,5 +1,5 @@
 import {
-  Box, Collapse, Group, Text, UnstyledButton,
+  Alert, Box, Button, Collapse, Group, Text, UnstyledButton,
 } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { IconChevronDown } from '@tabler/icons-react'
@@ -25,6 +25,8 @@ export function HotModelList() {
     } = {},
     isLoading,
     isPending,
+    isLoadingError,
+    refetch,
   } = useQuery(catalogModelsQueryOptions({
     ...search,
     page: 1,
@@ -64,12 +66,28 @@ export function HotModelList() {
       </Group>
 
       <Box miw={780} maw={1380}>
-        <ResourceCardGrid
-          loading={isLoading || isPending}
-          skeletonCount={4}
-        >
-          {cardElements.slice(0, 4)}
-        </ResourceCardGrid>
+        {isLoadingError
+          ? (
+              <Alert color="red" title={t('model.list.loadFailed')}>
+                <Button
+                  mt="sm"
+                  size="xs"
+                  variant="light"
+                  onClick={() => void refetch()}
+                >
+                  {t('model.list.retry')}
+                </Button>
+              </Alert>
+            )
+          : (
+              <ResourceCardGrid
+                loading={isLoading || isPending}
+                skeletonCount={4}
+                emptyTitle={t('model.list.noRecommended')}
+              >
+                {cardElements.slice(0, 4)}
+              </ResourceCardGrid>
+            )}
         <Collapse in={opened}>
           <Box pt="lg">
             <ResourceCardGrid>

--- a/ui/src/features/models/pages/ModelCreatePage.tsx
+++ b/ui/src/features/models/pages/ModelCreatePage.tsx
@@ -1,14 +1,19 @@
 import {
+  Anchor,
   Alert,
-  Button, Group,
+  Box,
+  Button,
+  Group,
   rem,
   Stack,
   Text,
   TextInput,
 } from '@mantine/core'
-import { IconInfoCircle } from '@tabler/icons-react'
+import { IconArrowUpRight, IconInfoCircle } from '@tabler/icons-react'
 import { useMutation } from '@tanstack/react-query'
-import { useNavigate, useRouter } from '@tanstack/react-router'
+import {
+  Link, useNavigate, useRouter,
+} from '@tanstack/react-router'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -117,16 +122,34 @@ export function ModelCreatePage({ initialProjectId = '' }: ModelCreatePageProps)
             validators={{ onChange: projectIdValidator }}
           >
             {field => (
-              <ProjectSelect
-                data={projects}
-                value={field.state.value}
-                onChange={field.handleChange}
-                inputProps={{
-                  disabled: !!initialProjectId,
-                  onBlur: field.handleBlur,
-                  error: fieldError(field),
-                }}
-              />
+              <Group align="flex-end" wrap="nowrap">
+                <Box flex={1}>
+                  <ProjectSelect
+                    data={projects}
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                    inputProps={{
+                      disabled: !!initialProjectId,
+                      onBlur: field.handleBlur,
+                      error: fieldError(field),
+                    }}
+                  />
+                </Box>
+                {!initialProjectId && (
+                  <Anchor
+                    component={Link}
+                    to="/projects"
+                    pb="xs"
+                    size="sm"
+                    flex="0 0 auto"
+                  >
+                    <Group gap={4} wrap="nowrap">
+                      {t('model.create.createProject')}
+                      <IconArrowUpRight size={16} />
+                    </Group>
+                  </Anchor>
+                )}
+              </Group>
             )}
           </form.Field>
 

--- a/ui/src/features/models/pages/ModelCreatePage.tsx
+++ b/ui/src/features/models/pages/ModelCreatePage.tsx
@@ -1,25 +1,29 @@
 import {
-  Anchor,
   Alert,
   Box,
   Button,
   Group,
+  Paper,
   rem,
   Stack,
   Text,
   TextInput,
 } from '@mantine/core'
-import { IconExternalLink, IconInfoCircle } from '@tabler/icons-react'
-import { useMutation } from '@tanstack/react-query'
+import { useDisclosure } from '@mantine/hooks'
 import {
-  Link, useNavigate, useRouter,
-} from '@tanstack/react-router'
+  IconFolderPlus,
+  IconInfoCircle,
+  IconPlus,
+} from '@tabler/icons-react'
+import { useMutation } from '@tanstack/react-query'
+import { useNavigate, useRouter } from '@tanstack/react-router'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { createModelMutationOptions } from '@/features/models/models.mutation'
 import { useWritableModelProjects } from '@/features/models/models.query.ts'
 import { createModelSchema } from '@/features/models/models.schema'
+import { CreateProjectModal } from '@/features/projects/components/CreateProjectModal'
 import { ProjectSelect } from '@/shared/components/ProjectSelect'
 import { useForm } from '@/shared/hooks/useForm'
 import { fieldError } from '@/shared/utils/form.ts'
@@ -32,6 +36,7 @@ export function ModelCreatePage({ initialProjectId = '' }: ModelCreatePageProps)
   const { t } = useTranslation()
   const navigate = useNavigate()
   const router = useRouter()
+  const [createProjectOpened, createProjectHandlers] = useDisclosure(false)
 
   const mutation = useMutation(createModelMutationOptions())
   const modelCreateSchema = createModelSchema(t)
@@ -71,7 +76,21 @@ export function ModelCreatePage({ initialProjectId = '' }: ModelCreatePageProps)
     },
   })
 
-  const { data: projects = [] } = useWritableModelProjects()
+  const {
+    data: projects = [],
+    isLoadingError: isProjectsLoadingError,
+    isPending: isProjectsPending,
+    refetch: refetchProjects,
+  } = useWritableModelProjects()
+  const showEmptyProjectPrompt = !initialProjectId
+    && !isProjectsPending
+    && !isProjectsLoadingError
+    && projects.length === 0
+
+  const handleProjectCreated = async (projectName: string) => {
+    await refetchProjects()
+    form.setFieldValue('projectId', projectName)
+  }
 
   useEffect(() => {
     const projectId = form.state.values.projectId
@@ -121,42 +140,79 @@ export function ModelCreatePage({ initialProjectId = '' }: ModelCreatePageProps)
             name="projectId"
             validators={{ onChange: projectIdValidator }}
           >
-            {field => (
-              <Group align="flex-end" wrap="nowrap">
-                <Box flex={1}>
-                  <ProjectSelect
-                    data={projects}
-                    value={field.state.value}
-                    onChange={field.handleChange}
-                    inputProps={{
-                      disabled: !!initialProjectId,
-                      onBlur: field.handleBlur,
-                      error: fieldError(field),
-                    }}
-                  />
-                </Box>
-                {!initialProjectId && (
-                  <Anchor
-                    component={Link}
-                    to="/projects"
-                    pb="xs"
-                    size="md"
-                    c="var(--mantine-color-text)"
-                    underline="never"
-                    flex="0 0 auto"
-                  >
-                    <Group gap={6} wrap="nowrap">
-                      {t('model.create.createProject')}
-                      <IconExternalLink
-                        size={28}
-                        stroke={1.75}
+            {(field) => {
+              const error = fieldError(field)
+
+              if (showEmptyProjectPrompt) {
+                return (
+                  <Paper withBorder radius="md" px="lg" py="xl">
+                    <Stack align="center" gap="xs">
+                      <IconFolderPlus
+                        size={44}
+                        stroke={1.25}
                         color="var(--mantine-primary-color-filled)"
                       />
-                    </Group>
-                  </Anchor>
-                )}
-              </Group>
-            )}
+                      <Text fw={600}>{t('model.create.emptyProjectTitle')}</Text>
+                      <Text size="sm" c="dimmed" ta="center">
+                        {t('model.create.emptyProjectDescription')}
+                      </Text>
+                      <Button
+                        type="button"
+                        mt="xs"
+                        onClick={createProjectHandlers.open}
+                      >
+                        {t('model.create.createProject')}
+                      </Button>
+                    </Stack>
+                  </Paper>
+                )
+              }
+
+              return (
+                <Group align="flex-start" gap="sm" wrap="nowrap">
+                  <Box flex="0 0 100%">
+                    <ProjectSelect
+                      data={projects}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      inputProps={{
+                        disabled: !!initialProjectId || isProjectsPending,
+                        onBlur: field.handleBlur,
+                        error,
+                        styles: {
+                          input: error
+                            ? {
+                                borderColor: 'var(--mantine-color-red-4)',
+                                boxShadow: '0 0 0 2px var(--mantine-color-red-0)',
+                              }
+                            : undefined,
+                          error: {
+                            color: 'var(--mantine-color-red-6)',
+                            fontWeight: 500,
+                            lineHeight: rem(16),
+                            marginTop: rem(5),
+                          },
+                        },
+                      }}
+                    />
+                  </Box>
+                  {!initialProjectId && (
+                    <Button
+                      type="button"
+                      variant="subtle"
+                      mt={rem(29)}
+                      h={36}
+                      flex="0 0 auto"
+                      px="xs"
+                      leftSection={<IconPlus size={16} />}
+                      onClick={createProjectHandlers.open}
+                    >
+                      {t('model.create.createProject')}
+                    </Button>
+                  )}
+                </Group>
+              )
+            }}
           </form.Field>
 
           <Alert
@@ -192,6 +248,12 @@ export function ModelCreatePage({ initialProjectId = '' }: ModelCreatePageProps)
           </form.Subscribe>
         </Stack>
       </form>
+
+      <CreateProjectModal
+        opened={createProjectOpened}
+        onClose={createProjectHandlers.close}
+        onCreated={handleProjectCreated}
+      />
     </Stack>
   )
 }

--- a/ui/src/features/models/pages/ModelCreatePage.tsx
+++ b/ui/src/features/models/pages/ModelCreatePage.tsx
@@ -9,7 +9,7 @@ import {
   Text,
   TextInput,
 } from '@mantine/core'
-import { IconArrowUpRight, IconInfoCircle } from '@tabler/icons-react'
+import { IconExternalLink, IconInfoCircle } from '@tabler/icons-react'
 import { useMutation } from '@tanstack/react-query'
 import {
   Link, useNavigate, useRouter,
@@ -140,12 +140,18 @@ export function ModelCreatePage({ initialProjectId = '' }: ModelCreatePageProps)
                     component={Link}
                     to="/projects"
                     pb="xs"
-                    size="sm"
+                    size="md"
+                    c="var(--mantine-color-text)"
+                    underline="never"
                     flex="0 0 auto"
                   >
-                    <Group gap={4} wrap="nowrap">
+                    <Group gap={6} wrap="nowrap">
                       {t('model.create.createProject')}
-                      <IconArrowUpRight size={16} />
+                      <IconExternalLink
+                        size={28}
+                        stroke={1.75}
+                        color="var(--mantine-primary-color-filled)"
+                      />
                     </Group>
                   </Anchor>
                 )}

--- a/ui/src/features/models/pages/ModelsPage.tsx
+++ b/ui/src/features/models/pages/ModelsPage.tsx
@@ -14,11 +14,11 @@ const { useSearch } = getRouteApi('/(auth)/(app)/models/')
 export function ModelsPage() {
   const search = useSearch()
   const {
-    data, isLoadingError,
+    data, isSuccess,
   } = useQuery(catalogModelsQueryOptions(search))
   const hasActiveFilters = Boolean(search.q || search.task || search.library || search.project)
   const modelCount = data?.pagination?.total ?? data?.items?.length
-  const repositoryIsEmpty = !hasActiveFilters && modelCount === 0
+  const repositoryIsEmpty = isSuccess && !hasActiveFilters && modelCount === 0
 
   return (
     <Flex mih="100%" justify="center" pt="lg" pb="xl">
@@ -55,7 +55,7 @@ export function ModelsPage() {
           flex={76}
           gap="lg"
         >
-          {!repositoryIsEmpty && !isLoadingError && <HotModelList />}
+          {!repositoryIsEmpty && <HotModelList />}
 
           <AllModelList />
         </Stack>

--- a/ui/src/features/models/pages/ModelsPage.tsx
+++ b/ui/src/features/models/pages/ModelsPage.tsx
@@ -1,12 +1,25 @@
 import {
   Box, Flex, Group, Stack,
 } from '@mantine/core'
+import { useQuery } from '@tanstack/react-query'
+import { getRouteApi } from '@tanstack/react-router'
 
 import { AllModelList } from '@/features/models/components/AllModelList'
 import { HotModelList } from '@/features/models/components/HotModelList'
 import { ModelsFilterPanel } from '@/features/models/components/ModelsFilterPanel'
+import { catalogModelsQueryOptions } from '@/features/models/models.query'
+
+const { useSearch } = getRouteApi('/(auth)/(app)/models/')
 
 export function ModelsPage() {
+  const search = useSearch()
+  const {
+    data, isLoadingError,
+  } = useQuery(catalogModelsQueryOptions(search))
+  const hasActiveFilters = Boolean(search.q || search.task || search.library || search.project)
+  const modelCount = data?.pagination?.total ?? data?.items?.length
+  const repositoryIsEmpty = !hasActiveFilters && modelCount === 0
+
   return (
     <Flex mih="100%" justify="center" pt="lg" pb="xl">
       <Group
@@ -42,7 +55,7 @@ export function ModelsPage() {
           flex={76}
           gap="lg"
         >
-          <HotModelList />
+          {!repositoryIsEmpty && !isLoadingError && <HotModelList />}
 
           <AllModelList />
         </Stack>

--- a/ui/src/features/models/pages/ModelsPage.tsx
+++ b/ui/src/features/models/pages/ModelsPage.tsx
@@ -13,12 +13,10 @@ const { useSearch } = getRouteApi('/(auth)/(app)/models/')
 
 export function ModelsPage() {
   const search = useSearch()
-  const {
-    data, isSuccess,
-  } = useQuery(catalogModelsQueryOptions(search))
+  const { data } = useQuery(catalogModelsQueryOptions(search))
   const hasActiveFilters = Boolean(search.q || search.task || search.library || search.project)
   const modelCount = data?.pagination?.total ?? data?.items?.length
-  const repositoryIsEmpty = isSuccess && !hasActiveFilters && modelCount === 0
+  const repositoryIsEmpty = !hasActiveFilters && modelCount === 0
 
   return (
     <Flex mih="100%" justify="center" pt="lg" pb="xl">

--- a/ui/src/features/projects/components/CreateProjectModal.tsx
+++ b/ui/src/features/projects/components/CreateProjectModal.tsx
@@ -25,11 +25,13 @@ import {
 export interface CreateProjectModalProps {
   opened: boolean
   onClose: () => void
+  onCreated?: (projectName: string) => void | Promise<void>
 }
 
 export function CreateProjectModal({
   opened,
   onClose,
+  onCreated,
 }: CreateProjectModalProps) {
   const { t } = useTranslation()
   const mutation = useMutation(createProjectMutationOptions())
@@ -45,6 +47,7 @@ export function CreateProjectModal({
     },
     onSubmit: async ({ value }) => {
       await mutation.mutateAsync(value)
+      await onCreated?.(value.name)
       onClose()
     },
   })

--- a/ui/src/locales/en/model.json
+++ b/ui/src/locales/en/model.json
@@ -12,6 +12,13 @@
     },
     "recommend": "Recommended Models",
     "allModels": "All Models",
+    "noRecommended": "No recommended models",
+    "emptyTitle": "No models yet",
+    "emptyDescription": "Create a model repository, then upload model files to get started.",
+    "create": "Create Model",
+    "uploadGuide": "Learn how to upload models",
+    "loadFailed": "Failed to load models",
+    "retry": "Retry",
     "viewMore": "View More",
     "collapse": "Collapse"
   },
@@ -69,6 +76,7 @@
     "modelNameHelper": "Supports letters, numbers, underscore, hyphen, and dot. Must start with a letter or number.",
     "submit": "Create Model",
     "uploadTip": "After creating the model, you can upload files using the command line.",
+    "createProject": "Create Project",
     "modelNameInvalid": "Invalid model name format",
     "success": "Model created successfully",
     "error": "Failed to create model"

--- a/ui/src/locales/en/model.json
+++ b/ui/src/locales/en/model.json
@@ -77,6 +77,8 @@
     "submit": "Create Model",
     "uploadTip": "After creating the model, you can upload files using the command line.",
     "createProject": "Create Project",
+    "emptyProjectTitle": "No projects yet",
+    "emptyProjectDescription": "Create a project first. It will be selected automatically.",
     "modelNameInvalid": "Invalid model name format",
     "success": "Model created successfully",
     "error": "Failed to create model"

--- a/ui/src/locales/zh/model.json
+++ b/ui/src/locales/zh/model.json
@@ -12,6 +12,13 @@
     },
     "recommend": "推荐模型",
     "allModels": "全部模型",
+    "noRecommended": "暂无推荐模型",
+    "emptyTitle": "还没有模型",
+    "emptyDescription": "先创建一个模型仓库，再上传模型文件开始使用。",
+    "create": "创建模型",
+    "uploadGuide": "了解如何上传模型",
+    "loadFailed": "模型加载失败",
+    "retry": "重试",
     "viewMore": "查看更多",
     "collapse": "收起"
   },
@@ -69,6 +76,7 @@
     "modelNameHelper": "支持数字、字母、下划线、短横线和点，且只能以数字、字母开头",
     "submit": "创建模型",
     "uploadTip": "模型创建完成后，您可以使用命令行上传文件。",
+    "createProject": "创建项目",
     "modelNameInvalid": "模型名称格式不正确",
     "success": "模型创建成功",
     "error": "创建模型失败"

--- a/ui/src/locales/zh/model.json
+++ b/ui/src/locales/zh/model.json
@@ -77,6 +77,8 @@
     "submit": "创建模型",
     "uploadTip": "模型创建完成后，您可以使用命令行上传文件。",
     "createProject": "创建项目",
+    "emptyProjectTitle": "还没有项目",
+    "emptyProjectDescription": "先创建一个项目，创建完成后会自动选中。",
     "modelNameInvalid": "模型名称格式不正确",
     "success": "模型创建成功",
     "error": "创建模型失败"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

An empty model repository previously rendered the generic no-data grid without a clear next step. The create-model form also required users without a writable project to leave the page before they could continue.

This PR:

- replaces the unfiltered empty model grid with a focused card that links to model creation and the upload guide;
- hides recommendations when the repository is genuinely empty, while preserving distinct loading, request-error, filtered-empty, and no-recommendation states;
- lets users create a project in a dialog from the model form and automatically selects the new project;
- preserves the project selector width and alignment, including validation-error layouts;
- shows a compact project empty-state card when no writable projects are available;
- adds matching English and Chinese copy.

#### Which issue(s) this PR fixes:

Fixes #871

#### Special notes for your reviewer:

- Browser verification covered repository empty, filtered empty, loading, request error/retry, no recommendations, create-model navigation, project validation, and project creation with automatic selection.
- The UI package currently has no checked-in unit/E2E test runner, so no automated UI test was added.
- No documentation change is needed; the existing upload guide is linked from the new empty state.

#### Checklist

- [x] Tests(ut, e2e) added or updated, or not needed and explained
- [x] Docs(tech docs, usage docs) updated, or not needed and explained

#### Does this PR introduce a user-facing change?

```release-note
Improved empty model repository guidance and allowed projects to be created directly from the model creation form.
```
