### PR TITLE
fix(ui): bound large commit diff rendering

### DIFF
--- a/ui/src/locales/en/shared.json
+++ b/ui/src/locales/en/shared.json
@@ -27,7 +27,9 @@
     "committedOn": "committed on ",
     "emptyDiff": "No diff content",
     "loadingDiff": "Rendering diff...",
-    "diffLimitNoticeWithLink": "This view is limited to {{count}} files because it contains too many changes. <0>See raw diff</0>"
+    "diffLimitNoticeWithLink": "This view is limited to {{count}} files because it contains too many changes. <0>See raw diff</0>",
+    "diffTooBig": "The diff for this file is too large to render.",
+    "rawDiffLink": "See raw diff"
   },
   "commitsTable": {
     "columns": {

--- a/ui/src/locales/zh/shared.json
+++ b/ui/src/locales/zh/shared.json
@@ -27,7 +27,9 @@
     "committedOn": "提交于 ",
     "emptyDiff": "暂无变更内容",
     "loadingDiff": "正在渲染 diff...",
-    "diffLimitNoticeWithLink": "由于变更过多，此视图仅显示前 {{count}} 个文件。<0>查看原始 diff</0>"
+    "diffLimitNoticeWithLink": "由于变更过多，此视图仅显示前 {{count}} 个文件。<0>查看原始 diff</0>",
+    "diffTooBig": "此文件的 diff 过大，无法渲染。",
+    "rawDiffLink": "查看原始 diff"
   },
   "commitsTable": {
     "columns": {

--- a/ui/src/shared/components/commit-detail/CommitDetail.css
+++ b/ui/src/shared/components/commit-detail/CommitDetail.css
@@ -22,6 +22,12 @@
 .d2h-file-header {
   border-radius: var(--mantine-radius-md)  var(--mantine-radius-md) 0 0;
 }
+
+.commit-detail-raw-diff-link,
+.commit-detail-raw-diff-link:visited {
+  color: var(--mantine-primary-color-filled);
+}
+
 .d2h-files-diff {
   border-radius: 0 0 var(--mantine-radius-md) var(--mantine-radius-md);
   overflow: hidden;

--- a/ui/src/shared/components/commit-detail/CommitDetail.tsx
+++ b/ui/src/shared/components/commit-detail/CommitDetail.tsx
@@ -8,7 +8,6 @@ import {
   Tooltip,
 } from '@mantine/core'
 import dayjs from 'dayjs'
-import { html as formatDiffHtml, parse } from 'diff2html'
 import {
   type MouseEvent,
   useEffect,
@@ -16,6 +15,10 @@ import {
 } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import {
+  MAX_FILES,
+  renderCommitDiff,
+} from '@/shared/components/commit-detail/commitDiff'
 import { CommitHashCard } from '@/shared/components/commit-detail/CommitHashCard'
 import { CommitMessageSection } from '@/shared/components/commit-detail/CommitMessageSection'
 import { DiffLimitAlert } from '@/shared/components/commit-detail/DiffLimitAlert'
@@ -30,19 +33,18 @@ interface CommitDetailProps {
   commit?: Commit
 }
 
-const MAX_FILES = 50
 const DIFF_PARSE_DELAY_MS = 30
 const RAW_DIFF_URL_REVOKE_DELAY_MS = 60_000
 
 interface DiffRenderState {
   html: string
-  hasLimit: boolean
+  hasTooManyFiles: boolean
   loading: boolean
 }
 
 const EMPTY_DIFF_RENDER_STATE: DiffRenderState = {
   html: '',
-  hasLimit: false,
+  hasTooManyFiles: false,
   loading: false,
 }
 
@@ -96,20 +98,15 @@ export function CommitDetail({ commit }: CommitDetailProps) {
         return
       }
 
-      const diffJson = parse(rawDiff)
-      const limitedDiffJson = diffJson.slice(0, MAX_FILES)
-      const nextDiffHtml = limitedDiffJson.length > 0
-        ? formatDiffHtml(limitedDiffJson, {
-            drawFileList: true,
-            matching: 'lines',
-            outputFormat: 'side-by-side',
-          })
-        : ''
+      const nextDiffRender = renderCommitDiff(
+        rawDiff,
+        t('shared.commitDetail.diffTooBig'),
+        t('shared.commitDetail.rawDiffLink'),
+      )
 
       if (!cancelled) {
         setDiffRender({
-          html: nextDiffHtml,
-          hasLimit: diffJson.length > MAX_FILES,
+          ...nextDiffRender,
           loading: false,
         })
       }
@@ -120,17 +117,29 @@ export function CommitDetail({ commit }: CommitDetailProps) {
       window.clearTimeout(loadingTimerId)
       window.clearTimeout(parseTimerId)
     }
-  }, [commit?.diff])
+  }, [commit?.diff, t])
 
-  const handleOpenRawDiff = (event: MouseEvent<HTMLAnchorElement>) => {
-    event.preventDefault()
-
+  const openRawDiff = () => {
     const rawDiffUrl = URL.createObjectURL(
       new Blob([commit?.diff ?? ''], { type: 'text/plain;charset=utf-8' }),
     )
 
     window.open(rawDiffUrl, '_blank', 'noopener,noreferrer')
     setTimeout(() => URL.revokeObjectURL(rawDiffUrl), RAW_DIFF_URL_REVOKE_DELAY_MS)
+  }
+
+  const handleOpenRawDiff = (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault()
+    openRawDiff()
+  }
+
+  const handleDiffHtmlClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (!(event.target instanceof Element) || !event.target.closest('[data-commit-raw-diff-link]')) {
+      return
+    }
+
+    event.preventDefault()
+    openRawDiff()
   }
 
   return (
@@ -179,7 +188,7 @@ export function CommitDetail({ commit }: CommitDetailProps) {
               )
             : (
                 <>
-                  {diffRender.hasLimit
+                  {diffRender.hasTooManyFiles
                     ? (
                         <DiffLimitAlert
                           maxFiles={MAX_FILES}
@@ -193,6 +202,7 @@ export function CommitDetail({ commit }: CommitDetailProps) {
                       ? (
                           <Box
                             pos="relative"
+                            onClick={handleDiffHtmlClick}
                             // diff2html returns escaped markup intended for direct rendering.
                             // eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
                             dangerouslySetInnerHTML={{ __html: diffRender.html }}

--- a/ui/src/shared/components/commit-detail/CommitDetail.tsx
+++ b/ui/src/shared/components/commit-detail/CommitDetail.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from 'react-i18next'
 import {
   MAX_FILES,
   renderCommitDiff,
+  splitCommitDiff,
 } from '@/shared/components/commit-detail/commitDiff'
 import { CommitHashCard } from '@/shared/components/commit-detail/CommitHashCard'
 import { CommitMessageSection } from '@/shared/components/commit-detail/CommitMessageSection'
@@ -119,9 +120,9 @@ export function CommitDetail({ commit }: CommitDetailProps) {
     }
   }, [commit?.diff, t])
 
-  const openRawDiff = () => {
+  const openRawDiff = (diff: string) => {
     const rawDiffUrl = URL.createObjectURL(
-      new Blob([commit?.diff ?? ''], { type: 'text/plain;charset=utf-8' }),
+      new Blob([diff], { type: 'text/plain;charset=utf-8' }),
     )
 
     window.open(rawDiffUrl, '_blank', 'noopener,noreferrer')
@@ -130,16 +131,26 @@ export function CommitDetail({ commit }: CommitDetailProps) {
 
   const handleOpenRawDiff = (event: MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault()
-    openRawDiff()
+    openRawDiff(commit?.diff ?? '')
   }
 
   const handleDiffHtmlClick = (event: MouseEvent<HTMLDivElement>) => {
-    if (!(event.target instanceof Element) || !event.target.closest('[data-commit-raw-diff-link]')) {
+    if (!(event.target instanceof Element)) {
+      return
+    }
+
+    const link = event.target.closest<HTMLElement>('[data-commit-raw-diff-link]')
+
+    if (!link) {
       return
     }
 
     event.preventDefault()
-    openRawDiff()
+
+    const fileIndex = Number(link.dataset.commitRawDiffLink)
+    const fileDiff = splitCommitDiff(commit?.diff ?? '')[fileIndex]
+
+    openRawDiff(fileDiff ?? commit?.diff ?? '')
   }
 
   return (

--- a/ui/src/shared/components/commit-detail/commitDiff.ts
+++ b/ui/src/shared/components/commit-detail/commitDiff.ts
@@ -1,0 +1,40 @@
+import { html as formatDiffHtml, parse } from 'diff2html'
+
+export const MAX_FILES = 50
+const MAX_FILE_DIFF_BYTES = 100_000
+
+interface CommitDiffRender {
+  html: string
+  hasTooManyFiles: boolean
+}
+
+export function renderCommitDiff(
+  rawDiff: string,
+  diffTooBigMessage: string,
+  rawDiffLinkText: string,
+): CommitDiffRender {
+  const message = `${diffTooBigMessage} <a href="#" class="commit-detail-raw-diff-link" data-commit-raw-diff-link>${rawDiffLinkText}</a>`
+  const fileDiffs = rawDiff.split(/(?=^diff --git )/m).filter(Boolean)
+  const diffJson = fileDiffs.slice(0, MAX_FILES).flatMap((fileDiff) => {
+    const isTooBig = new TextEncoder().encode(fileDiff).byteLength > MAX_FILE_DIFF_BYTES
+    const options = isTooBig
+      ? {
+          diffMaxChanges: 0,
+          diffTooBigMessage: () => message,
+        }
+      : undefined
+
+    return parse(isTooBig ? `${fileDiff}\n ` : fileDiff, options)
+  })
+
+  return {
+    html: diffJson.length > 0
+      ? formatDiffHtml(diffJson, {
+          drawFileList: true,
+          matching: 'lines',
+          outputFormat: 'side-by-side',
+        })
+      : '',
+    hasTooManyFiles: fileDiffs.length > MAX_FILES,
+  }
+}

--- a/ui/src/shared/components/commit-detail/commitDiff.ts
+++ b/ui/src/shared/components/commit-detail/commitDiff.ts
@@ -24,7 +24,32 @@ export function renderCommitDiff(
         }
       : undefined
 
-    return parse(isTooBig ? `${fileDiff}\n ` : fileDiff, options)
+    const parsedDiff = parse(isTooBig ? `${fileDiff}\n ` : fileDiff, options)
+
+    if (isTooBig && parsedDiff[0]) {
+      let addedLines = 0
+      let deletedLines = 0
+      let inHunk = false
+
+      for (let lineStart = 0; lineStart < fileDiff.length;) {
+        const lineEnd = fileDiff.indexOf('\n', lineStart)
+
+        if (fileDiff.startsWith('@@', lineStart)) {
+          inHunk = true
+        } else if (inHunk && fileDiff[lineStart] === '+') {
+          addedLines++
+        } else if (inHunk && fileDiff[lineStart] === '-') {
+          deletedLines++
+        }
+
+        lineStart = lineEnd === -1 ? fileDiff.length : lineEnd + 1
+      }
+
+      parsedDiff[0].addedLines = addedLines
+      parsedDiff[0].deletedLines = deletedLines
+    }
+
+    return parsedDiff
   })
 
   return {

--- a/ui/src/shared/components/commit-detail/commitDiff.ts
+++ b/ui/src/shared/components/commit-detail/commitDiff.ts
@@ -3,9 +3,15 @@ import { html as formatDiffHtml, parse } from 'diff2html'
 export const MAX_FILES = 50
 const MAX_FILE_DIFF_BYTES = 100_000
 
+const textEncoder = new TextEncoder()
+
 interface CommitDiffRender {
   html: string
   hasTooManyFiles: boolean
+}
+
+export function splitCommitDiff(rawDiff: string): string[] {
+  return rawDiff.split(/(?=^diff --git )/m).filter(Boolean)
 }
 
 export function renderCommitDiff(
@@ -13,40 +19,25 @@ export function renderCommitDiff(
   diffTooBigMessage: string,
   rawDiffLinkText: string,
 ): CommitDiffRender {
-  const message = `${diffTooBigMessage} <a href="#" class="commit-detail-raw-diff-link" data-commit-raw-diff-link>${rawDiffLinkText}</a>`
-  const fileDiffs = rawDiff.split(/(?=^diff --git )/m).filter(Boolean)
-  const diffJson = fileDiffs.slice(0, MAX_FILES).flatMap((fileDiff) => {
-    const isTooBig = new TextEncoder().encode(fileDiff).byteLength > MAX_FILE_DIFF_BYTES
-    const options = isTooBig
-      ? {
-          diffMaxChanges: 0,
-          diffTooBigMessage: () => message,
-        }
-      : undefined
+  const fileDiffs = splitCommitDiff(rawDiff)
+  const diffJson = fileDiffs.slice(0, MAX_FILES).flatMap((fileDiff, fileIndex) => {
+    const parsedDiff = parse(fileDiff)
 
-    const parsedDiff = parse(isTooBig ? `${fileDiff}\n ` : fileDiff, options)
+    // Parsing is cheap; rendering (especially side-by-side line matching) is what
+    // blows up on large files. Keep the parser's line counts, drop the blocks so
+    // the renderer only emits the placeholder message.
+    if (textEncoder.encode(fileDiff).byteLength > MAX_FILE_DIFF_BYTES) {
+      const message = `${diffTooBigMessage} <a href="#" class="commit-detail-raw-diff-link" data-commit-raw-diff-link="${fileIndex}">${rawDiffLinkText}</a>`
 
-    if (isTooBig && parsedDiff[0]) {
-      let addedLines = 0
-      let deletedLines = 0
-      let inHunk = false
-
-      for (let lineStart = 0; lineStart < fileDiff.length;) {
-        const lineEnd = fileDiff.indexOf('\n', lineStart)
-
-        if (fileDiff.startsWith('@@', lineStart)) {
-          inHunk = true
-        } else if (inHunk && fileDiff[lineStart] === '+') {
-          addedLines++
-        } else if (inHunk && fileDiff[lineStart] === '-') {
-          deletedLines++
-        }
-
-        lineStart = lineEnd === -1 ? fileDiff.length : lineEnd + 1
+      for (const file of parsedDiff) {
+        file.isTooBig = true
+        file.blocks = [{
+          header: message,
+          lines: [],
+          newStartLine: 0,
+          oldStartLine: 0,
+        }]
       }
-
-      parsedDiff[0].addedLines = addedLines
-      parsedDiff[0].deletedLines = deletedLines
     }
 
     return parsedDiff

--- a/ui/tests/commitDiff.test.mjs
+++ b/ui/tests/commitDiff.test.mjs
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { createServer } from 'vite'
+
+const root = fileURLToPath(new URL('../', import.meta.url))
+
+function addedFileDiff(filename, content) {
+  return [
+    `diff --git a/${filename} b/${filename}`,
+    'new file mode 100644',
+    '--- /dev/null',
+    `+++ b/${filename}`,
+    '@@ -0,0 +1 @@',
+    `+${content}`,
+    '',
+  ].join('\n')
+}
+
+function sizedFileDiff(filename, byteLength, fill = 'x') {
+  const emptyDiff = addedFileDiff(filename, '')
+  const contentLength = byteLength - Buffer.byteLength(emptyDiff)
+
+  assert.ok(contentLength >= 0)
+
+  const fillBytes = Buffer.byteLength(fill)
+  const content = fill.repeat(Math.floor(contentLength / fillBytes))
+    + 'x'.repeat(contentLength % fillBytes)
+  const rawDiff = addedFileDiff(filename, content)
+
+  assert.equal(Buffer.byteLength(rawDiff), byteLength)
+
+  return rawDiff
+}
+
+function addedLinesDiff(filename, lines) {
+  return [
+    `diff --git a/${filename} b/${filename}`,
+    'new file mode 100644',
+    '--- /dev/null',
+    `+++ b/${filename}`,
+    `@@ -0,0 +1,${lines.length} @@`,
+    ...lines.map(line => `+${line}`),
+    '',
+  ].join('\n')
+}
+
+test('commit diffs follow the Hugging Face file size and file count limits', async () => {
+  const server = await createServer({
+    appType: 'custom',
+    configFile: false,
+    optimizeDeps: { noDiscovery: true },
+    root,
+    server: { middlewareMode: true },
+  })
+
+  try {
+    const {
+      MAX_FILES,
+      renderCommitDiff,
+    } = await server.ssrLoadModule('/src/shared/components/commit-detail/commitDiff.ts')
+    const message = 'The diff for this file is too large to render.'
+    const linkText = 'See raw diff'
+
+    const atLimitResult = renderCommitDiff(
+      sizedFileDiff('at-limit.txt', 100_000, '界'),
+      message,
+      linkText,
+    )
+
+    assert.equal(atLimitResult.hasTooManyFiles, false)
+    assert.equal(atLimitResult.html.includes(message), false)
+    assert.match(atLimitResult.html, /at-limit\.txt/)
+
+    const overLimitResult = renderCommitDiff(
+      sizedFileDiff('over-limit.txt', 100_001, '界'),
+      message,
+      linkText,
+    )
+
+    assert.equal(overLimitResult.hasTooManyFiles, false)
+    assert.equal(overLimitResult.html.includes(message), true)
+    assert.match(overLimitResult.html, /data-commit-raw-diff-link/)
+    assert.match(overLimitResult.html, />See raw diff<\/a>/)
+    assert.ok(overLimitResult.html.length < 10_000)
+
+    const changedLines = Array.from({ length: 9_000 }, (_, index) => String(index))
+    const changedLinesDiff = addedLinesDiff('many-lines.txt', changedLines)
+
+    assert.ok(Buffer.byteLength(changedLinesDiff) < 100_000)
+
+    const changedLinesResult = renderCommitDiff(
+      changedLinesDiff,
+      message,
+      linkText,
+    )
+
+    assert.equal(changedLinesResult.html.includes(message), false)
+    assert.match(changedLinesResult.html, />8999</)
+
+    const oversizedFilesDiff = Array.from(
+      { length: MAX_FILES + 1 },
+      (_, index) => sizedFileDiff(`file-${index}.txt`, 100_001),
+    ).join('')
+
+    assert.ok(Buffer.byteLength(oversizedFilesDiff) > 5_000_000)
+
+    const fileLimitResult = renderCommitDiff(
+      oversizedFilesDiff,
+      message,
+      linkText,
+    )
+
+    assert.equal(fileLimitResult.hasTooManyFiles, true)
+    assert.match(fileLimitResult.html, new RegExp(`file-${MAX_FILES - 1}\\.txt`))
+    assert.doesNotMatch(fileLimitResult.html, new RegExp(`file-${MAX_FILES}\\.txt`))
+    assert.equal(fileLimitResult.html.split(message).length - 1, MAX_FILES)
+  } finally {
+    await server.close()
+  }
+})

--- a/ui/tests/commitDiff.test.mjs
+++ b/ui/tests/commitDiff.test.mjs
@@ -73,8 +73,21 @@ test('commit diffs follow the Hugging Face file size and file count limits', asy
     assert.equal(atLimitResult.html.includes(message), false)
     assert.match(atLimitResult.html, /at-limit\.txt/)
 
+    const oversizedModifiedDiff = [
+      'diff --git a/over-limit.txt b/over-limit.txt',
+      '--- a/over-limit.txt',
+      '+++ b/over-limit.txt',
+      '@@ -1 +1,2 @@',
+      '-old',
+      '+new',
+      `+${'界'.repeat(40_000)}`,
+      '',
+    ].join('\n')
+
+    assert.ok(Buffer.byteLength(oversizedModifiedDiff) > 100_000)
+
     const overLimitResult = renderCommitDiff(
-      sizedFileDiff('over-limit.txt', 100_001, '界'),
+      oversizedModifiedDiff,
       message,
       linkText,
     )
@@ -83,6 +96,8 @@ test('commit diffs follow the Hugging Face file size and file count limits', asy
     assert.equal(overLimitResult.html.includes(message), true)
     assert.match(overLimitResult.html, /data-commit-raw-diff-link/)
     assert.match(overLimitResult.html, />See raw diff<\/a>/)
+    assert.match(overLimitResult.html, /d2h-lines-added">\+2<\/span>/)
+    assert.match(overLimitResult.html, /d2h-lines-deleted">-1<\/span>/)
     assert.ok(overLimitResult.html.length < 10_000)
 
     const changedLines = Array.from({ length: 9_000 }, (_, index) => String(index))

--- a/ui/tests/commitDiff.test.mjs
+++ b/ui/tests/commitDiff.test.mjs
@@ -59,6 +59,7 @@ test('commit diffs follow the Hugging Face file size and file count limits', asy
     const {
       MAX_FILES,
       renderCommitDiff,
+      splitCommitDiff,
     } = await server.ssrLoadModule('/src/shared/components/commit-detail/commitDiff.ts')
     const message = 'The diff for this file is too large to render.'
     const linkText = 'See raw diff'
@@ -94,7 +95,7 @@ test('commit diffs follow the Hugging Face file size and file count limits', asy
 
     assert.equal(overLimitResult.hasTooManyFiles, false)
     assert.equal(overLimitResult.html.includes(message), true)
-    assert.match(overLimitResult.html, /data-commit-raw-diff-link/)
+    assert.match(overLimitResult.html, /data-commit-raw-diff-link="0"/)
     assert.match(overLimitResult.html, />See raw diff<\/a>/)
     assert.match(overLimitResult.html, /d2h-lines-added">\+2<\/span>/)
     assert.match(overLimitResult.html, /d2h-lines-deleted">-1<\/span>/)
@@ -131,6 +132,9 @@ test('commit diffs follow the Hugging Face file size and file count limits', asy
     assert.match(fileLimitResult.html, new RegExp(`file-${MAX_FILES - 1}\\.txt`))
     assert.doesNotMatch(fileLimitResult.html, new RegExp(`file-${MAX_FILES}\\.txt`))
     assert.equal(fileLimitResult.html.split(message).length - 1, MAX_FILES)
+    assert.match(fileLimitResult.html, new RegExp(`data-commit-raw-diff-link="${MAX_FILES - 1}"`))
+    assert.doesNotMatch(fileLimitResult.html, new RegExp(`data-commit-raw-diff-link="${MAX_FILES}"`))
+    assert.equal(splitCommitDiff(oversizedFilesDiff)[MAX_FILES - 1].startsWith(`diff --git a/file-${MAX_FILES - 1}.txt`), true)
   } finally {
     await server.close()
   }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

Large text commits could expand into a much larger HTML diff and stall or crash the browser.

This PR aligns MatrixHub's commit diff limits with the observed Hugging Face behavior:

- defers diff rendering until commit data is available;
- preserves the existing 50-file cap and its dedicated notice, parsing and rendering only the first 50 files;
- measures each file patch independently using its UTF-8 byte size;
- renders file patches up to 100,000 bytes inline, without separate changed-line or line-length limits;
- shows an inline fallback with a raw diff link only for a file patch larger than 100,000 bytes;
- keeps the existing full raw diff available from every fallback;
- does not add a separate total raw-diff limit;
- adds focused regression coverage for the UTF-8 byte boundary, a 9,000-line patch, an aggregate diff over 5 MB, and 51 changed files.

#### Which issue(s) this PR fixes:

Fixes #439

#### Special notes for your reviewer:

##### Hugging Face reference

Threshold test repository (will be made public): [linghaoSu/issue-439-large-diff-demo](https://huggingface.co/linghaoSu/issue-439-large-diff-demo)

<img width="1126" height="495" alt="image" src="https://github.com/user-attachments/assets/53726c5e-e299-47cb-b85a-00a9ecded277" />
<img width="1917" height="564" alt="image" src="https://github.com/user-attachments/assets/6976a240-2370-4ab7-a30b-16b5d37edf3c" />

Threshold probes indicate that Hugging Face uses a per-file patch-size limit of approximately 100 KB rather than a line-count limit:

- a roughly 99 KB patch with 9,000 added lines renders fully, including the final line;
- a roughly 100.1 KB patch shows the per-file “too large to render” fallback;
- a 51-file commit renders the first 50 files and shows the dedicated 50-file notice.

The exact comparison operator is not published as a public Hugging Face contract. MatrixHub therefore uses the tested boundary of 100,000 bytes rendered and 100,001 bytes omitted.

##### MatrixHub

<img width="1731" height="556" alt="image" src="https://github.com/user-attachments/assets/236a3154-6e01-4e71-8424-9687e3cf0056" />

MatrixHub handles the two limits independently:

- More than 50 changed files: parse and render the first 50 files, then show the original 50-file notice with the raw diff link.
- A file patch larger than 100,000 UTF-8 bytes: show the fallback and raw diff link inside that file only, without the top 50-file notice.
- A file patch at or below the threshold: render it fully, including the verified 9,000-line case.

As requested, this intentionally does not add aggregate line-count, line-length, lazy-rendering, or total-size guards beyond the behavior observed on Hugging Face. A commit containing many files just below the per-file threshold can therefore still be expensive to render.

Validation:

- `node --test tests/commitDiff.test.mjs`
- focused ESLint with pnpm 10
- `tsc -b --noEmit`
- `vite build`
- React Doctor: 92/100, no issues
- independent correctness, style, and traceability reviews: LGTM

#### Checklist

- [x] Tests(ut, e2e) added or updated, or not needed and explained
- [x] Docs(tech docs, usage docs) updated, or not needed and explained

No documentation update is needed; this is an internal rendering safeguard.

#### Does this PR introduce a user-facing change?

```release-note
Large per-file commit diffs now show an inline raw diff link while the existing 50-file limit remains unchanged.
```
