### PR TITLE
fix(ui): guide empty registry on project creation

### DIFF
--- a/ui/src/features/admin/registries/components/CreateRegistryAction.tsx
+++ b/ui/src/features/admin/registries/components/CreateRegistryAction.tsx
@@ -1,16 +1,43 @@
 import { Button } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { IconHomePlus } from '@tabler/icons-react'
+import { getRouteApi } from '@tanstack/react-router'
+import { useEffect, useEffectEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { RegistryFormModal } from './RegistryFormModal'
 
+const registriesRouteApi = getRouteApi('/(auth)/admin/registries')
+
 export function CreateRegistryAction() {
   const { t } = useTranslation()
+  const navigate = registriesRouteApi.useNavigate()
+  const { create } = registriesRouteApi.useSearch()
   const [opened, {
     open,
     close,
   }] = useDisclosure(false)
+
+  // `?create=true` (e.g. from project creation) opens the dialog on arrival.
+  // The param is dropped right away so a later reload does not reopen it.
+  const openFromSearch = useEffectEvent(() => {
+    if (!create) {
+      return
+    }
+
+    open()
+    void navigate({
+      search: prev => ({
+        ...prev,
+        create: undefined,
+      }),
+      replace: true,
+    })
+  })
+
+  useEffect(() => {
+    openFromSearch()
+  }, [create])
 
   return (
     <>

--- a/ui/src/features/admin/registries/components/RegistryFormModal.tsx
+++ b/ui/src/features/admin/registries/components/RegistryFormModal.tsx
@@ -243,6 +243,9 @@ export function RegistryFormModal({
             <TextInput
               label={t('routes.admin.registries.form.name')}
               withAsterisk
+              // The provider select above it already has a usable default,
+              // so focus starts on the first field that needs input.
+              data-autofocus
               value={field.state.value}
               onChange={event => field.handleChange(
                 sanitizeRegistryName(event.currentTarget.value),

--- a/ui/src/features/admin/registries/registries.query.ts
+++ b/ui/src/features/admin/registries/registries.query.ts
@@ -13,7 +13,16 @@ import {
 export const adminRegistryKeys = {
   all: ['admin', 'registries'] as const,
   lists: () => [...adminRegistryKeys.all, 'list'] as const,
-  list: (search: RegistriesSearch) => [...adminRegistryKeys.lists(), search] as const,
+  // Only paging/search affect the response, so UI-only params (e.g. `create`)
+  // must not become part of the cache key.
+  list: (search: RegistriesSearch) => [
+    ...adminRegistryKeys.lists(),
+    {
+      page: search.page,
+      query: search.query,
+    },
+  ] as const,
+  allList: () => [...adminRegistryKeys.lists(), 'all'] as const,
 }
 
 export function registriesQueryOptions(search: RegistriesSearch) {
@@ -30,6 +39,21 @@ export function registriesQueryOptions(search: RegistriesSearch) {
         registries: response.registries ?? [],
         pagination: response.pagination,
       }
+    },
+  })
+}
+
+/**
+ * Every registry in one page, for selectors such as project creation.
+ * Shares the `lists()` key prefix so registry mutations invalidate it too.
+ */
+export function allRegistriesQueryOptions() {
+  return queryOptions({
+    queryKey: adminRegistryKeys.allList(),
+    queryFn: async () => {
+      const response = await Registries.ListRegistries({ pageSize: -1 })
+
+      return response.registries ?? []
     },
   })
 }

--- a/ui/src/features/admin/registries/registries.schema.ts
+++ b/ui/src/features/admin/registries/registries.schema.ts
@@ -6,11 +6,19 @@ export const DEFAULT_REGISTRIES_PAGE_SIZE = 10
 export const registriesSearchDefaults = {
   page: DEFAULT_REGISTRIES_PAGE,
   query: undefined as string | undefined,
+  create: undefined as boolean | undefined,
 }
 
 export const registriesSearchSchema = z.object({
   page: z.coerce.number().int().positive().default(registriesSearchDefaults.page).catch(registriesSearchDefaults.page),
   query: z.string().trim().optional().catch(registriesSearchDefaults.query),
+  // Opens the create dialog on arrival, e.g. when linked from project creation.
+  // Accepts both the parsed boolean and the raw "true"/"false" string, since
+  // the router may hand over either. `z.coerce.boolean()` is unusable here:
+  // it turns the string "false" into true.
+  create: z.union([z.boolean(), z.enum(['true', 'false']).transform(v => v === 'true')])
+    .optional()
+    .catch(registriesSearchDefaults.create),
 })
 
 export type RegistriesSearch = z.infer<typeof registriesSearchSchema>

--- a/ui/src/features/projects/components/CreateProjectModal.tsx
+++ b/ui/src/features/projects/components/CreateProjectModal.tsx
@@ -1,6 +1,5 @@
 import {
   ActionIcon,
-  Anchor,
   Checkbox,
   Group,
   Input,
@@ -20,6 +19,7 @@ import { Trans, useTranslation } from 'react-i18next'
 
 import { allRegistriesQueryOptions } from '@/features/admin/registries/registries.query'
 import { useCurrentUser } from '@/features/auth/auth.query'
+import AnchorLink from '@/shared/components/AnchorLink'
 import { FieldHintLabel } from '@/shared/components/FieldHintLabel.tsx'
 import { ModalWrapper } from '@/shared/components/ModalWrapper'
 import { useForm } from '@/shared/hooks/useForm'
@@ -39,8 +39,6 @@ export interface CreateProjectModalProps {
   onCreated?: (projectName: string) => void | Promise<void>
 }
 
-const REGISTRY_CREATE_PATH = '/admin/registries?create=true'
-
 /**
  * Link to registry creation. Opened in a new tab so the half-filled project
  * form stays untouched, with the usual icon marking the tab switch.
@@ -53,10 +51,10 @@ function RegistryCreateLink({
   size?: MantineSize
 }) {
   return (
-    <Anchor
-      href={REGISTRY_CREATE_PATH}
+    <AnchorLink
+      to="/admin/registries"
+      search={{ create: true }}
       target="_blank"
-      rel="noopener noreferrer"
       size={size}
       inherit={!size}
     >
@@ -64,7 +62,7 @@ function RegistryCreateLink({
         {children}
         <IconExternalLink size={14} />
       </Group>
-    </Anchor>
+    </AnchorLink>
   )
 }
 
@@ -115,10 +113,13 @@ export function CreateProjectModal({
     label: r.name ?? r.url ?? '',
   }))
 
-  // Only treat an empty list as "no registry" once the request has succeeded,
-  // so loading and error states do not show the guidance by mistake.
+  // Both states are decided only once the request has succeeded, so loading
+  // and error states show neither the guidance nor the shortcut, and the row
+  // does not shift as the request settles.
   const showEmptyRegistryHint
     = registriesQuery.isSuccess && registryOptions.length === 0
+  const showCreateRegistryShortcut
+    = registriesQuery.isSuccess && registryOptions.length > 0
 
   // Opened in a new tab so the half-filled project form stays untouched here.
   const registryLink = <RegistryCreateLink />
@@ -214,10 +215,12 @@ export function CreateProjectModal({
               <form.Subscribe selector={s => s.values.enabledProxy}>
                 {enabledProxy => enabledProxy && !showEmptyRegistryHint && (
                   <Group gap="xs" align="center" wrap="nowrap">
-                    <RegistryCreateLink size="sm">
-                      <IconPlus size={14} />
-                      {t('projects.createModal.createRegistry')}
-                    </RegistryCreateLink>
+                    {showCreateRegistryShortcut && (
+                      <RegistryCreateLink size="sm">
+                        <IconPlus size={14} />
+                        {t('projects.createModal.createRegistry')}
+                      </RegistryCreateLink>
+                    )}
                     {refreshRegistriesButton}
                   </Group>
                 )}

--- a/ui/src/features/projects/components/CreateProjectModal.tsx
+++ b/ui/src/features/projects/components/CreateProjectModal.tsx
@@ -1,16 +1,24 @@
 import {
+  ActionIcon,
+  Anchor,
   Checkbox,
   Group,
   Input,
   Select,
+  Stack,
   Switch,
+  Text,
   TextInput,
+  Tooltip,
 } from '@mantine/core'
-import { Registries } from '@matrixhub/api-ts/v1alpha1/registry.pb'
+import {
+  IconExternalLink, IconInfoCircle, IconPlus, IconRefresh,
+} from '@tabler/icons-react'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { useEffect, useEffectEvent } from 'react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 
+import { allRegistriesQueryOptions } from '@/features/admin/registries/registries.query'
 import { useCurrentUser } from '@/features/auth/auth.query'
 import { FieldHintLabel } from '@/shared/components/FieldHintLabel.tsx'
 import { ModalWrapper } from '@/shared/components/ModalWrapper'
@@ -22,10 +30,42 @@ import {
   organizationSchema, projectNameSchema, registryIdSchema,
 } from '../projects.schema'
 
+import type { MantineSize } from '@mantine/core'
+import type { ReactNode } from 'react'
+
 export interface CreateProjectModalProps {
   opened: boolean
   onClose: () => void
   onCreated?: (projectName: string) => void | Promise<void>
+}
+
+const REGISTRY_CREATE_PATH = '/admin/registries?create=true'
+
+/**
+ * Link to registry creation. Opened in a new tab so the half-filled project
+ * form stays untouched, with the usual icon marking the tab switch.
+ */
+function RegistryCreateLink({
+  children,
+  size,
+}: {
+  children?: ReactNode
+  size?: MantineSize
+}) {
+  return (
+    <Anchor
+      href={REGISTRY_CREATE_PATH}
+      target="_blank"
+      rel="noopener noreferrer"
+      size={size}
+      inherit={!size}
+    >
+      <Group component="span" gap={2} align="center" wrap="nowrap" display="inline-flex">
+        {children}
+        <IconExternalLink size={14} />
+      </Group>
+    </Anchor>
+  )
 }
 
 export function CreateProjectModal({
@@ -66,15 +106,38 @@ export function CreateProjectModal({
 
   // Fetch registries for the dropdown when proxy is enabled
   const registriesQuery = useQuery({
-    queryKey: ['registries', 'list'],
-    queryFn: () => Registries.ListRegistries({ pageSize: -1 }),
+    ...allRegistriesQueryOptions(),
     enabled: opened,
   })
 
-  const registryOptions = (registriesQuery.data?.registries ?? []).map(r => ({
+  const registryOptions = (registriesQuery.data ?? []).map(r => ({
     value: String(r.id),
     label: r.name ?? r.url ?? '',
   }))
+
+  // Only treat an empty list as "no registry" once the request has succeeded,
+  // so loading and error states do not show the guidance by mistake.
+  const showEmptyRegistryHint
+    = registriesQuery.isSuccess && registryOptions.length === 0
+
+  // Opened in a new tab so the half-filled project form stays untouched here.
+  const registryLink = <RegistryCreateLink />
+
+  // Sits next to whichever registry action is currently shown: the create
+  // shortcut when registries exist, the guidance line when none do.
+  const refreshRegistriesButton = (
+    <Tooltip label={t('projects.createModal.refreshRegistries')}>
+      <ActionIcon
+        variant="subtle"
+        color="gray"
+        aria-label={t('projects.createModal.refreshRegistries')}
+        loading={registriesQuery.isFetching}
+        onClick={() => void registriesQuery.refetch()}
+      >
+        <IconRefresh size={16} />
+      </ActionIcon>
+    </Tooltip>
+  )
 
   const handleSubmit = () => {
     void form.handleSubmit()
@@ -130,60 +193,94 @@ export function CreateProjectModal({
               />
             )}
           >
-            <form.Field name="enabledProxy">
-              {field => (
-                <Switch
-                  mt={4}
-                  label={field.state.value
-                    ? t('projects.createModal.proxyEnabled')
-                    : t('projects.createModal.proxyDisabled')}
-                  checked={field.state.value}
-                  onChange={(e) => {
-                    field.handleChange(e.currentTarget.checked)
-                    if (!e.currentTarget.checked) {
-                      form.deleteField('organization')
-                      form.deleteField('registryId')
-                    }
-                  }}
-                />
-              )}
-            </form.Field>
+            <Group justify="space-between" align="center" wrap="nowrap" mt={4}>
+              <form.Field name="enabledProxy">
+                {field => (
+                  <Switch
+                    label={field.state.value
+                      ? t('projects.createModal.proxyEnabled')
+                      : t('projects.createModal.proxyDisabled')}
+                    checked={field.state.value}
+                    onChange={(e) => {
+                      field.handleChange(e.currentTarget.checked)
+                      if (!e.currentTarget.checked) {
+                        form.deleteField('organization')
+                        form.deleteField('registryId')
+                      }
+                    }}
+                  />
+                )}
+              </form.Field>
+              <form.Subscribe selector={s => s.values.enabledProxy}>
+                {enabledProxy => enabledProxy && !showEmptyRegistryHint && (
+                  <Group gap="xs" align="center" wrap="nowrap">
+                    <RegistryCreateLink size="sm">
+                      <IconPlus size={14} />
+                      {t('projects.createModal.createRegistry')}
+                    </RegistryCreateLink>
+                    {refreshRegistriesButton}
+                  </Group>
+                )}
+              </form.Subscribe>
+            </Group>
             <form.Subscribe selector={s => s.values.enabledProxy}>
               {enabledProxy => enabledProxy && (
-                <Group gap="xs" grow align="flex-start" mt="xs">
-                  <form.Field
-                    name="registryId"
-                    validators={{
-                      onChange: registryIdSchema,
-                    }}
-                  >
-                    {field => (
-                      <Select
-                        data={registryOptions}
-                        value={field.state.value != null ? String(field.state.value) : null}
-                        onChange={val => field.handleChange(Number(val))}
-                        onBlur={field.handleBlur}
-                        error={fieldError(field)}
+                <Stack gap="xs" mt="xs">
+                  {showEmptyRegistryHint && (
+                    <Group gap={4} align="center" wrap="nowrap">
+                      <IconInfoCircle
+                        size={16}
+                        color="var(--mantine-primary-color-filled)"
                       />
-                    )}
-                  </form.Field>
+                      <Text size="sm" c="dimmed">
+                        <Trans
+                          i18nKey="projects.createModal.emptyRegistryHint"
+                          components={[registryLink]}
+                        />
+                      </Text>
+                      {refreshRegistriesButton}
+                    </Group>
+                  )}
 
-                  <form.Field
-                    name="organization"
-                    validators={{
-                      onChange: organizationSchema,
-                    }}
-                  >
-                    {field => (
-                      <TextInput
-                        placeholder={t('projects.createModal.organizationPlaceholder')}
-                        value={field.state.value ?? ''}
-                        onChange={e => field.handleChange(e.currentTarget.value)}
-                        error={fieldError(field)}
-                      />
-                    )}
-                  </form.Field>
-                </Group>
+                  <Group gap="xs" align="flex-start" wrap="nowrap">
+                    <form.Field
+                      name="registryId"
+                      validators={{
+                        onChange: registryIdSchema,
+                      }}
+                    >
+                      {field => (
+                        <Select
+                          flex={1}
+                          data={registryOptions}
+                          placeholder={t('projects.createModal.registryPlaceholder')}
+                          nothingFoundMessage={t('projects.createModal.registryEmptyOption')}
+                          value={field.state.value != null ? String(field.state.value) : null}
+                          onChange={val => field.handleChange(Number(val))}
+                          onBlur={field.handleBlur}
+                          error={fieldError(field)}
+                        />
+                      )}
+                    </form.Field>
+
+                    <form.Field
+                      name="organization"
+                      validators={{
+                        onChange: organizationSchema,
+                      }}
+                    >
+                      {field => (
+                        <TextInput
+                          flex={1}
+                          placeholder={t('projects.createModal.organizationPlaceholder')}
+                          value={field.state.value ?? ''}
+                          onChange={e => field.handleChange(e.currentTarget.value)}
+                          error={fieldError(field)}
+                        />
+                      )}
+                    </form.Field>
+                  </Group>
+                </Stack>
               )}
             </form.Subscribe>
           </Input.Wrapper>

--- a/ui/src/locales/en/projects.json
+++ b/ui/src/locales/en/projects.json
@@ -113,6 +113,11 @@
     "registryLabel": "Registry",
     "organizationLabel": "Organization / User",
     "organizationPlaceholder": "For example: Qwen",
+    "createRegistry": "Create Registry",
+    "emptyRegistryHint": "No registry available. Please <0>create a registry</0> first.",
+    "registryPlaceholder": "https://huggingface.co",
+    "registryEmptyOption": "No data",
+    "refreshRegistries": "Refresh registry list",
     "createFailed": "Failed to create project"
   },
   "deleteModal": {

--- a/ui/src/locales/zh/projects.json
+++ b/ui/src/locales/zh/projects.json
@@ -113,6 +113,11 @@
     "registryLabel": "上游仓库",
     "organizationLabel": "Organization / 用户名",
     "organizationPlaceholder": "例如：Qwen",
+    "createRegistry": "创建目标仓库",
+    "emptyRegistryHint": "暂无可用目标仓库，请先创建仓库，<0>去创建目标仓库</0>",
+    "registryPlaceholder": "https://huggingface.co",
+    "registryEmptyOption": "暂无数据",
+    "refreshRegistries": "刷新仓库列表",
     "createFailed": "项目创建失败"
   },
   "deleteModal": {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When creating a project with proxy enabled, the registry selector gave no
explanation when it had no options — users had no way to know that a registry
must be created first, or where to do it.

This adds:

- An inline hint below the proxy toggle when no registry exists, linking to
  registry creation.
- A `+ Create Registry` shortcut in the same row when registries already exist.
- A refresh control to pick up registries created elsewhere without reopening
  the project dialog.

Both links open in a **new tab** so the half-filled project form is preserved,
and carry `?create=true` so the registry dialog opens immediately on arrival
(the param is stripped right after, so a later reload does not reopen it).

The empty state is only shown once the request has succeeded, so loading and
error states do not show the guidance by mistake.

<img width="2596" height="1544" alt="image" src="https://github.com/user-attachments/assets/5aa156c4-0a46-4253-85b7-916c88a95e9a" />

<img width="1816" height="1308" alt="image" src="https://github.com/user-attachments/assets/f8e5746c-4e59-455e-a218-ef61aa794a82" />


#### Special notes for your reviewer:

**Pre-existing bug fixed along the way.** The registry selector queried
`['registries', 'list']` while registry mutations invalidate
`['admin', 'registries', 'list']`. The two never matched, so a newly created
registry would not appear in the selector. The selector now goes through
`allRegistriesQueryOptions()`, which shares the admin key prefix. Without this,
the new refresh button would have been the only way to see a new registry.

`adminRegistryKeys.list()` previously spread the whole search object into the
cache key; it now picks only `page` and `query`, so the new UI-only `create`
param does not fragment the cache.

The `create` search param deliberately avoids `z.coerce.boolean()`, which
would turn the string `"false"` into `true`.

Also focuses the registry name field in the create dialog — focus previously
landed on the provider select, which already has a usable default.

#### Which issue(s) this PR fixes:

Fixes #485

#### Checklist

- [ ] Tests(ut, e2e) added or updated, or not needed and explained
- [ ] Docs(tech docs, usage docs) updated, or not needed and explained

No tests added — the repo has no test setup for UI components, and this is
presentational. Verified with `tsc -b --noEmit` and `eslint`. No docs update
needed: no API or user-facing configuration change.

#### Does this PR introduce a user-facing change?

```release-note
Guide users to create a registry when the target registry selector is empty during project creation.
```
