### PR TITLE
fix(ui): clarify registry target url guidance

### DIFF
--- a/ui/src/features/admin/registries/components/RegistryFormModal.tsx
+++ b/ui/src/features/admin/registries/components/RegistryFormModal.tsx
@@ -300,7 +300,7 @@ export function RegistryFormModal({
                             display="block"
                             inherit
                             c="yellow.7"
-                            mt="xs"
+                            mt={4}
                           >
                             {t(urlCopyKeys.repositoryUrlWarning)}
                           </Text>
@@ -308,7 +308,7 @@ export function RegistryFormModal({
                       </>
                     )}
                     inputWrapperOrder={['label', 'input', 'description', 'error']}
-                    styles={{ error: { marginTop: 'var(--mantine-spacing-xs)' } }}
+                    styles={{ error: { marginTop: 4 } }}
                     value={field.state.value}
                     onChange={event => field.handleChange(event.currentTarget.value)}
                     onBlur={field.handleBlur}

--- a/ui/src/features/admin/registries/components/RegistryFormModal.tsx
+++ b/ui/src/features/admin/registries/components/RegistryFormModal.tsx
@@ -368,10 +368,10 @@ export function RegistryFormModal({
           opened
           onClose={closeProviderSwitchConfirm}
           type="info"
-          size="sm"
+          size="md"
           title={t('routes.admin.registries.switchProviderModal.title')}
           footer={(
-            <Group justify="flex-end" gap="md">
+            <Group justify="flex-end" gap="md" wrap="nowrap">
               <Button
                 color="default"
                 variant="subtle"

--- a/ui/src/features/admin/registries/components/RegistryFormModal.tsx
+++ b/ui/src/features/admin/registries/components/RegistryFormModal.tsx
@@ -5,12 +5,15 @@ import {
   PasswordInput,
   Select,
   Stack,
+  Text,
   TextInput,
   Textarea,
 } from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
 import { RegistryType } from '@matrixhub/api-ts/v1alpha1/registry.pb'
 import { useStore } from '@tanstack/react-form'
 import { useMutation } from '@tanstack/react-query'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { FieldHintLabel } from '@/shared/components/FieldHintLabel'
@@ -24,7 +27,11 @@ import {
   buildUpdateRegistryRequest,
   createRegistryFormSchema,
   editRegistryFormSchema,
+  getRegistryDefaultUrl,
   getRegistryFormValues,
+  getRegistryUrlCopyKeys,
+  isRegistryUrlPristine,
+  isLikelyRepositoryUrl,
   REGISTRY_DESCRIPTION_MAX_LENGTH,
   registryProviderLabelKeys,
   registryDescriptionSchema,
@@ -88,6 +95,69 @@ export function RegistryFormModal({
     }
   })
   const isSubmitting = useStore(form.store, state => state.isSubmitting)
+  const [pendingType, setPendingType] = useState<RegistryType | null>(null)
+  const [
+    switchConfirmOpened,
+    {
+      open: openSwitchConfirm,
+      close: closeSwitchConfirm,
+    },
+  ] = useDisclosure(false)
+
+  const applyProviderChange = (nextType: RegistryType, nextUrl: string) => {
+    form.setFieldValue('type', nextType)
+    form.setFieldValue('url', nextUrl)
+
+    /* Switching providers rewrites the URL on the user's behalf, so the field
+    starts over as untouched instead of complaining about the value it just got. */
+    form.setFieldMeta('url', meta => ({
+      ...meta,
+      isTouched: false,
+      isDirty: false,
+      errors: [],
+      errorMap: {},
+    }))
+  }
+
+  const handleProviderChange = (nextType: RegistryType) => {
+    const currentValues = form.state.values
+
+    if (nextType === currentValues.type) {
+      return
+    }
+
+    /* Only a user-customized URL is worth a confirmation prompt;
+    an untouched one is replaced with the new provider default silently. */
+    if (isRegistryUrlPristine(currentValues.url, currentValues.type)) {
+      applyProviderChange(nextType, getRegistryDefaultUrl(nextType))
+
+      return
+    }
+
+    setPendingType(nextType)
+    openSwitchConfirm()
+  }
+
+  const closeProviderSwitchConfirm = () => {
+    closeSwitchConfirm()
+    setPendingType(null)
+  }
+
+  const handleKeepUrlAndSwitch = () => {
+    if (pendingType != null) {
+      applyProviderChange(pendingType, form.state.values.url)
+    }
+
+    closeProviderSwitchConfirm()
+  }
+
+  const handleClearUrlAndSwitch = () => {
+    if (pendingType != null) {
+      applyProviderChange(pendingType, getRegistryDefaultUrl(pendingType))
+    }
+
+    closeProviderSwitchConfirm()
+  }
 
   const handleTestConnection = async () => {
     await pingMutation.mutateAsync(buildPingRegistryRequest(form.state.values))
@@ -155,7 +225,7 @@ export function RegistryFormModal({
               withAsterisk
               data={providerOptions}
               value={field.state.value}
-              onChange={value => field.handleChange(
+              onChange={value => handleProviderChange(
                 (value as RegistryType | null) ?? RegistryType.REGISTRY_TYPE_HUGGINGFACE,
               )}
               onBlur={field.handleBlur}
@@ -202,22 +272,51 @@ export function RegistryFormModal({
           )}
         </form.Field>
 
-        <form.Field
-          name="url"
-          validators={{ onChange: registryUrlSchema }}
-        >
-          {field => (
-            <TextInput
-              label={t('routes.admin.registries.form.url')}
-              withAsterisk
-              placeholder={t('routes.admin.registries.form.urlPlaceholder')}
-              value={field.state.value}
-              onChange={event => field.handleChange(event.currentTarget.value)}
-              onBlur={field.handleBlur}
-              error={fieldError(field)}
-            />
-          )}
-        </form.Field>
+        <form.Subscribe selector={state => state.values.type}>
+          {(type) => {
+            const urlCopyKeys = getRegistryUrlCopyKeys(type)
+
+            return (
+              <form.Field
+                name="url"
+                validators={{ onChange: registryUrlSchema }}
+              >
+                {field => (
+                  <TextInput
+                    label={(
+                      <FieldHintLabel
+                        label={t('routes.admin.registries.form.url')}
+                        hint={t(urlCopyKeys.hint)}
+                      />
+                    )}
+                    withAsterisk
+                    placeholder={t(urlCopyKeys.placeholder)}
+                    description={(
+                      <>
+                        {t(urlCopyKeys.description)}
+                        {isLikelyRepositoryUrl(field.state.value) && (
+                          <Text
+                            component="span"
+                            display="block"
+                            inherit
+                            c="yellow.7"
+                          >
+                            {t(urlCopyKeys.repositoryUrlWarning)}
+                          </Text>
+                        )}
+                      </>
+                    )}
+                    inputWrapperOrder={['label', 'input', 'description', 'error']}
+                    value={field.state.value}
+                    onChange={event => field.handleChange(event.currentTarget.value)}
+                    onBlur={field.handleBlur}
+                    error={fieldError(field)}
+                  />
+                )}
+              </form.Field>
+            )
+          }}
+        </form.Subscribe>
 
         <form.Field name="username">
           {field => (
@@ -263,6 +362,45 @@ export function RegistryFormModal({
           )}
         </form.Field>
       </Stack>
+
+      {switchConfirmOpened && (
+        <ModalWrapper
+          opened
+          onClose={closeProviderSwitchConfirm}
+          type="info"
+          size="sm"
+          title={t('routes.admin.registries.switchProviderModal.title')}
+          footer={(
+            <Group justify="flex-end" gap="md">
+              <Button
+                color="default"
+                variant="subtle"
+                fw={400}
+                onClick={closeProviderSwitchConfirm}
+              >
+                {t('common.cancel')}
+              </Button>
+              <Button
+                variant="outline"
+                fw={400}
+                onClick={handleClearUrlAndSwitch}
+              >
+                {t('routes.admin.registries.switchProviderModal.clearAndSwitch')}
+              </Button>
+              <Button
+                fw={400}
+                onClick={handleKeepUrlAndSwitch}
+              >
+                {t('routes.admin.registries.switchProviderModal.keepAndSwitch')}
+              </Button>
+            </Group>
+          )}
+        >
+          <Text size="sm">
+            {t('routes.admin.registries.switchProviderModal.description')}
+          </Text>
+        </ModalWrapper>
+      )}
     </ModalWrapper>
   )
 }

--- a/ui/src/features/admin/registries/components/RegistryFormModal.tsx
+++ b/ui/src/features/admin/registries/components/RegistryFormModal.tsx
@@ -300,6 +300,7 @@ export function RegistryFormModal({
                             display="block"
                             inherit
                             c="yellow.7"
+                            mt="xs"
                           >
                             {t(urlCopyKeys.repositoryUrlWarning)}
                           </Text>
@@ -307,6 +308,7 @@ export function RegistryFormModal({
                       </>
                     )}
                     inputWrapperOrder={['label', 'input', 'description', 'error']}
+                    styles={{ error: { marginTop: 'var(--mantine-spacing-xs)' } }}
                     value={field.state.value}
                     onChange={event => field.handleChange(event.currentTarget.value)}
                     onBlur={field.handleBlur}

--- a/ui/src/features/admin/registries/registries.form.ts
+++ b/ui/src/features/admin/registries/registries.form.ts
@@ -23,6 +23,101 @@ export const registryProviderLabelKeys: Partial<Record<RegistryType, string>> = 
   [RegistryType.REGISTRY_TYPE_MATRIXHUB]: 'routes.admin.registries.provider.matrixHub',
 }
 
+export interface RegistryUrlCopyKeys {
+  hint: string
+  description: string
+  placeholder: string
+  repositoryUrlWarning: string
+}
+
+const huggingFaceUrlCopyKeys: RegistryUrlCopyKeys = {
+  hint: 'routes.admin.registries.form.urlHint.huggingFace',
+  description: 'routes.admin.registries.form.urlDescription.huggingFace',
+  placeholder: 'routes.admin.registries.form.urlPlaceholder.huggingFace',
+  repositoryUrlWarning: 'routes.admin.registries.form.urlRepositoryWarning.huggingFace',
+}
+
+/* The target URL is a base address, so the guidance differs per provider:
+Hugging Face accepts the upstream site or a mirror, MatrixHub expects an instance address. */
+const registryUrlCopyKeys: Partial<Record<RegistryType, RegistryUrlCopyKeys>> = {
+  [RegistryType.REGISTRY_TYPE_HUGGINGFACE]: huggingFaceUrlCopyKeys,
+  [RegistryType.REGISTRY_TYPE_MATRIXHUB]: {
+    hint: 'routes.admin.registries.form.urlHint.matrixHub',
+    description: 'routes.admin.registries.form.urlDescription.matrixHub',
+    placeholder: 'routes.admin.registries.form.urlPlaceholder.matrixHub',
+    repositoryUrlWarning: 'routes.admin.registries.form.urlRepositoryWarning.matrixHub',
+  },
+}
+
+export function getRegistryUrlCopyKeys(type: RegistryType): RegistryUrlCopyKeys {
+  return registryUrlCopyKeys[type] ?? huggingFaceUrlCopyKeys
+}
+
+/* Hugging Face has a well-known upstream address that can be prefilled,
+while a MatrixHub instance address is deployment specific and must be typed in. */
+const registryDefaultUrls: Partial<Record<RegistryType, string>> = {
+  [RegistryType.REGISTRY_TYPE_HUGGINGFACE]: 'https://huggingface.co',
+  [RegistryType.REGISTRY_TYPE_MATRIXHUB]: '',
+}
+
+export function getRegistryDefaultUrl(type: RegistryType): string {
+  return registryDefaultUrls[type] ?? ''
+}
+
+/* A URL still equal to its provider default (or empty) was never customized,
+so switching providers may overwrite it without asking. */
+export function isRegistryUrlPristine(url: string, type: RegistryType): boolean {
+  const trimmedUrl = url.trim()
+
+  return trimmedUrl.length === 0 || trimmedUrl === getRegistryDefaultUrl(type)
+}
+
+/* The stored URL is a base address that later gets joined with resource paths,
+so trailing slashes are dropped to keep one canonical form. */
+export function normalizeRegistryUrl(url: string): string {
+  return url.trim().replace(/\/+$/u, '')
+}
+
+/* Paths that only ever appear on a concrete repository address, never on a
+base address. Deliberately narrow: the goal is to catch the common
+copy-the-model-page mistake, not to validate every possible URL shape. */
+const registryRepositoryPathPrefixes = ['models', 'datasets', 'spaces']
+
+/**
+ * Detect a URL that looks like a specific repository rather than a base address,
+ * e.g. `https://huggingface.co/Qwen/Qwen3-32B` or `https://hf-mirror.com/models/...`.
+ * This is advisory only — the address may still be valid, so it never blocks submit.
+ */
+export function isLikelyRepositoryUrl(url: string): boolean {
+  const normalizedUrl = normalizeRegistryUrl(url)
+
+  if (!normalizedUrl) {
+    return false
+  }
+
+  let segments: string[]
+
+  try {
+    segments = new URL(normalizedUrl).pathname
+      .split('/')
+      .filter(Boolean)
+  } catch {
+    return false
+  }
+
+  const [firstSegment] = segments
+
+  if (firstSegment == null) {
+    return false
+  }
+
+  if (registryRepositoryPathPrefixes.includes(firstSegment.toLowerCase())) {
+    return true
+  }
+
+  return segments.length >= 2
+}
+
 export interface RegistryFormValues {
   type: RegistryType
   name: string
@@ -124,12 +219,14 @@ export const createRegistryFormSchema = z.object({
 export const editRegistryFormSchema = createRegistryFormSchema
 
 export function getRegistryFormValues(registry?: Registry | null): RegistryFormValues {
+  const type = registry?.type ?? RegistryType.REGISTRY_TYPE_HUGGINGFACE
+
   return {
     ...defaultRegistryFormValues,
-    type: registry?.type ?? RegistryType.REGISTRY_TYPE_HUGGINGFACE,
+    type,
     name: sanitizeRegistryName(registry?.name ?? ''),
     description: registry?.description ?? '',
-    url: registry?.url ?? '',
+    url: registry?.url ?? getRegistryDefaultUrl(type),
     username: registry?.basic?.username ?? '',
     password: registry?.basic?.password ?? '',
     verifyRemoteCert: !registry?.insecure,
@@ -157,7 +254,7 @@ export function buildCreateRegistryRequest(values: RegistryFormValues): CreateRe
     name: sanitizeRegistryName(values.name),
     description: values.description.trim(),
     type: values.type,
-    url: values.url.trim(),
+    url: normalizeRegistryUrl(values.url),
     insecure: !values.verifyRemoteCert,
     ...(basic ? { basic } : {}),
   }
@@ -173,7 +270,7 @@ export function buildUpdateRegistryRequest(
     id: registryId,
     name: sanitizeRegistryName(values.name),
     description: values.description.trim(),
-    url: values.url.trim(),
+    url: normalizeRegistryUrl(values.url),
     insecure: !values.verifyRemoteCert,
     ...(basic ? { basic } : {}),
   }
@@ -184,7 +281,7 @@ export function buildPingRegistryRequest(values: RegistryFormValues): PingRegist
 
   return {
     type: values.type,
-    url: values.url.trim(),
+    url: normalizeRegistryUrl(values.url),
     insecure: !values.verifyRemoteCert,
     ...(basic ? { basic } : {}),
   }

--- a/ui/src/locales/en/routes/admin.registries.json
+++ b/ui/src/locales/en/routes/admin.registries.json
@@ -10,10 +10,25 @@
   },
   "form": {
     "provider": "Provider",
-    "name": "Registry Name",
+    "name": "Registry Source Name",
     "description": "Description",
-    "url": "Target URL",
-    "urlPlaceholder": "https://hf.m.daocloud.io",
+    "url": "Registry Base URL",
+    "urlHint": {
+      "huggingFace": "Enter the base address of the upstream platform or mirror service, not a specific model or repository path. Examples: https://huggingface.co, https://hf-mirror.com",
+      "matrixHub": "Enter the base address of the MatrixHub instance, not a specific project or model path. Example: http://<matrixhub-host>:<port>"
+    },
+    "urlDescription": {
+      "huggingFace": "Base address of the upstream platform or mirror service",
+      "matrixHub": "Base address of the MatrixHub instance"
+    },
+    "urlPlaceholder": {
+      "huggingFace": "https://huggingface.co",
+      "matrixHub": "http://<matrixhub-host>:<port>"
+    },
+    "urlRepositoryWarning": {
+      "huggingFace": "This looks like a specific repository address. Enter the base address of the platform or mirror service instead, e.g. https://huggingface.co",
+      "matrixHub": "This looks like a specific repository address. Enter the base address of the MatrixHub instance instead, e.g. http://<matrixhub-host>:<port>"
+    },
     "username": "Username",
     "usernameHint": "Enter the upstream registry username and access token when pulling private models; robot accounts are supported.",
     "password": "Access Token",
@@ -57,9 +72,15 @@
     "title": "Delete Registry",
     "description": "Are you sure you want to delete registry {{name}}?"
   },
+  "switchProviderModal": {
+    "title": "Switch Provider",
+    "description": "The current URL has been modified and may not apply after switching providers. Keep it?",
+    "clearAndSwitch": "Clear and Switch",
+    "keepAndSwitch": "Keep and Switch"
+  },
   "validation": {
     "nameLength": "Registry name must be {{min}}-{{max}} characters",
-    "urlRequired": "Target URL is required",
+    "urlRequired": "Registry base URL is required",
     "urlInvalid": "Please enter a valid URL"
   },
   "notifications": {

--- a/ui/src/locales/zh/routes/admin.registries.json
+++ b/ui/src/locales/zh/routes/admin.registries.json
@@ -10,10 +10,25 @@
   },
   "form": {
     "provider": "提供者",
-    "name": "仓库名称",
+    "name": "仓库源名称",
     "description": "描述",
-    "url": "目标 URL",
-    "urlPlaceholder": "https://hf.m.daocloud.io",
+    "url": "仓库源基础 URL",
+    "urlHint": {
+      "huggingFace": "请输入上游平台或镜像服务的基础地址，不要填写具体模型或仓库路径。示例：https://huggingface.co、https://hf-mirror.com",
+      "matrixHub": "请输入 MatrixHub 实例的基础地址，不要填写具体项目或模型路径。示例：http://<matrixhub-host>:<port>"
+    },
+    "urlDescription": {
+      "huggingFace": "请输入上游平台或镜像服务的基础地址",
+      "matrixHub": "请输入 MatrixHub 实例的基础地址"
+    },
+    "urlPlaceholder": {
+      "huggingFace": "https://huggingface.co",
+      "matrixHub": "http://<matrixhub-host>:<port>"
+    },
+    "urlRepositoryWarning": {
+      "huggingFace": "检测到该地址可能是具体仓库地址，请填写平台或镜像服务的基础地址，例如：https://huggingface.co",
+      "matrixHub": "检测到该地址可能是具体仓库地址，请填写 MatrixHub 实例的基础地址，例如：http://<matrixhub-host>:<port>"
+    },
     "username": "用户名",
     "usernameHint": "若拉取目标仓库中的私密模型，请输入目标仓库的用户名和访问密钥，支持机器人账号。",
     "password": "访问密钥",
@@ -57,9 +72,15 @@
     "title": "删除目标仓库",
     "description": "确定要删除目标仓库 {{name}} 吗？"
   },
+  "switchProviderModal": {
+    "title": "切换提供者",
+    "description": "当前 URL 已被修改，切换提供者后可能不适用。是否保留？",
+    "clearAndSwitch": "清空并切换",
+    "keepAndSwitch": "保留并切换"
+  },
   "validation": {
     "nameLength": "名称长度需在{{min}}-{{max}}字符之间",
-    "urlRequired": "请输入目标 URL",
+    "urlRequired": "请输入仓库源基础 URL",
     "urlInvalid": "请输入有效的 URL"
   },
   "notifications": {

--- a/website/docs/operations/platform-settings/registry-management.md
+++ b/website/docs/operations/platform-settings/registry-management.md
@@ -22,7 +22,7 @@ Registry Management is used to configure the platform's connection information f
 
     ![Create Registry](./images/repo-create.jpg)
 
-1. Fill in fields such as **Registry Name**, **Target URL**, **Authentication Information**, and **Certificate Verification** according to your actual environment (see the **Configuration Parameters** below for details).
+1. Fill in fields such as **Registry Source Name**, **Registry Base URL**, **Authentication Information**, and **Certificate Verification** according to your actual environment (see the **Configuration Parameters** below for details).
 
 1. Click **Confirm** to complete the creation. After creation, you can **Edit** or **Delete** the registry in the list; created registries can be used as the **Source Registry** on the **Remote Synchronization** page.
 
@@ -31,8 +31,8 @@ Registry Management is used to configure the platform's connection information f
 | Parameter | Description |
 |-----------|-------------|
 | Provider | The upstream protocol or platform type, such as **Hugging Face**, **ModelScope**, or other supported sources. |
-| Name | The display name of the current connection configuration, an identifiable alias is recommended (e.g., `HF-Official`, `HF-Mirror`). |
-| Target URL | The entry address of the upstream service. Example: `https://huggingface.co`, `https://hf-mirror.com`. |
+| Registry Source Name | The display name of the current connection configuration, an identifiable alias is recommended (e.g., `HF-Official`, `HF-Mirror`). |
+| Registry Base URL | The base address of the upstream platform, mirror service, or MatrixHub instance — not a specific model or repository path.<br />✅ `https://huggingface.co`, `https://hf-mirror.com`, `http://<matrixhub-host>:<port>`<br />❌ `https://huggingface.co/Qwen/Qwen3-32B`, `https://github.com/<owner>/<repo>` |
 | Username | The account identifier used to access upstream private resources; can be left blank for public resources depending on the interface requirements. |
 | Password / Token | The password or access token corresponding to the username. In the Hugging Face scenario, you usually enter the Access Token here. |
 | Verify Remote Certificate | If checked, it verifies the remote TLS certificate. If the remote source uses a self-signed or untrusted certificate, you can uncheck it depending on your environment's policy. |

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operations/platform-settings/registry-management.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/operations/platform-settings/registry-management.md
@@ -22,7 +22,7 @@ sidebar_position: 3
 
     ![创建仓库](./images/repo-create.jpg)
 
-1. 根据您的实际环境，填写 **仓库名称**、**目标 URL**、**认证信息** 和 **证书验证** 等字段（详见下方的**配置参数**）。
+1. 根据您的实际环境，填写 **仓库源名称**、**仓库源基础 URL**、**认证信息** 和 **证书验证** 等字段（详见下方的**配置参数**）。
 
 1. 点击 **确认** 完成创建。创建完成后，您可以在列表中对仓库进行 **编辑** 或 **删除**；已创建的仓库可用作 **远程同步** 页面中的 **源仓库**。
 
@@ -31,8 +31,8 @@ sidebar_position: 3
 | 参数 | 描述 |
 |-----------|-------------|
 | 提供商 | 上游协议或平台类型，如 **Hugging Face**、**ModelScope** 或其他支持的源。 |
-| 名称 | 当前连接配置的显示名称，建议使用易于识别的别名（如 `HF-Official`、`HF-Mirror`）。 |
-| 目标 URL | 上游服务的入口地址。示例：`https://huggingface.co`、`https://hf-mirror.com`。 |
+| 仓库源名称 | 当前连接配置的显示名称，建议使用易于识别的别名（如 `HF-Official`、`HF-Mirror`）。 |
+| 仓库源基础 URL | 上游平台、镜像服务或 MatrixHub 实例的基础地址，不要填写具体模型或仓库路径。<br />✅ `https://huggingface.co`、`https://hf-mirror.com`、`http://<matrixhub-host>:<port>`<br />❌ `https://huggingface.co/Qwen/Qwen3-32B`、`https://github.com/<owner>/<repo>` |
 | 用户名 | 用于访问上游私有资源的账号标识；对于公共资源，根据界面要求可留空。 |
 | 密码 / Token | 与用户名对应的密码或访问令牌。在 Hugging Face 场景中，通常在此处输入 Access Token。 |
 | 验证远程证书 | 如果勾选，将验证远程 TLS 证书。如果远程源使用自签名或不受信任的证书，您可以根据环境策略取消勾选。 |


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

https://github.com/user-attachments/assets/e4e1566f-222f-4878-b6df-d8c02ccc527d


When creating a registry, the Target URL field gave no indication that it expects the base address of a platform or mirror. Users often paste a specific model page (e.g. `https://huggingface.co/Qwen/Qwen3-32B`) or a project repository URL instead, and can only find the right form by trial and error.

This PR fills in the guidance for that field, following the design:

- **Field renaming**: "Registry Name" becomes "Registry Source Name" and "Target URL" becomes "Registry Base URL", so the "base address" semantics are visible in the label itself.
- **Provider-specific copy**: the label gains a question-mark tooltip, a persistent description sits below the input, and the placeholder also varies by provider. Hugging Face points at the upstream platform or a mirror service; MatrixHub points at an instance address.
- **Defaults and provider switching**: selecting Hugging Face prefills `https://huggingface.co`. On a provider switch, an untouched URL is replaced with the new provider's default silently, while a customized one raises a confirmation dialog offering "Clear and Switch" or "Keep and Switch". After clearing, the field returns to an untouched state so it does not immediately show a "required" error.
- **Trailing slash normalization**: trailing `/` is stripped on submit so the stored value has one canonical form.
- **Repository-address warning**: URLs with a `/models`, `/datasets` or `/spaces` prefix, or with two or more path segments, get an advisory note below the field along with a correct example. Per the design, the detection is deliberately narrow rather than attempting to cover every complex URL, and the warning never blocks submit.

#### Which issue(s) this PR fixes:

Fixes #486

#### Special notes for your reviewer:

- The repository-address detection is intentionally conservative: a single-segment path such as `http://host:8080/matrixhub` (possibly a sub-path deployment) does not trigger the warning. Only known prefixes or paths with two or more segments do.
- After "Clear and Switch" the field meta is reset to untouched, which makes `isValid` true. The Test Connection button is unaffected because its disabled condition already includes a non-empty URL check, and `onSubmit` validation still rejects an empty value.
- The configuration parameter tables in the docs were updated to match the new field names, with correct/incorrect address examples added.

#### Checklist

- [ ] Tests(ut, e2e) added or updated, or not needed and explained
- [x] Docs(tech docs, usage docs) updated, or not needed and explained

The repository has no frontend unit test setup, and this change covers form copy and interaction only, so no tests were added. Verified with `pnpm lint` and `pnpm build`.

#### Does this PR introduce a user-facing change?

```release-note
Improve guidance for the Registry Base URL field when creating a registry: provider-specific hints and defaults, a confirmation before overwriting a customized URL on provider switch, and a warning for addresses that look like a specific repository.
```
