### PR TITLE
fix(ui): make table columns fit and keep row actions reachable (#949)

### DIFF
--- a/ui/agents/patterns.md
+++ b/ui/agents/patterns.md
@@ -392,6 +392,14 @@ Peer deps kept in the project: `@mantine/dates`, `@tabler/icons-react`, `clsx`, 
 
 All data tables go through the project wrapper. If the wrapper does not yet cover your case, extend the wrapper first, then use it in the page. The wrapper owns pagination, loading, empty state, row actions, selection behavior, shared styling, and default MRT filter behavior. Feature tables should only opt specific columns in with `enableColumnFilter: true` and the needed column filter props. Use `DataTable`'s `enableRowActions` + `renderRowActions` for per-row operations instead of adding regular columns like `id: 'actions'`. Use `pinRowActions` when the row actions column should remain fixed during horizontal scrolling.
 
+**Column width and overflow.** The wrapper runs MRT in `layoutMode: 'grid'`, so per-column `size` / `minSize` / `maxSize` actually apply (in the default `semantic` mode they mostly do not). Wrapper defaults are `size: 160`, `minSize: 80`, `maxSize: 400`; override per column in the feature table. Columns grow to fill leftover width by default — set `grow: false` on fixed-content columns (badges, dates, action buttons) so the growth goes to the text-heavy columns instead. This keeps the table inside the viewport on wide screens; the container still scrolls horizontally when the viewport is genuinely too narrow.
+
+For a column whose value can overflow its width, render `TruncatedText` (`src/shared/components/TruncatedText.tsx`) instead of a bare `<Text>`: it clamps to one line and shows the full value in a tooltip, but only when the text actually overflows. Pass custom content as `children` when the cell renders something other than plain text (e.g. an `Anchor`).
+
+When a table is wide enough to scroll, pin the identity columns with `tableOptions.enableColumnPinning` + `initialState.columnPinning.left` so the user can still tell which row they are on, and combine it with `pinRowActions` so the actions stay reachable without scrolling to the far edge. `src/features/admin/registries/components/RegistriesTable.tsx` is the reference.
+
+The wrapper also gates the pinned-column shadow on real scroll position (`DataTable.module.css`). MRT paints that divider whenever a column is pinned, even when the table fits and nothing can scroll; the wrapper tracks the container's `scrollLeft` / `scrollWidth` and hides each side's shadow until that side actually has content out of view. The same stylesheet overrides two other MRT defaults that only misbehave under `layoutMode: 'grid'` — pinned cells are forced opaque (MRT's `opacity: 0.97` lets the scrolling columns bleed through them), and the row border is moved from `tr` onto `td` (flex rows do not collapse the border into the fixed cell height, so every row would grow by 1px).
+
 Route-backed list pages hold search params, pagination navigation, refresh triggers, and row-selection state in the page layer or a shared hook — `src/shared/hooks/useRouteListState.ts`. The hook expects the search object to have `page` and `query` fields, and derives selected row ids + current-page selected records from `records` + `getRecordId`. Feature table components stay focused on columns, cells, and feature-specific toolbar actions.
 
 Do not introduce a second table abstraction or a second table library for the same class of UI.
@@ -465,3 +473,4 @@ import { Users } from '@matrixhub/api-ts/v1alpha1/user.pb'
 - Do not wire `mantine-react-table` directly in a feature page — use the project wrapper.
 - Do not add a direct `@tanstack/react-table` dependency.
 - Do not introduce a second table library for the same class of UI without agreement.
+- Do not leave overflow-prone columns un-truncated — use `TruncatedText` instead of letting one long value stretch the whole table.

--- a/ui/src/features/admin/registries/components/RegistriesTable.tsx
+++ b/ui/src/features/admin/registries/components/RegistriesTable.tsx
@@ -13,6 +13,7 @@ import {
   type DataTableProps,
   type DataTableRowActionsProps,
 } from '@/shared/components/DataTable'
+import { TruncatedText } from '@/shared/components/TruncatedText'
 import { formatDateTime } from '@/shared/utils/date'
 
 import { DeleteRegistryAction } from './DeleteRegistryAction'
@@ -26,6 +27,12 @@ import type { MRT_ColumnDef } from 'mantine-react-table'
 type RegistryCellProps = Parameters<NonNullable<MRT_ColumnDef<Registry>['Cell']>>[0]
 
 type RegistriesTableProps = Omit<DataTableProps<Registry>, 'columns'>
+
+function RegistryNameCell({ row }: RegistryCellProps) {
+  const name = row.original.name
+
+  return <TruncatedText value={name || '-'} />
+}
 
 function RegistryTypeCell({ row }: RegistryCellProps) {
   const { t } = useTranslation()
@@ -66,9 +73,11 @@ function RegistryUrlCell({ row }: RegistryCellProps) {
   }
 
   return (
-    <Anchor size="sm" href={url} target="_blank" rel="noopener noreferrer">
-      {url}
-    </Anchor>
+    <TruncatedText value={url}>
+      <Anchor size="sm" href={url} target="_blank" rel="noopener noreferrer">
+        {url}
+      </Anchor>
+    </TruncatedText>
   )
 }
 
@@ -122,37 +131,51 @@ export function RegistriesTable(props: RegistriesTableProps) {
     {
       id: 'name',
       header: t('routes.admin.registries.table.name'),
-      accessorFn: row => row.name ?? '-',
+      size: 180,
+      minSize: 140,
+      Cell: RegistryNameCell,
     },
     {
       id: 'status',
       header: t('routes.admin.registries.table.status'),
+      size: 100,
+      grow: false,
       Cell: RegistryStatusCell,
     },
     {
       id: 'url',
       header: t('routes.admin.registries.table.url'),
+      size: 190,
+      minSize: 160,
       Cell: RegistryUrlCell,
     },
     {
       id: 'type',
       header: t('routes.admin.registries.table.type'),
+      size: 130,
+      grow: false,
       Cell: RegistryTypeCell,
     },
     {
       id: 'insecure',
       header: t('routes.admin.registries.table.insecure'),
+      size: 160,
+      grow: false,
       Cell: RegistryInsecureCell,
     },
     {
       id: 'credential',
       header: t('routes.admin.registries.table.credential'),
+      size: 100,
+      grow: false,
       Cell: RegistryCredentialCell,
     },
     {
       id: 'createdAt',
       header: t('routes.admin.registries.table.createdAt'),
       accessorFn: row => formatDateTime(row.createdAt),
+      size: 150,
+      grow: false,
     },
   ], [t])
 
@@ -165,6 +188,14 @@ export function RegistriesTable(props: RegistriesTableProps) {
       getRowId={getRegistryRowId}
       enableRowActions
       renderRowActions={RegistryActionsCell}
+      pinRowActions
+      tableOptions={{
+        enableColumnPinning: true,
+        initialState: {
+          // Keep the row identity visible while scrolling the wider columns.
+          columnPinning: { left: ['name'] },
+        },
+      }}
     />
   )
 }

--- a/ui/src/features/admin/replications/components/ReplicationsTable.tsx
+++ b/ui/src/features/admin/replications/components/ReplicationsTable.tsx
@@ -19,6 +19,7 @@ import {
   type DataTableRowActionsProps,
 } from '@/shared/components/DataTable'
 import { FieldHintLabel } from '@/shared/components/FieldHintLabel'
+import { TruncatedText } from '@/shared/components/TruncatedText'
 
 import { DeleteReplicationAction } from './DeleteReplicationAction'
 import { EditReplicationAction } from './EditReplicationAction'
@@ -40,32 +41,36 @@ type ReplicationsTableProps = Omit<DataTableProps<SyncPolicyItem>, 'columns'>
 
 const EMPTY_VALUE = '-'
 
+function ReplicationTruncatedTextCell({ cell }: ReplicationCellProps) {
+  return <TruncatedText value={cell.getValue<string>() || '-'} />
+}
+
 function ReplicationNameCell({ row }: ReplicationCellProps) {
   const name = row.original.name
   const replicationId = row.original.id
 
   if (replicationId == null) {
     return (
-      <Text fw={500}>
-        {name ?? EMPTY_VALUE}
-      </Text>
+      <TruncatedText value={name ?? EMPTY_VALUE} fw={500} />
     )
   }
 
   return (
-    <Anchor
-      fw={500}
-      underline="never"
-      renderRoot={props => (
-        <Link
-          {...props}
-          to="/admin/replications/$replicationId/executions"
-          params={{ replicationId: String(replicationId) }}
-        />
-      )}
-    >
-      {name ?? EMPTY_VALUE}
-    </Anchor>
+    <TruncatedText value={name ?? EMPTY_VALUE}>
+      <Anchor
+        fw={500}
+        underline="never"
+        renderRoot={props => (
+          <Link
+            {...props}
+            to="/admin/replications/$replicationId/executions"
+            params={{ replicationId: String(replicationId) }}
+          />
+        )}
+      >
+        {name ?? EMPTY_VALUE}
+      </Anchor>
+    </TruncatedText>
   )
 }
 
@@ -208,6 +213,7 @@ export function ReplicationsTable(props: ReplicationsTableProps) {
       id: 'source',
       header: t('routes.admin.replications.table.source'),
       accessorFn: row => getReplicationSource(row, localLabel),
+      Cell: ReplicationTruncatedTextCell,
     },
     {
       id: 'syncMode',
@@ -228,6 +234,7 @@ export function ReplicationsTable(props: ReplicationsTableProps) {
       id: 'target',
       header: t('routes.admin.replications.table.target'),
       accessorFn: row => getReplicationTarget(row, localLabel),
+      Cell: ReplicationTruncatedTextCell,
     },
     {
       id: 'triggerType',
@@ -255,6 +262,11 @@ export function ReplicationsTable(props: ReplicationsTableProps) {
       getRowId={getReplicationRowId}
       enableRowActions
       renderRowActions={ReplicationActionsCell}
+      pinRowActions
+      displayColumnDefOptions={{
+        // Four text buttons; the wrapper default clips them.
+        'mrt-row-actions': { size: 250 },
+      }}
     />
   )
 }

--- a/ui/src/features/admin/replications/components/ReplicationsTable.tsx
+++ b/ui/src/features/admin/replications/components/ReplicationsTable.tsx
@@ -42,7 +42,7 @@ type ReplicationsTableProps = Omit<DataTableProps<SyncPolicyItem>, 'columns'>
 const EMPTY_VALUE = '-'
 
 function ReplicationTruncatedTextCell({ cell }: ReplicationCellProps) {
-  return <TruncatedText value={cell.getValue<string>() || '-'} />
+  return <TruncatedText value={cell.getValue<string>() || EMPTY_VALUE} />
 }
 
 function ReplicationNameCell({ row }: ReplicationCellProps) {

--- a/ui/src/features/admin/robots/components/RobotTable.tsx
+++ b/ui/src/features/admin/robots/components/RobotTable.tsx
@@ -15,6 +15,7 @@ import {
   type DataTableProps,
   type DataTableRowActionsProps,
 } from '@/shared/components/DataTable'
+import { TruncatedText } from '@/shared/components/TruncatedText'
 import { formatDateTime } from '@/shared/utils/date'
 
 import {
@@ -48,6 +49,10 @@ function RobotStatusCell({ row }: RobotCellProps) {
         : t('routes.admin.robots.boolean.no')}
     </Badge>
   )
+}
+
+function RobotNameCell({ row }: RobotCellProps) {
+  return <TruncatedText value={row.original.name || '-'} />
 }
 
 function RobotPlatformPermissionsCell({ row }: RobotCellProps) {
@@ -125,7 +130,8 @@ export function RobotTable({
     {
       id: 'name',
       header: t('routes.admin.robots.table.name'),
-      accessorFn: row => row.name ?? '-',
+      size: 180,
+      Cell: RobotNameCell,
     },
     {
       id: 'status',
@@ -135,11 +141,13 @@ export function RobotTable({
     {
       id: 'platformPermissions',
       header: t('routes.admin.robots.table.platformPermissions'),
+      size: 170,
       Cell: RobotPlatformPermissionsCell,
     },
     {
       id: 'projectCoverage',
       header: t('routes.admin.robots.table.projectCoverage'),
+      size: 210,
       Cell: RobotProjectCoverageCell,
     },
     {
@@ -218,6 +226,10 @@ export function RobotTable({
       enableRowActions
       renderRowActions={renderRobotActions}
       pinRowActions
+      displayColumnDefOptions={{
+        // Four text buttons; the wrapper default clips them.
+        'mrt-row-actions': { size: 320 },
+      }}
     />
   )
 }

--- a/ui/src/features/admin/users/components/UsersTable.tsx
+++ b/ui/src/features/admin/users/components/UsersTable.tsx
@@ -115,6 +115,11 @@ export function UsersTable({
       getRowId={getUserRowId}
       enableRowActions
       renderRowActions={UserActionsCell}
+      pinRowActions
+      displayColumnDefOptions={{
+        // Three text buttons; the wrapper default clips them.
+        'mrt-row-actions': { size: 330 },
+      }}
       tableOptions={{
         ...tableOptions,
         enableBatchRowSelection: true,

--- a/ui/src/features/projects/members/components/MembersTable.tsx
+++ b/ui/src/features/projects/members/components/MembersTable.tsx
@@ -101,7 +101,7 @@ function ActionsCell({
   const isSelf = meta?.currentUsername === row.original.memberName
 
   return (
-    <Group gap="md">
+    <Group gap="md" wrap="nowrap">
       <Anchor
         component="button"
         type="button"
@@ -192,6 +192,10 @@ export function MembersTable({
       getRowId={row => `${row.memberType}:${row.memberId}`}
       enableRowActions={isAdmin}
       renderRowActions={ActionsCell}
+      displayColumnDefOptions={{
+        // "Edit Permission" + "Remove"; the wrapper default clips them.
+        'mrt-row-actions': { size: 200 },
+      }}
       tableOptions={{
         enableBatchRowSelection: true,
         enableMultiRowSelection: true,

--- a/ui/src/shared/components/DataTable.module.css
+++ b/ui/src/shared/components/DataTable.module.css
@@ -1,0 +1,49 @@
+/* MRT paints the pinned-column divider unconditionally, so a pinned column
+   shows a shadow even when the table fits and there is nothing to scroll.
+   Gate each side's shadow on the container's actual scroll position.
+
+   Head/footer cells carry the shadow directly, body cells carry it on
+   `::before`. The extra `[data-column-pinned]` qualifier keeps these rules
+   above MRT's own selectors, which would otherwise tie on specificity and be
+   decided by stylesheet order. */
+
+.container:not([data-scrolled-left]) {
+  & [data-column-pinned='left'][data-column-pinned][data-last-left-pinned] {
+    box-shadow: none;
+
+    &::before {
+      box-shadow: none;
+    }
+  }
+}
+
+.container:not([data-scrollable-right]) {
+  & [data-column-pinned='right'][data-column-pinned][data-first-right-pinned] {
+    box-shadow: none;
+
+    &::before {
+      box-shadow: none;
+    }
+  }
+}
+
+/* MRT gives pinned cells `opacity: 0.97`, so the columns scrolling underneath
+   bleed through them. Keep them fully opaque — the pinned column has to read as
+   a solid layer above the scrolling content, not a translucent one. The `tr td`
+   qualifier matches the specificity of MRT's own row-scoped rule. */
+.container [data-column-pinned],
+.container tr td[data-column-pinned] {
+  opacity: 1;
+}
+
+/* `layoutMode: 'grid'` turns rows into flex containers, so the row border no
+   longer collapses into the cell box the way it did in semantic table layout —
+   each row would grow by 1px. Move the border onto the cells, where
+   `box-sizing: border-box` keeps it inside the fixed cell height. */
+.container tbody tr {
+  border-bottom: none;
+}
+
+.container tbody tr td {
+  border-bottom: 1px solid var(--table-border-color, var(--mantine-color-gray-3));
+}

--- a/ui/src/shared/components/DataTable.tsx
+++ b/ui/src/shared/components/DataTable.tsx
@@ -39,7 +39,7 @@ import type {
   MRT_TableOptions,
 } from 'mantine-react-table'
 import type {
-  Dispatch, ReactNode, SetStateAction,
+  Dispatch, MutableRefObject, ReactNode, SetStateAction,
 } from 'react'
 
 // -- Toolbar types --
@@ -170,9 +170,53 @@ function mergeTableOptionProps<TData extends MRT_RowData, TProps extends object>
   }
 }
 
+type TableContainerProps = BoxProps & HTMLPropsRef<HTMLDivElement>
+
+// The wrapper's own `ref` and `className` drive the pinned-shadow tracking and
+// its stylesheet, so they must survive a caller-supplied
+// `mantineTableContainerProps`. Merge those two explicitly instead of letting a
+// plain spread drop them; everything else still overrides as usual.
+//
+// MRT types this `ref` as a ref object rather than a callback, so the two refs
+// cannot be combined into one. The wrapper's ref stays on the element and the
+// caller's is populated from it in an effect.
+function mergeTableContainerProps<TData extends MRT_RowData>(
+  defaults: TableContainerProps & { className: string },
+  props:
+    | TableContainerProps
+    | ((args: { table: MRT_TableInstance<TData> }) => TableContainerProps)
+    | undefined,
+) {
+  const combine = (overrides: TableContainerProps | undefined): TableContainerProps => {
+    if (!overrides) {
+      return defaults
+    }
+
+    const {
+      ref: _callerRef,
+      className: overrideClassName,
+      ...rest
+    } = overrides
+
+    return {
+      ...defaults,
+      ...rest,
+      ref: defaults.ref,
+      className: overrideClassName
+        ? `${defaults.className} ${overrideClassName}`
+        : defaults.className,
+    }
+  }
+
+  if (typeof props === 'function') {
+    return (args: { table: MRT_TableInstance<TData> }) => combine(props(args))
+  }
+
+  return combine(props)
+}
+
 function resolveTableOptionProps<TArgs extends object, TProps extends object>(
-  props: TProps | ((args: TArgs) => TProps) | undefined,
-  args: TArgs,
+  props: TProps | ((args: TArgs) => TProps) | undefined, args: TArgs,
 ) {
   if (!props) {
     return undefined
@@ -246,14 +290,26 @@ function withFilterTooltipLabels<TData extends MRT_RowData>(
 // there is nothing to scroll. Track the container's real scroll position and
 // expose it as data attributes so the stylesheet can hide each side's shadow
 // until that side actually has content scrolled out of view.
-function usePinnedShadowContainerRef() {
+function usePinnedShadowContainerRef(callerRef?: MutableRefObject<HTMLDivElement | null> | null) {
   const containerRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
     const element = containerRef.current
 
+    // MRT only accepts one ref object on the container, so a caller-supplied
+    // ref is populated from ours rather than replacing it.
+    if (callerRef) {
+      callerRef.current = element
+    }
+
     if (!element) {
       return
+    }
+
+    const detachCallerRef = () => {
+      if (callerRef) {
+        callerRef.current = null
+      }
     }
 
     const update = () => {
@@ -291,8 +347,9 @@ function usePinnedShadowContainerRef() {
     return () => {
       observer.disconnect()
       element.removeEventListener('scroll', update)
+      detachCallerRef()
     }
-  }, [])
+  }, [callerRef])
 
   return containerRef
 }
@@ -357,7 +414,13 @@ export function DataTable<TData extends MRT_RowData>({
 
   const enhancedColumns = useMemo(() => withFilterTooltipLabels(columns), [columns])
 
-  const containerRef = usePinnedShadowContainerRef()
+  // A container ref is only reachable from the static form of the prop; the
+  // function form is resolved per-render by MRT.
+  const callerContainerRef = typeof mantineTableContainerProps === 'function'
+    ? undefined
+    : mantineTableContainerProps?.ref
+
+  const containerRef = usePinnedShadowContainerRef(callerContainerRef)
 
   const shouldPinRowActions = enableRowActions && pinRowActions
   const actionColumnPinning = initialState?.columnPinning
@@ -574,10 +637,7 @@ export function DataTable<TData extends MRT_RowData>({
           },
           mantinePaperProps,
         )}
-        mantineTableContainerProps={mergeTableOptionProps<
-          TData,
-          BoxProps & HTMLPropsRef<HTMLDivElement>
-        >(
+        mantineTableContainerProps={mergeTableContainerProps<TData>(
           {
             ref: containerRef,
             className: classes.container,

--- a/ui/src/shared/components/DataTable.tsx
+++ b/ui/src/shared/components/DataTable.tsx
@@ -383,7 +383,11 @@ export function DataTable<TData extends MRT_RowData>({
     ...(displayColumnDefOptions ?? {}),
     'mrt-row-select': {
       header: '',
+      // `minSize` has to be overridden too: the wrapper's `defaultColumn`
+      // minimum applies to display columns as well and would otherwise win
+      // over this size.
       size: 44,
+      minSize: 44,
       grow: false,
       ...displayColumnDefOptions?.['mrt-row-select'],
     },

--- a/ui/src/shared/components/DataTable.tsx
+++ b/ui/src/shared/components/DataTable.tsx
@@ -14,9 +14,14 @@ import { useDebouncedCallback, useDebouncedValue } from '@mantine/hooks'
 import { IconRefresh, IconTrash } from '@tabler/icons-react'
 import { MantineReactTable } from 'mantine-react-table'
 import 'mantine-react-table/styles.css'
-import { useMemo } from 'react'
+import {
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react'
 import { useTranslation } from 'react-i18next'
 
+import classes from './DataTable.module.css'
 import { Pagination } from './Pagination'
 import {
   SearchToolbar,
@@ -25,6 +30,7 @@ import {
 
 import type { Pagination as PaginationData } from '@matrixhub/api-ts/v1alpha1/utils.pb'
 import type {
+  HTMLPropsRef,
   MRT_ColumnDef,
   MRT_Row,
   MRT_RowData,
@@ -236,8 +242,62 @@ function withFilterTooltipLabels<TData extends MRT_RowData>(
   })
 }
 
-// -- DataTable --
+// MRT always paints the pinned-column divider, even when the table fits and
+// there is nothing to scroll. Track the container's real scroll position and
+// expose it as data attributes so the stylesheet can hide each side's shadow
+// until that side actually has content scrolled out of view.
+function usePinnedShadowContainerRef() {
+  const containerRef = useRef<HTMLDivElement | null>(null)
 
+  useEffect(() => {
+    const element = containerRef.current
+
+    if (!element) {
+      return
+    }
+
+    const update = () => {
+      const {
+        scrollLeft,
+        scrollWidth,
+        clientWidth,
+      } = element
+
+      // 1px tolerance: sub-pixel layout can leave a fractional remainder.
+      element.toggleAttribute('data-scrolled-left', scrollLeft > 0)
+      element.toggleAttribute(
+        'data-scrollable-right',
+        scrollWidth - clientWidth - scrollLeft > 1,
+      )
+    }
+
+    update()
+
+    const observer = new ResizeObserver(update)
+
+    // The container tracks viewport resizes; the inner table tracks row and
+    // column changes, which move the scrollable width without resizing the
+    // container.
+    observer.observe(element)
+
+    const table = element.querySelector('table')
+
+    if (table) {
+      observer.observe(table)
+    }
+
+    element.addEventListener('scroll', update, { passive: true })
+
+    return () => {
+      observer.disconnect()
+      element.removeEventListener('scroll', update)
+    }
+  }, [])
+
+  return containerRef
+}
+
+// -- DataTable --
 export function DataTable<TData extends MRT_RowData>({
   data,
   columns,
@@ -285,6 +345,7 @@ export function DataTable<TData extends MRT_RowData>({
     enableColumnPinning = false,
     enableColumnFilters = true,
     initialState,
+    layoutMode = 'grid',
     mantineFilterSelectProps,
     mantineFilterTextInputProps,
     mantinePaperProps,
@@ -295,6 +356,8 @@ export function DataTable<TData extends MRT_RowData>({
   } = tableOptions ?? {}
 
   const enhancedColumns = useMemo(() => withFilterTooltipLabels(columns), [columns])
+
+  const containerRef = usePinnedShadowContainerRef()
 
   const shouldPinRowActions = enableRowActions && pinRowActions
   const actionColumnPinning = initialState?.columnPinning
@@ -326,6 +389,13 @@ export function DataTable<TData extends MRT_RowData>({
     },
     'mrt-row-actions': {
       header: t('shared.actions'),
+      // MRT's default is too narrow for multi-button action cells. An action
+      // column that is too narrow hides its buttons *without* widening the
+      // table, so no scrollbar appears and they become unreachable — size this
+      // to the widest action row in the feature table rather than relying on
+      // the default.
+      size: 140,
+      grow: false,
       ...displayColumnDefOptions?.['mrt-row-actions'],
     },
   }
@@ -450,8 +520,14 @@ export function DataTable<TData extends MRT_RowData>({
         enableSorting={false}
         enableTableHead={!hideTableHead}
         columnFilterDisplayMode={columnFilterDisplayMode}
+        // `grid` layout makes per-column `size` actually apply, so wide content
+        // no longer stretches the table into a long horizontal scroll.
+        layoutMode={layoutMode}
         defaultColumn={{
           enableColumnFilter: false,
+          size: 160,
+          minSize: 80,
+          maxSize: 400,
           ...defaultColumn,
         }}
         // Selection
@@ -494,8 +570,13 @@ export function DataTable<TData extends MRT_RowData>({
           },
           mantinePaperProps,
         )}
-        mantineTableContainerProps={mergeTableOptionProps<TData, BoxProps>(
+        mantineTableContainerProps={mergeTableOptionProps<
+          TData,
+          BoxProps & HTMLPropsRef<HTMLDivElement>
+        >(
           {
+            ref: containerRef,
+            className: classes.container,
             style: {
               maxWidth: '100%',
               overflowX: 'auto',

--- a/ui/src/shared/components/TruncatedText.tsx
+++ b/ui/src/shared/components/TruncatedText.tsx
@@ -11,7 +11,7 @@ import type {
   TextProps,
   TooltipProps,
 } from '@mantine/core'
-import type { ReactNode } from 'react'
+import type { MouseEvent, ReactNode } from 'react'
 
 export interface TruncatedTextProps extends Omit<TextProps, 'truncate' | 'children'> {
   /** Full value. Used both as rendered content and as the tooltip label. */
@@ -22,6 +22,8 @@ export interface TruncatedTextProps extends Omit<TextProps, 'truncate' | 'childr
   children?: ReactNode
   /** Extra props forwarded to the tooltip. */
   tooltipProps?: Omit<TooltipProps, 'children' | 'label'>
+  /** Composed with the internal overflow check rather than replacing it. */
+  onMouseEnter?: (event: MouseEvent<HTMLDivElement>) => void
 }
 
 /**
@@ -34,17 +36,23 @@ export function TruncatedText({
   tooltipLabel,
   children,
   tooltipProps,
+  onMouseEnter,
   ...textProps
 }: TruncatedTextProps) {
   const contentRef = useRef<HTMLDivElement>(null)
   const [overflowing, setOverflowing] = useState(false)
 
-  const syncOverflow = () => {
+  // Composed rather than passed straight to `Text`, so a caller-provided
+  // `onMouseEnter` cannot replace the overflow check and silently disable the
+  // tooltip.
+  const handleMouseEnter = (event: MouseEvent<HTMLDivElement>) => {
     const element = contentRef.current
 
     if (element) {
       setOverflowing(element.scrollWidth > element.clientWidth)
     }
+
+    onMouseEnter?.(event)
   }
 
   const content = (
@@ -52,8 +60,8 @@ export function TruncatedText({
       ref={contentRef}
       size="sm"
       truncate="end"
-      onMouseEnter={syncOverflow}
       {...textProps}
+      onMouseEnter={handleMouseEnter}
     >
       {children ?? value}
     </Text>

--- a/ui/src/shared/components/TruncatedText.tsx
+++ b/ui/src/shared/components/TruncatedText.tsx
@@ -1,0 +1,75 @@
+import {
+  Text,
+  Tooltip,
+} from '@mantine/core'
+import {
+  useRef,
+  useState,
+} from 'react'
+
+import type {
+  TextProps,
+  TooltipProps,
+} from '@mantine/core'
+import type { ReactNode } from 'react'
+
+export interface TruncatedTextProps extends Omit<TextProps, 'truncate' | 'children'> {
+  /** Full value. Used both as rendered content and as the tooltip label. */
+  value: ReactNode
+  /** Tooltip label when it should differ from `value` (e.g. `value` is a link). */
+  tooltipLabel?: ReactNode
+  /** Rendered content when it should differ from `value` (e.g. an `Anchor`). */
+  children?: ReactNode
+  /** Extra props forwarded to the tooltip. */
+  tooltipProps?: Omit<TooltipProps, 'children' | 'label'>
+}
+
+/**
+ * Single-line cell text that truncates on overflow and reveals the full value
+ * on hover. The tooltip only activates when the text actually overflows, so
+ * short values do not get a redundant hover card.
+ */
+export function TruncatedText({
+  value,
+  tooltipLabel,
+  children,
+  tooltipProps,
+  ...textProps
+}: TruncatedTextProps) {
+  const contentRef = useRef<HTMLDivElement>(null)
+  const [overflowing, setOverflowing] = useState(false)
+
+  const syncOverflow = () => {
+    const element = contentRef.current
+
+    if (element) {
+      setOverflowing(element.scrollWidth > element.clientWidth)
+    }
+  }
+
+  const content = (
+    <Text
+      ref={contentRef}
+      size="sm"
+      truncate="end"
+      onMouseEnter={syncOverflow}
+      {...textProps}
+    >
+      {children ?? value}
+    </Text>
+  )
+
+  return (
+    <Tooltip
+      label={tooltipLabel ?? value}
+      disabled={!overflowing}
+      multiline
+      maw={480}
+      withArrow
+      openDelay={200}
+      {...tooltipProps}
+    >
+      {content}
+    </Tooltip>
+  )
+}


### PR DESCRIPTION
Closes #949

/kind bug

## Problem


Registry management stretched far past the viewport. Reaching a row's actions meant scrolling to the far right, where the row identity was no longer visible — so you couldn't tell which registry you were about to edit.

The root cause is that per-column `size` had no effect: `mantine-react-table` runs in `semantic` layout by default, where column sizes are mostly ignored. Any long value stretched the whole table.

## Changes

**Shared `DataTable`**
- Run MRT in `layoutMode: 'grid'` so column `size` / `minSize` / `maxSize` actually apply, with sensible defaults. Columns grow to fill leftover width; `grow: false` opts fixed-content columns out.
- Gate the pinned-column shadow on real scroll position. MRT paints that divider whenever a column is pinned, even when nothing can scroll.
- Two MRT defaults only misbehave under grid layout, overridden in `DataTable.module.css`: pinned cells are forced opaque (`opacity: 0.97` let the scrolling columns bleed through), and the row border moves from `tr` to `td` (flex rows don't collapse it into the fixed cell height, so every row grew by 1px).

**New `TruncatedText`** — clamps to one line and reveals the full value on hover, but only when the text actually overflows. Supports non-text content (e.g. an `Anchor`) via `children`.

**Registry management** — explicit column widths, name column pinned, actions pinned. Now fits with no horizontal scrollbar.

**Action column sizing** — an action column that is too narrow hides its buttons *without* widening the table, so no scrollbar appears and the buttons become unreachable. Sized per table for user management, robot accounts, remote sync, and project members. Project members also lacked `wrap="nowrap"`, which stacked its two links vertically and broke the row height.

**Docs** — `ui/agents/patterns.md` §17 updated in the same PR, per the shared-wrapper rule.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm build` all pass.

Measured in-browser at 1440x900 and 1000x800 across user management, robot accounts, registry management, remote sync, projects, and project members:

| | result |
|---|---|
| Unreachable action buttons | 0 |
| Clipped cells | 0 |
| Row height | 44px on every table, matching pre-change baseline |
| Pinned cell opacity | 1 (no bleed-through) |
| Registry management overflow | 0px (was 124px) |

Row height and the checkbox column width were verified against the pre-change code by stashing the diff and re-measuring — the checkbox column is 80px before and after, unchanged.

## Not covered

- Only the English locale was exercised in the browser. Chinese headers are generally shorter, so widths should be no tighter, but a visual pass in Chinese is worth doing.
- Viewports other than the two above weren't checked.
- The scrollbar was initially suspected of being clipped by the pinned column. It is not: a pixel-level comparison of the scrollbar band with pinning enabled vs. with `position: static` forced on the pinned cells is byte-identical (thumb `3..333`, track continuing to the full width in both). The bar that looks truncated is just the proportional thumb — 716/1520 ≈ 47% on that table. No change needed.

#### Does this PR introduce a user-facing change?

```release-note
make table columns fit and keep row actions reachable.
```


