### PR TITLE
fix(ui): remove misleading resource name placeholder in replication form

### DIFF
--- a/ui/src/features/admin/replications/components/ReplicationFormModal.tsx
+++ b/ui/src/features/admin/replications/components/ReplicationFormModal.tsx
@@ -431,7 +431,6 @@ export function ReplicationFormModal({
                   leftSection={renderInlineFieldSection(
                     t('routes.admin.replications.form.resourceName'),
                   )}
-                  placeholder={t('routes.admin.replications.form.resourceNamePlaceholder')}
                   value={field.state.value}
                   onChange={event => field.handleChange(event.currentTarget.value)}
                   onBlur={field.handleBlur}

--- a/ui/src/locales/en/routes/admin.replications.json
+++ b/ui/src/locales/en/routes/admin.replications.json
@@ -55,7 +55,6 @@
     "sourceRegistryHint": "Create a registry first in Registry Management before selecting it here.",
     "resourceFilter": "Resource Filter",
     "resourceName": "Resource Name",
-    "resourceNamePlaceholder": "e.g., model-name or * for all",
     "resourceFilterHint": "Filters resources by name. Leave it empty or use \"*\" to match all resources; \"qwen/**\" only matches resources under \"qwen\". See the user guide for more patterns.",
     "resourceTypes": {
       "label": "Resource Types",

--- a/ui/src/locales/zh/routes/admin.replications.json
+++ b/ui/src/locales/zh/routes/admin.replications.json
@@ -55,7 +55,6 @@
     "sourceRegistryHint": "需先在“仓库管理”中创建仓库。",
     "resourceFilter": "资源过滤器",
     "resourceName": "资源名称",
-    "resourceNamePlaceholder": "例如：model-name 或 * 表示全部",
     "resourceFilterHint": "过滤资源的名字。不填或者填写“*”匹配所有资源；“qwen/**”匹配“qwen”下的资源。更多的匹配模式请参考用户手册。",
     "resourceTypes": {
       "label": "资源类型",


### PR DESCRIPTION
## What

The replication (remote sync) form's **Resource Name** input carried the placeholder `e.g., model-name or * for all` / `例如：model-name 或 * 表示全部`. Users read it as "type the model name", entered a bare name, and the sync job then failed with:

```
[ERROR] local model /Qwen2.5-0.5B not found: failed to get model: record not found
```

The correct guidance — leave empty or use `*` to match all, `qwen/**` to scope by prefix — already lives in the **Resource Filter** tooltip, so the placeholder was both redundant and misleading.

Per the maintainer's decision in the issue thread ("Empty it"), this drops the placeholder entirely and keeps the tooltip as the single source of guidance.

## Changes

- `ui/src/features/admin/replications/components/ReplicationFormModal.tsx` — remove the `placeholder` prop from the resource name `TextInput`
- `ui/src/locales/{en,zh}/routes/admin.replications.json` — remove the now-unused `resourceNamePlaceholder` key

The tooltip hint and the field's `Resource Name` label are untouched.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean

## Notes

Not addressed here, since it's outside the scope of what was asked in the issue: the field is `withAsterisk` and `replications.schema.ts:76` requires `min(1)`, yet the tooltip says the field can be left empty to match all resources. Either the tooltip or the validation is wrong — worth a separate issue.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Remove misleading resource name placeholder in replication form- #954
```

Fixes #854