### PR TITLE
docs(blog): clarify P2P target model-file download as 0s

### DIFF
--- a/website/blog/2026-08-12-matrixhub-modelexpress-dynamo-p2p.md
+++ b/website/blog/2026-08-12-matrixhub-modelexpress-dynamo-p2p.md
@@ -182,7 +182,7 @@ With the functional path established, place the direct and P2P records in one ta
 | Source model acquisition endpoint | Hugging Face mirror | MatrixHub | Hugging Face mirror | MatrixHub |
 | Target weight source | Target-local model files | Target-local model files | Source GPU | Source GPU |
 | Source model-file preparation | 4,382.20 s | 144.579 s | 4,161.32 s | 143.34 s |
-| Target model-file download | 4,247.68 s | 150.718 s | Not applicable | Not applicable |
+| Target model-file download | 4,247.68 s | 150.718 s | 0s (not needed) | 0s (not needed) |
 | Source GPU loading | 20.88 s | 28.22 s | `MxModelLoader` 159.36 s | `MxModelLoader` 152.70 s |
 | Target GPU loading | 32.46 s | 69.05 s | `MxModelLoader` 3.41 s | `MxModelLoader` 3.13 s |
 | P2P tensors / data | None | None | 312 / 15.24 GB | 312 / 15.24 GB |
@@ -193,7 +193,7 @@ The table expresses two complementary facts.
 
 First, MatrixHub successfully served the model to both nodes. In the archived runs on the same source node, model-file preparation took 4,382.20 seconds through the Hugging Face mirror and 144.579 seconds through MatrixHub. The exact ratio depends on the network, upstream state, and cache conditions, but the result demonstrates the value of placing model distribution close to the inference cluster.
 
-Second, the P2P scenarios did not repeat the weight-file download on the target. They received 15.24 GB of weights from a ready source GPU instead. In E4, the complete target `MxModelLoader` stage took 3.13 seconds and inference then passed.
+Second, the P2P scenarios did not repeat the weight-file download on the target (the "Target model-file download" step can be treated as 0s). They received 15.24 GB of weights from a ready source GPU instead. In E4, the complete target `MxModelLoader` stage took 3.13 seconds and inference then passed.
 
 ## Conclusion
 
@@ -202,7 +202,7 @@ MatrixHub and ModelExpress P2P are not competing choices. They serve adjacent st
 | Situation | Recommended path |
 |---|---|
 | First replica or no ready source | Download from an in-cluster MatrixHub cache |
-| Scale-out while a compatible source is ready | Use ModelExpress P2P from the source GPU |
+| Scale-out while a source is ready and an RDMA path is available | Use ModelExpress P2P from the source GPU |
 | No RDMA-capable path | Use MatrixHub direct download |
 | Air-gapped or controlled model supply | Use MatrixHub as the governed model source |
 | Need to evaluate startup performance | Measure file preparation, GPU loading, and end-to-end readiness separately |

--- a/website/i18n/zh-CN/docusaurus-plugin-content-blog/2026-08-12-matrixhub-modelexpress-dynamo-p2p.md
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-blog/2026-08-12-matrixhub-modelexpress-dynamo-p2p.md
@@ -182,7 +182,7 @@ curl -sS http://127.0.0.1:8000/v1/chat/completions \
 | Source 模型获取 Endpoint | Hugging Face 镜像 | MatrixHub | Hugging Face 镜像 | MatrixHub |
 | Target 权重来源 | Target 本地模型文件 | Target 本地模型文件 | Source GPU | Source GPU |
 | Source 模型文件准备 | 4,382.20 s | 144.579 s | 4,161.32 s | 143.34 s |
-| Target 模型文件下载 | 4,247.68 s | 150.718 s | 不适用 | 不适用 |
+| Target 模型文件下载 | 4,247.68 s | 150.718 s | 0s(不需要) | 0s(不需要) |
 | Source GPU 加载 | 20.88 s | 28.22 s | `MxModelLoader` 159.36 s | `MxModelLoader` 152.70 s |
 | Target GPU 加载 | 32.46 s | 69.05 s | `MxModelLoader` 3.41 s | `MxModelLoader` 3.13 s |
 | P2P 张量数 / 数据量 | 无 | 无 | 312 / 15.24 GB | 312 / 15.24 GB |
@@ -193,7 +193,7 @@ curl -sS http://127.0.0.1:8000/v1/chat/completions \
 
 第一，MatrixHub 在两个节点上都成功完成了模型文件供应。在同一 Source 节点的归档记录中，经 Hugging Face 镜像准备模型文件耗时 4,382.20 秒，经 MatrixHub 则为 144.579 秒。具体倍数取决于实际网络、上游状态和缓存条件，但这组结果体现了将模型分发服务部署在推理集群附近的价值。
 
-第二，P2P 场景不再让 Target 重复下载权重文件，而是从 Ready Source GPU 接收 15.24 GB 权重。在 E4 中，Target 的完整 `MxModelLoader` 阶段为 3.13 秒，随后推理验证通过。
+第二，P2P 场景不再让 Target 重复下载权重文件（「Target 模型文件下载」这一步可视为 0s），而是从 Ready Source GPU 接收 15.24 GB 权重。在 E4 中，Target 的完整 `MxModelLoader` 阶段为 3.13 秒，随后推理验证通过。
 
 ## 结论
 
@@ -202,7 +202,7 @@ MatrixHub 与 ModelExpress P2P 不是竞争关系，而是模型就绪链路中�
 | 场景 | 建议路径 |
 |---|---|
 | 第一个副本，或当前没有 Ready Source | 从集群内 MatrixHub 缓存下载 |
-| 已有兼容的 Ready Source，需要继续扩容 | 使用 ModelExpress P2P 从 Source GPU 获取权重 |
+| 已有 Ready Source，且集群有可用的 RDMA 通道，需要继续扩容 | 使用 ModelExpress P2P 从 Source GPU 获取权重 |
 | 集群没有可用的 RDMA 通道 | 使用 MatrixHub 直拉 |
 | 离线环境或需要受控的模型供应 | 使用 MatrixHub 作为统一模型源 |
 | 需要评估启动性能 | 分开测量文件准备、GPU 加载和端到端就绪耗时 |


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Clarify the Dynamo + MatrixHub + ModelExpress P2P blog comparison for EN and ZH:

- Replace `Not applicable` / `不适用` with `0s (not needed)` / `0s(不需要)` for the Target model-file download row in P2P columns.
- Note in the follow-up text that this step can be treated as 0s.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Docs-only change to the EN/ZH P2P blog posts.

#### Checklist

- [x] Tests(ut, e2e) added or updated, or not needed and explained
- [x] Docs(tech docs, usage docs) updated, or not needed and explained

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


Made with [Cursor](https://cursor.com)