### PR TITLE
chore: automate release note collection

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,7 +38,7 @@ Please use the following format for linking documentation below checkbox:
 - [ ] Tests(ut, e2e) added or updated, or not needed and explained
 - [ ] Docs(tech docs, usage docs) updated, or not needed and explained
 
-#### Does this PR introduce a user-facing change?
+#### Does this PR introduce a user-facing, API-facing, or operator-facing change?
 <!--
 If no, just write "NONE" in the release-note block below.
 If yes, a release note is required:

--- a/.github/workflows/ci-bot.yml
+++ b/.github/workflows/ci-bot.yml
@@ -16,16 +16,34 @@ on:
   pull_request_target:
     types:
       - opened
+      - edited
+      - reopened
       - synchronize
+      - labeled
+      - unlabeled
+
+concurrency:
+  group: ci-bot-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
 
 env:
-  # This plugins is for anyone who can use it
+  # Public on issues and pull requests.
   PLUGINS: |-
     assign
     auto-cc
     cc
+    label-kind
 
-  # This plugins is for author of issue or PR
+  # Public on issues only.
+  ISSUE_PLUGINS: |-
+    assign
+    auto-cc
+    cc
+    label-good-first-issue
+    label-help-wanted
+    label-kind
+
+  # PR or issue authors.
   AUTHOR_PLUGINS: |-
     label-bug
     label-documentation
@@ -33,13 +51,10 @@ env:
     label-question
     retest
 
-  # This plugins is for organization member or repository member
-  MEMBERS_PLUGINS: |-
+  # Organization or repository members.
+  MEMBER_ONLY_PLUGINS: |-
     label-duplicate
-    label-good-first-issue
-    label-help-wanted
     label-invalid
-    label-kind
     label-wontfix
     label-bug
     label-documentation
@@ -48,12 +63,12 @@ env:
     lifecycle
     retest
 
-  # This plugins is for in the REVIEWERS environment variable
+  # Named reviewers.
   REVIEWERS_PLUGINS: |-
     label-lgtm
     retitle
 
-  # This plugins is for in the APPROVERS environment variable
+  # Named approvers.
   APPROVERS_PLUGINS: |-
     label-approve
     label
@@ -62,11 +77,11 @@ env:
     rebase
     cherry-pick
 
-  # This plugins is for in the MAINTAINERS environment variable
+  # Named maintainers.
   MAINTAINERS_PLUGINS: |-
     milestone
 
-  # This plugins is for organization owner or repository owner
+  # Organization or repository owners.
   OWNERS_PLUGINS: ""
 
   REVIEWERS: |-
@@ -105,7 +120,7 @@ permissions:
   pull-requests: write
   repository-projects: read
   security-events: none
-  statuses: read
+  statuses: write
 
 jobs:
   bot:
@@ -116,6 +131,14 @@ jobs:
         uses: wzshiming/gh-ci-bot@v1.5.0
         if: ${{ github.event_name == 'issues' }}
         env:
+          PLUGINS: ${{ env.ISSUE_PLUGINS }}
+          MEMBERS_PLUGINS: &members_plugins >-
+            ${{ contains(
+              fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+              github.event.comment.author_association
+                || github.event.pull_request.author_association
+                || github.event.issue.author_association
+            ) && env.MEMBER_ONLY_PLUGINS || '' }}
           LOGIN: ${{ github.event.issue.user.login }}
           AUTHOR: ${{ github.event.issue.user.login }}
           MESSAGE: ${{ github.event.issue.body }}
@@ -132,6 +155,7 @@ jobs:
         uses: wzshiming/gh-ci-bot@v1.5.0
         if: ${{ github.event_name == 'pull_request_target' && github.event.action == 'opened' }}
         env:
+          MEMBERS_PLUGINS: *members_plugins
           LOGIN: ${{ github.event.pull_request.user.login }}
           AUTHOR: ${{ github.event.pull_request.user.login }}
           MESSAGE: ${{ github.event.pull_request.body }}
@@ -145,10 +169,25 @@ jobs:
             If the PR is ready, use the `/auto-cc` command to assign Reviewer to Review. 
             We will review it shortly.
 
+      - name: PR Edited
+        uses: wzshiming/gh-ci-bot@v1.5.0
+        if: ${{ github.event_name == 'pull_request_target' && github.event.action == 'edited' }}
+        env:
+          MEMBERS_PLUGINS: *members_plugins
+          LOGIN: ${{ github.event.pull_request.user.login }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          MESSAGE: ${{ github.event.pull_request.body }}
+          ISSUE_NUMBER: ${{ github.event.pull_request.number }}
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          ISSUE_KIND: pr
+          # v1.5.0 has no edited type; comment reparses the body without greeting.
+          TYPE: comment
+
       - name: PR Synchronize
         uses: wzshiming/gh-ci-bot@v1.5.0
         if: ${{ github.event_name == 'pull_request_target' && github.event.action == 'synchronize' }}
         env:
+          MEMBERS_PLUGINS: *members_plugins
           LOGIN: ${{ github.event.pull_request.user.login }}
           AUTHOR: ${{ github.event.pull_request.user.login }}
           MESSAGE: ""
@@ -161,6 +200,8 @@ jobs:
         uses: wzshiming/gh-ci-bot@v1.5.0
         if: ${{ github.event_name == 'issue_comment' && !github.event.issue.pull_request }}
         env:
+          PLUGINS: ${{ env.ISSUE_PLUGINS }}
+          MEMBERS_PLUGINS: *members_plugins
           LOGIN: ${{ github.event.comment.user.login }}
           AUTHOR: ${{ github.event.issue.user.login }}
           MESSAGE: ${{ github.event.comment.body }}
@@ -173,6 +214,7 @@ jobs:
         uses: wzshiming/gh-ci-bot@v1.5.0
         if: ${{ github.event_name == 'pull_request_review_comment' }}
         env:
+          MEMBERS_PLUGINS: *members_plugins
           LOGIN: ${{ github.event.comment.user.login }}
           AUTHOR: ${{ github.event.pull_request.user.login }}
           MESSAGE: ${{ github.event.comment.body }}
@@ -185,6 +227,7 @@ jobs:
         uses: wzshiming/gh-ci-bot@v1.5.0
         if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
         env:
+          MEMBERS_PLUGINS: *members_plugins
           LOGIN: ${{ github.event.comment.user.login }}
           AUTHOR: ${{ github.event.issue.user.login }}
           MESSAGE: ${{ github.event.comment.body }}
@@ -192,3 +235,172 @@ jobs:
           AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
           ISSUE_KIND: pr
           TYPE: comment
+
+      # gh-ci-bot has no scoped area, priority, or triage plugins.
+      - name: Apply public labels
+        uses: actions/github-script@v8
+        if: ${{ github.event_name != 'pull_request_target' || github.event.action == 'opened' || github.event.action == 'edited' }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const message = (context.payload.comment?.body
+              ?? context.payload.pull_request?.body
+              ?? context.payload.issue?.body
+              ?? '')
+              .replace(/<!--[\s\S]*?-->/g, '');
+
+            if (!message) {
+              return;
+            }
+
+            const allowed = {
+              area: ['test', 'ui'],
+              priority: ['backlog', 'critical-urgent', 'important-longterm', 'important-soon'],
+              triage: ['duplicate', 'needs-information', 'not-reproducible'],
+            };
+            const operations = [];
+            const commandPattern = /^\/(remove-)?(area|priority|triage)\s+(.+?)\s*$/i;
+            for (const rawLine of message.split(/\r?\n/)) {
+              const match = commandPattern.exec(rawLine.trim());
+              if (!match) {
+                continue;
+              }
+
+              const remove = Boolean(match[1]);
+              const family = match[2].toLowerCase();
+              for (const value of match[3].toLowerCase().split(/[\s,]+/).filter(Boolean)) {
+                if (allowed[family].includes(value)) {
+                  operations.push({ label: `${family}/${value}`, remove });
+                } else {
+                  core.warning(`Ignoring non-public label: ${family}/${value}`);
+                }
+              }
+            }
+
+            if (operations.length === 0) {
+              return;
+            }
+
+            const available = new Set((await github.paginate(
+              github.rest.issues.listLabelsForRepo,
+              { owner, repo, per_page: 100 },
+            )).map(({ name }) => name));
+            const target = { owner, repo, issue_number };
+            const { data: issue } = await github.rest.issues.get(target);
+            const applied = new Set(issue.labels.map((label) =>
+              typeof label === 'string' ? label : label.name));
+
+            for (const { label, remove } of operations) {
+              if (!available.has(label)) {
+                core.warning(`Skipping unavailable label: ${label}`);
+                continue;
+              }
+              if (remove === applied.has(label)) {
+                if (remove) {
+                  await github.rest.issues.removeLabel({ ...target, name: label });
+                  applied.delete(label);
+                } else {
+                  await github.rest.issues.addLabels({ ...target, labels: [label] });
+                  applied.add(label);
+                }
+              }
+            }
+
+      - name: Reconcile PR merge blockers
+        uses: actions/github-script@v8
+        if: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'issue_comment' && github.event.issue.pull_request) || github.event_name == 'pull_request_review_comment' }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request?.number
+              ?? context.payload.issue?.number;
+
+            if (!pull_number) {
+              return;
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number,
+            });
+            const target = { owner, repo, issue_number: pull_number };
+            const labels = new Set(pull.labels.map((label) => label.name));
+
+            async function setLabel(label, present) {
+              if (labels.has(label) === present) {
+                return;
+              }
+              if (present) {
+                await github.rest.issues.addLabels({ ...target, labels: [label] });
+                labels.add(label);
+              } else {
+                await github.rest.issues.removeLabel({ ...target, name: label });
+                labels.delete(label);
+              }
+              core.info(`${present ? 'Added' : 'Removed'} ${label}`);
+            }
+
+            // Match Kubernetes' public /hold command behavior. If a comment
+            // contains more than one hold command, the last command wins.
+            if (context.eventName === 'issue_comment'
+                || context.eventName === 'pull_request_review_comment') {
+              const body = (context.payload.comment?.body ?? '')
+                .replace(/<!--[\s\S]*?-->/g, '');
+              let hold = null;
+              for (const rawLine of body.split(/\r?\n/)) {
+                const line = rawLine.trim().toLowerCase();
+                if (line === '/hold') {
+                  hold = true;
+                } else if (line === '/hold cancel'
+                    || line === '/unhold'
+                    || line === '/remove-hold') {
+                  hold = false;
+                }
+              }
+              if (hold !== null) {
+                await setLabel('do-not-merge/hold', hold);
+              }
+            }
+
+            const hasKind = [...labels].some((label) => label.startsWith('kind/'));
+            await setLabel('do-not-merge/needs-kind', !hasKind);
+
+            const releaseNoteMatch = /```release-note[^\S\r\n]*(?:\r?\n)?([\s\S]*?)```/i
+              .exec(pull.body ?? '');
+            const releaseNote = releaseNoteMatch?.[1]?.trim() ?? '';
+            const hasNoReleaseNote = /^\W*(?:NONE|NO)\W*$/i.test(releaseNote);
+
+            if (!releaseNote) {
+              await setLabel('release-note', false);
+              await setLabel('release-note-none', false);
+              await setLabel('do-not-merge/needs-release-note', true);
+            } else if (hasNoReleaseNote) {
+              await setLabel('release-note', false);
+              await setLabel('release-note-none', true);
+              await setLabel('do-not-merge/needs-release-note', false);
+            } else {
+              await setLabel('release-note-none', false);
+              await setLabel('release-note', true);
+              await setLabel('do-not-merge/needs-release-note', false);
+            }
+
+            const blockerPrefix = 'do-not-merge/';
+            const blockers = [...labels]
+              .filter((label) => label.startsWith(blockerPrefix))
+              .sort();
+            const blocked = blockers.length > 0;
+            const summary = blocked
+              ? `Blocked by: ${blockers.map((label) => label.slice(blockerPrefix.length)).join(', ')}`
+              : 'No do-not-merge labels are present';
+
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha: pull.head.sha,
+              state: blocked ? 'failure' : 'success',
+              context: 'ci-bot/merge-blockers',
+              description: summary.slice(0, 140),
+              target_url: pull.html_url,
+            });

--- a/.github/workflows/prepare-release-notes.yml
+++ b/.github/workflows/prepare-release-notes.yml
@@ -1,0 +1,172 @@
+name: Prepare Release Notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Official version to prepare (vX.Y.Z)
+        required: true
+        type: string
+      base_branch:
+        description: Branch that will be tagged
+        required: true
+        default: main
+        type: string
+      start_ref:
+        description: Previous official tag (leave empty to auto-detect)
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-release-notes-${{ inputs.version }}-${{ inputs.base_branch }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Generate changelog draft
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out release branch
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.base_branch }}
+
+      - name: Fetch tags
+        run: git fetch --force --tags origin
+
+      - name: Restore hand-written draft content
+        id: draft
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${RELEASE_VERSION}" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+            echo "version must be an official version in vX.Y.Z form" >&2
+            exit 1
+          fi
+
+          output_path="CHANGELOG/CHANGELOG-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.md"
+          release_branch="release-notes/${RELEASE_VERSION}"
+          remote_ref="refs/remotes/origin/${release_branch}"
+          expected_remote_sha=
+
+          if git fetch origin "refs/heads/${release_branch}:${remote_ref}"; then
+            expected_remote_sha="$(git rev-parse --verify "${remote_ref}^{commit}")"
+            if git cat-file -e "${remote_ref}:${output_path}"; then
+              git restore --source "${remote_ref}" -- "${output_path}"
+              echo "Restored hand-written content from ${release_branch}."
+            fi
+          fi
+
+          echo "output_path=${output_path}" >> "${GITHUB_OUTPUT}"
+          echo "release_branch=${release_branch}" >> "${GITHUB_OUTPUT}"
+          echo "expected_remote_sha=${expected_remote_sha}" >> "${GITHUB_OUTPUT}"
+
+      - name: Generate release notes
+        id: generate
+        env:
+          BASE_BRANCH: ${{ inputs.base_branch }}
+          END_REF: HEAD
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          START_REF: ${{ inputs.start_ref }}
+        run: |
+          set -euo pipefail
+
+          args=(
+            --version "${RELEASE_VERSION}"
+            --repo "${GITHUB_REPOSITORY}"
+            --end-ref "${END_REF}"
+            --base-branch "${BASE_BRANCH}"
+          )
+          if [[ -n "${START_REF}" ]]; then
+            args+=(--start-ref "${START_REF}")
+          fi
+
+          bash scripts/changelog.sh "${args[@]}"
+
+      - name: Create or update draft pull request
+        env:
+          BASE_BRANCH: ${{ inputs.base_branch }}
+          EXPECTED_REMOTE_SHA: ${{ steps.draft.outputs.expected_remote_sha }}
+          GH_TOKEN: ${{ github.token }}
+          OUTPUT_PATH: ${{ steps.generate.outputs.output_path }}
+          RELEASE_BRANCH: ${{ steps.draft.outputs.release_branch }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          START_REF: ${{ steps.generate.outputs.start_ref }}
+        run: |
+          set -euo pipefail
+
+          body_file="${RUNNER_TEMP}/release-notes-pr-body.md"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -C "${RELEASE_BRANCH}"
+          git add -- "${OUTPUT_PATH}"
+
+          if git diff --cached --quiet; then
+            echo "${OUTPUT_PATH} already contains the generated ${RELEASE_VERSION} notes."
+            exit 0
+          fi
+
+          git commit --signoff -m "docs: prepare ${RELEASE_VERSION} release notes"
+          git push \
+            --force-with-lease="refs/heads/${RELEASE_BRANCH}:${EXPECTED_REMOTE_SHA}" \
+            --set-upstream origin "HEAD:refs/heads/${RELEASE_BRANCH}"
+
+          printf '%s\n' \
+            '#### What type of PR is this?' \
+            '' \
+            '/kind documentation' \
+            '' \
+            '#### What this PR does / why we need it:' \
+            '' \
+            "Generates the ${RELEASE_VERSION} changelog from merged PRs in ${START_REF}..${BASE_BRANCH}." \
+            '' \
+            'Release owner checklist:' \
+            '' \
+            '- [ ] Review every generated entry for audience impact and wording.' \
+            '- [ ] Add an overview, upgrade instructions, deprecations, and known issues outside the generated markers as needed.' \
+            '- [ ] Rerun **Prepare Release Notes** after late PRs merge.' \
+            '- [ ] Mark this PR ready and merge it before creating the official tag.' \
+            '' \
+            '#### Does this PR introduce a user-facing, API-facing, or operator-facing change?' \
+            '' \
+            '```release-note' \
+            'NONE' \
+            '```' > "${body_file}"
+
+          pr_url="$(gh pr list \
+            --base "${BASE_BRANCH}" \
+            --head "${RELEASE_BRANCH}" \
+            --state open \
+            --json url \
+            --jq '.[0].url')"
+
+          if [[ -z "${pr_url}" ]]; then
+            pr_url="$(gh pr create \
+              --base "${BASE_BRANCH}" \
+              --head "${RELEASE_BRANCH}" \
+              --title "docs: prepare ${RELEASE_VERSION} release notes" \
+              --body-file "${body_file}" \
+              --draft)"
+          else
+            gh pr edit "${pr_url}" \
+              --title "docs: prepare ${RELEASE_VERSION} release notes" \
+              --body-file "${body_file}"
+          fi
+
+          # Events created with GITHUB_TOKEN do not trigger ci-bot, so apply the
+          # labels that ci-bot would infer from the generated PR body explicitly.
+          gh pr edit "${pr_url}" \
+            --add-label kind/documentation \
+            --add-label release-note-none
+
+          echo "Draft release notes PR: ${pr_url}"

--- a/.github/workflows/workflow-lint.yaml
+++ b/.github/workflows/workflow-lint.yaml
@@ -8,6 +8,8 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - 'scripts/changelog.sh'
+      - 'scripts/changelog.test.sh'
   push:
     branches:
       - main
@@ -15,6 +17,8 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - 'scripts/changelog.sh'
+      - 'scripts/changelog.test.sh'
 
 permissions:
   contents: read
@@ -31,6 +35,12 @@ jobs:
 
       - name: Run actionlint
         run: ./actionlint -color -shellcheck=
+
+      - name: Check release note collector syntax
+        run: bash -n scripts/changelog.sh scripts/changelog.test.sh
+
+      - name: Test release note collector
+        run: bash scripts/changelog.test.sh
 
       - name: Validate action refs
         env:

--- a/CHANGELOG/README.md
+++ b/CHANGELOG/README.md
@@ -4,4 +4,17 @@ MatrixHub release notes are maintained per minor version (Kubernetes-style). Off
 
 - [CHANGELOG-0.1.md](./CHANGELOG-0.1.md)
 
-Contributors record user-visible changes in pull request `release-note` blocks; maintainers aggregate them into the appropriate file at official release time. See [Release process](../docs/release-process.md).
+For pull request metadata, see
+[Release notes in pull requests](../CONTRIBUTING.md#release-notes-in-pull-requests).
+For generating and reviewing a changelog PR, see
+[Prepare release notes](../docs/release-process.md#prepare-release-notes).
+
+For a local dry run:
+
+```bash
+GITHUB_TOKEN="$(gh auth token)" bash scripts/changelog.sh \
+  --version v0.2.0 \
+  --repo matrixhub-ai/matrixhub \
+  --base-branch main \
+  --dry-run
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,8 @@ triage includes checking for duplicates, asking for missing reproduction steps o
 logs, confirming whether a bug can be reproduced, and suggesting the most relevant
 labels.
 
-If you have permission to label issues, add labels that match the issue:
+Anyone may add or remove existing public `kind/*`, `area/*`, `priority/*`, and
+`triage/*` labels with commands such as `/kind bug` and `/remove-kind bug`:
 
 - **Type:** `kind/bug`, `kind/feature`, `kind/design`, `kind/dependency`,
   `kind/documentation`, `kind/support`, `kind/cleanup`, `kind/flake`,
@@ -81,11 +82,8 @@ If you have permission to label issues, add labels that match the issue:
 - **Priority:** `priority/backlog`, `priority/important-soon`,
   `priority/important-longterm`, or `priority/critical-urgent`.
 
-Use `good first issue` or `help wanted` only when the issue is clear enough for a
-new contributor or when maintainer help is welcome.
-
-If you do not have permission to label issues, leave a comment with your triage
-notes and suggested labels. Maintainers can apply labels or ask follow-up questions from there.
+On issues, anyone may also use `/good-first-issue`, `/help-wanted`, and their
+`/remove-*` forms. Reserve them for clear starter work or issues seeking help.
 
 Once an issue is confirmed for a release, maintainers add it to the corresponding
 release milestone (for example `v0.2`).
@@ -227,13 +225,14 @@ commands, local setup, coverage, and E2E notes.
 - Keep PRs focused and reasonably small; link the issue they address.
 - Ensure **CI is green** (lint, unit tests, and other checks) and that your commits
   are **signed off**.
-- Fill in the PR template `release-note` block for user-visible changes (see
+- Choose a `/kind` and fill in the PR template `release-note` block (see
   [Release notes in pull requests](#release-notes-in-pull-requests)).
 
 ## Review process
 
 - Reviews follow the [`OWNERS`](OWNERS) model: maintainers use `/lgtm` and `/approve`
   on PRs. A PR is merged once it has the required approvals and CI passes.
+- Anyone may use `/hold` to pause a PR and `/hold cancel` or `/unhold` to resume it.
 - Be responsive to review feedback; maintainers aim to review promptly but this is a
   community project, so please be patient.
 
@@ -242,25 +241,21 @@ maintainer.
 
 ## Release notes in pull requests
 
-MatrixHub follows the [Kubernetes release notes model](https://github.com/kubernetes/community/blob/main/contributors/guide/release-notes.md):
+MatrixHub follows the [Kubernetes release notes model](https://github.com/kubernetes/community/blob/main/contributors/guide/release-notes.md).
+Every pull request must choose a `/kind` and complete the `release-note` block with
+a user-, API-, or operator-facing change, or `NONE`.
 
-- **Official releases only** (`vX.Y.Z`) publish release notes on the
-  [GitHub Releases](https://github.com/matrixhub-ai/matrixhub/releases) page and in
-  [`CHANGELOG/`](CHANGELOG/README.md). RC and dev tags do **not** publish release notes.
-- **Every pull request** with a user-visible change must include a `release-note`
-  block in the PR description (or `NONE` if not user-facing). The PR template already
-  includes this section.
-- Reviewers should check release note quality during review (clear, past tense,
-  user-focused).
+Anyone may correct Kind with `/kind` or `/remove-kind`. The bot derives release-note
+labels from the PR body, and reviewers verify the note's accuracy and wording.
 
 Example:
 
 ```release-note
-Added permission-based filtering to the project list API. (#664, @contributor)
+Added permission-based filtering to the project list API.
 ```
 
-Maintainers aggregate these notes into `CHANGELOG/` when cutting an official release.
-See [Release process](docs/release-process.md) for maintainer steps.
+The collector adds PR and author links. Maintainers should follow
+[Prepare release notes](docs/release-process.md#prepare-release-notes).
 
 ## License of contributions
 

--- a/Makefile
+++ b/Makefile
@@ -147,9 +147,11 @@ verify.ui: ## Run UI lint, typecheck, and build
 	cd ui && pnpm run build
 
 .PHONY: verify.workflow
-verify.workflow: ## Run GitHub Actions workflow lint checks
+verify.workflow: ## Run GitHub Actions workflow and release-note automation checks
 	go run github.com/rhysd/actionlint/cmd/actionlint@$(ACTIONLINT_VERSION) -color -shellcheck=
 	bash ./scripts/verify-action-refs.sh
+	bash -n scripts/changelog.sh scripts/changelog.test.sh
+	bash scripts/changelog.test.sh
 
 .PHONY: verify.govulncheck
 verify.govulncheck: ## Run Go vulnerability reachability checks

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -40,11 +40,12 @@ This matches the [Release workflow](../.github/workflows/release.yml): jobs `rel
 
 MatrixHub follows the Kubernetes model:
 
-1. **During development:** contributors add a `release-note` block (or `NONE`) in each pull request — this is source material, not a published release note by itself.
-2. **At an official release:** maintainers aggregate those PR release notes into [`CHANGELOG/`](../CHANGELOG/) and the [GitHub Releases](https://github.com/matrixhub-ai/matrixhub/releases) page for that version.
-3. **RC tags:** skipped — no aggregation and no publication until the official tag.
-
-See [Adding release notes in pull requests](#adding-release-notes-in-pull-requests).
+1. Contributors follow
+   [Release notes in pull requests](../CONTRIBUTING.md#release-notes-in-pull-requests).
+2. The release owner follows [Prepare release notes](#prepare-release-notes) to
+   generate, review, and merge the draft changelog PR before the official tag.
+3. The Release workflow uses the committed version section for the draft
+   [GitHub Release](https://github.com/matrixhub-ai/matrixhub/releases).
 
 ## Tags and branches
 
@@ -92,18 +93,6 @@ For **official** tags only (`vX.Y.Z` without `-rc` / `-dev`):
 Maintainers must **review and publish** the draft release manually.
 
 `scripts/release-notes.sh` reads the matching section from `CHANGELOG/CHANGELOG-X.Y.md`. If the tagged commit does not yet contain that file (for example when promoting `v0.1.0` on the same commit as `v0.1.0-rc.1`), the script falls back to `origin/main` for the changelog content. **Always verify the draft release body** before publishing — see [Promoting an RC on the same commit](#promoting-an-rc-on-the-same-commit).
-
-### Adding release notes in pull requests
-
-Every pull request with a user-visible change should include a release note in the PR template’s `release-note` block (or `NONE` if not user-facing). Reviewers check release note quality before merge — same idea as [Kubernetes](https://github.com/kubernetes/community/blob/main/contributors/guide/release-notes.md).
-
-Example:
-
-```release-note
-Added MatrixHub-type registry configuration for private deployments. (#710, @contributor)
-```
-
-These blocks are **not** shown as a versioned release note until an **official** tag is cut. RC tags do not trigger collection or publication.
 
 ## Release candidate process
 
@@ -166,7 +155,7 @@ An official (minor or initial) release is e.g. `v0.1.0`.
 
 An official release requires:
 
-- Prepare release notes (aggregate PR `release-note` blocks or bootstrap `CHANGELOG/` for the first GA)
+- Generate, review, and merge the release-notes PR (or bootstrap `CHANGELOG/` for the first GA)
 - CI green on the commit to be tagged
 - Tag the release (often after a final RC)
 - Verify release workflow succeeded
@@ -178,9 +167,25 @@ An official release requires:
 
 #### Prepare release notes
 
-Review merged PRs since the **last official tag** (not since the last RC). Collect non-`NONE` `release-note` blocks into the version section of [`CHANGELOG/`](../CHANGELOG/) (for example `CHANGELOG/CHANGELOG-0.1.md` for the v0.1 line).
+Create the draft around feature freeze or the first RC:
 
-For the **first official release** (`v0.1.0`), bootstrap that file manually if historical PRs lack release notes; see the bootstrap step in [Review and publish the GitHub Release](#review-and-publish-the-github-release).
+1. Open the repository's [**Actions**](https://github.com/matrixhub-ai/matrixhub/actions)
+   tab.
+2. In the left sidebar, select **Prepare Release Notes**.
+3. Above the workflow runs, click **Run workflow** to open the form.
+4. Select the branch containing the workflow, normally `main`, then fill in:
+   - **version:** the official `vX.Y.Z` version;
+   - **base_branch:** the branch to tag, normally `main`;
+   - **start_ref:** leave empty unless you need a custom range.
+5. Click the green **Run workflow** button in the form.
+6. When the run succeeds, review the draft PR from `release-notes/vX.Y.Z`. Add
+   hand-written content outside the generated markers.
+7. If validation fails, fix the reported PR metadata and rerun. Rerun again after
+   late fixes, then mark the PR ready and merge it before creating the official tag.
+
+The workflow collects changes since the previous official tag, omits `NONE`/`NO`
+entries, and updates `CHANGELOG/CHANGELOG-X.Y.md`. For the first official release,
+backfill old PR metadata or prepare the initial section manually.
 
 #### Check CI is green
 
@@ -302,8 +307,8 @@ If `main` contains new features but a patch release (`v0.1.1`) should include **
 A cherry-pick patch release requires:
 
 - Create (or reuse) a release branch
-- Cherry-pick fix commits into the release branch
-- Ensure cherry-pick PRs include `release-note` blocks for the patch notes
+- Merge fixes through PRs targeting the release branch
+- Generate, review, and merge the release-notes PR
 - Tag the patch on the release branch
 - Verify pipeline, publish draft release, smoke-test, announce
 
@@ -320,12 +325,13 @@ git push origin release-0.1
 ##### Cherry-pick fixes
 
 ```bash
-git checkout release-0.1
-git cherry-pick <SHA>   # repeat for each fix
-git push origin release-0.1
+git checkout -b backport-fix release-0.1
+git cherry-pick <SHA>
+git push origin HEAD
 ```
 
-Open a PR into `release-0.1` when cherry-picks need review.
+Open a PR into `release-0.1`, complete its `/kind` and `release-note` metadata,
+and merge it after CI passes.
 
 > **CI parity:** PRs (and pushes) to a `release-*` branch run the same gating CI as
 > `main` — Unit tests, Go Lint, govulncheck, CodeQL, Workflow Lint, and Website tests,
@@ -333,6 +339,11 @@ Open a PR into `release-0.1` when cherry-picks need review.
 > under these same checks as `main`** before merge, so the commit you tag from the
 > release line is CI-green. The workflows list `main` and `release-*` in their
 > `branches` filters; keep any new gating workflow aligned with this pattern.
+
+##### Prepare patch release notes
+
+Follow [Prepare release notes](#prepare-release-notes), using version `v0.1.1` and
+base branch `release-0.1`.
 
 ##### Tag patch release
 
@@ -360,7 +371,8 @@ Security fixes follow the same tagging pipeline. Additionally:
 Use this quick checklist for every official release:
 
 - [ ] Target commit is green on CI
-- [ ] Release notes prepared in `CHANGELOG/` (or draft body edited manually)
+- [ ] Generated release-notes PR reviewed, finalized, and merged into the branch
+      being tagged
 - [ ] RC smoke-tested (recommended for minor releases)
 - [ ] Tag pushed (`vX.Y.Z`)
 - [ ] Release workflow succeeded (image, chart, SBOM, cosign)
@@ -376,3 +388,4 @@ Use this quick checklist for every official release:
 - [Maintainers](../MAINTAINERS.md)
 - [GitHub Releases](https://github.com/matrixhub-ai/matrixhub/releases)
 - [Release workflow](https://github.com/matrixhub-ai/matrixhub/actions/workflows/release.yml)
+- [Prepare Release Notes workflow](https://github.com/matrixhub-ai/matrixhub/actions/workflows/prepare-release-notes.yml)

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,167 +1,752 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Copyright 2022 Authors of spidernet-io
+# Copyright 2026 MatrixHub Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# usage:
-#  GH_TOKEN=${{ github.token }} LABEL_FEATURE="release/feature-new" LABEL_CHANGED="release/feature-changed" LABEL_BUG="release/bug" PROJECT_REPO="xxx/xxx" changelog.sh  ./ v0.3.6
-#  GH_TOKEN=${{ github.token }} LABEL_FEATURE="release/feature-new" LABEL_CHANGED="release/feature-changed" LABEL_BUG="release/bug" PROJECT_REPO="xxx/xxx" changelog.sh  ./ v0.3.6 v0.3.5
+GENERATED_START='<!-- BEGIN GENERATED RELEASE NOTES -->'
+GENERATED_END='<!-- END GENERATED RELEASE NOTES -->'
+CHANGELOG_WORK_DIR=''
 
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/changelog.sh --version vX.Y.Z [options]
 
-CURRENT_DIR_PATH=$(cd `dirname $0`; pwd)
-PROJECT_ROOT_PATH="${CURRENT_DIR_PATH}/.."
+Options:
+  --repo OWNER/REPO       GitHub repository (defaults to GITHUB_REPOSITORY)
+  --start-ref REF         Previous official release (auto-detected when omitted)
+  --end-ref REF           Candidate commit or branch (default: HEAD)
+  --base-branch BRANCH    PR base branch used to disambiguate associated PRs
+  --output PATH           CHANGELOG file to update (default: CHANGELOG/CHANGELOG-X.Y.md)
+  --dry-run               Print the generated version section without writing a file
+  --help                  Show this help
+EOF
+}
 
-set -x
-set -o errexit
-set -o nounset
-set -o pipefail
+git_cmd() {
+  git "$@"
+}
 
-# optional
-OUTPUT_DIR=${1}
-# required
-DEST_TAG=${2}
-# optional
-START_TAG=${3:-""}
+github_api() {
+  local endpoint=$1
+  shift
 
+  gh api \
+    -H 'Accept: application/vnd.github+json' \
+    -H 'X-GitHub-Api-Version: 2022-11-28' \
+    "$@" \
+    "$endpoint"
+}
 
-LABEL_FEATURE=${LABEL_FEATURE:-"release/feature-new"}
-LABEL_CHANGED=${LABEL_CHANGED:-"release/feature-changed"}
-LABEL_BUG=${LABEL_BUG:-"release/bug"}
-PROJECT_REPO=${PROJECT_REPO:-""}
-[ -n "$PROJECT_REPO" ] || { echo "miss PROJECT_REPO"; exit 1 ; }
-[ -n "${GH_TOKEN}" ] || { echo "error, miss GH_TOKEN"; exit 1 ; }
+http_status_code() {
+  awk 'NR == 1 && /^HTTP\// { print $2; exit }'
+}
 
-( cd ${OUTPUT_DIR} ) || { echo "error, OUTPUT_DIR '${OUTPUT_DIR}' is not a valid directory" ; exit 1 ; }
-OUTPUT_DIR=$(cd ${OUTPUT_DIR}; pwd)
-echo "generate changelog to directory ${OUTPUT_DIR}"
+http_response_body() {
+  awk '
+    NR == 1 && /^HTTP\// { headers = 1; next }
+    headers {
+      sub(/\r$/, "")
+      if ($0 == "") headers = 0
+      next
+    }
+    { print }
+  '
+}
 
-# change to root for git cli
-cd ${PROJECT_ROOT_PATH}
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "error: required command not found: $1" >&2
+    return 1
+  }
+}
 
-#============================
-# Find the previous tag for changelog range
-# If START_TAG is not provided, find the previous official version tag from git
-if [ -z "${START_TAG}" ] ; then
-    echo "-------------- find previous tag"
-    # List all official version tags sorted by version, find the one just before DEST_TAG
-    PREV_TAG=$(git tag --sort=version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -B1 "^${DEST_TAG}$" | head -1)
-    if [ "$PREV_TAG" = "$DEST_TAG" ] || [ -z "$PREV_TAG" ]; then
-        # No previous tag, this is the first release
-        START_TAG=""
-        echo "No previous tag found, this is the first release"
-    else
-        START_TAG="$PREV_TAG"
-        echo "Previous tag: ${START_TAG}"
+append_line() {
+  printf '%s\n' "$2" >> "$1"
+}
+
+has_line() {
+  local lines=$1
+  local expected=$2
+  local line
+
+  while IFS= read -r line; do
+    [ "$line" = "$expected" ] && return 0
+  done <<EOF
+$lines
+EOF
+  return 1
+}
+
+trim_blank_lines() {
+  awk '
+    { lines[NR] = $0 }
+    END {
+      first = 1
+      while (first <= NR && lines[first] ~ /^[[:space:]]*$/) first++
+      last = NR
+      while (last >= first && lines[last] ~ /^[[:space:]]*$/) last--
+      if (first <= last) {
+        sub(/^[[:space:]]+/, "", lines[first])
+        sub(/[[:space:]]+$/, "", lines[last])
+      }
+      for (i = first; i <= last; i++) print lines[i]
+    }
+  '
+}
+
+extract_release_note() {
+  awk '
+    function remember(value) {
+      content[++count] = value
+    }
+    {
+      line = $0
+      sub(/\r$/, "", line)
+      lower = tolower(line)
+      if (!found && match(lower, /```release-note[[:blank:]]*/)) {
+        found = 1
+        rest = substr(line, RSTART + RLENGTH)
+        closing = index(rest, "```")
+        if (closing) {
+          remember(substr(rest, 1, closing - 1))
+          closed = 1
+          exit
+        }
+        remember(rest)
+        next
+      }
+      if (found) {
+        closing = index(line, "```")
+        if (closing) {
+          remember(substr(line, 1, closing - 1))
+          closed = 1
+          exit
+        }
+        remember(line)
+      }
+    }
+    END {
+      if (closed) {
+        for (i = 1; i <= count; i++) print content[i]
+      }
+    }
+  ' | trim_blank_lines
+}
+
+is_no_release_note() {
+  local upper
+  upper=$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]')
+  [[ $upper =~ ^[^A-Z0-9_]*(NONE|NO)[^A-Z0-9_]*$ ]]
+}
+
+version_is_less() {
+  local left=${1#v}
+  local right=${2#v}
+  local -a left_parts right_parts
+  local index left_part right_part left_digit right_digit
+
+  IFS=. read -r -a left_parts <<EOF
+$left
+EOF
+  IFS=. read -r -a right_parts <<EOF
+$right
+EOF
+
+  for index in 0 1 2; do
+    left_part=${left_parts[$index]}
+    right_part=${right_parts[$index]}
+    while [ "${#left_part}" -gt 1 ] && [ "${left_part#0}" != "$left_part" ]; do
+      left_part=${left_part#0}
+    done
+    while [ "${#right_part}" -gt 1 ] && [ "${right_part#0}" != "$right_part" ]; do
+      right_part=${right_part#0}
+    done
+    [ "${#left_part}" -lt "${#right_part}" ] && return 0
+    [ "${#left_part}" -gt "${#right_part}" ] && return 1
+    while [ -n "$left_part" ]; do
+      left_digit=${left_part%"${left_part#?}"}
+      right_digit=${right_part%"${right_part#?}"}
+      [ "$left_digit" -lt "$right_digit" ] && return 0
+      [ "$left_digit" -gt "$right_digit" ] && return 1
+      left_part=${left_part#?}
+      right_part=${right_part#?}
+    done
+  done
+  return 1
+}
+
+find_previous_official_tag() {
+  local version=$1
+  local end_ref=$2
+  local tag tags
+  local best=''
+
+  tags=$(git_cmd tag --merged "$end_ref" --list) || return 1
+  while IFS= read -r tag; do
+    [[ $tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue
+    version_is_less "$tag" "$version" || continue
+    if [ -z "$best" ] || version_is_less "$best" "$tag"; then
+      best=$tag
     fi
-fi
+  done <<EOF
+$tags
+EOF
+  printf '%s\n' "$best"
+}
 
-# Use v0.0.0 as display name for first release (for filename and content)
-DISPLAY_START_TAG="${START_TAG:-v0.0.0}"
+parse_pull_number_from_commit_message() {
+  awk '
+    /^Merge pull request #[0-9]+/ {
+      value = $0
+      sub(/^Merge pull request #/, "", value)
+      sub(/[^0-9].*$/, "", value)
+      print value
+      found = 1
+      exit
+    }
+    {
+      remaining = $0
+      while (match(remaining, /\(#[0-9]+\)/)) {
+        value = substr(remaining, RSTART + 2, RLENGTH - 3)
+        candidate = value
+        remaining = substr(remaining, RSTART + RLENGTH)
+      }
+    }
+    END {
+      if (!found && candidate != "") print candidate
+    }
+  '
+}
 
-echo "-------------- check tags "
-echo "DEST_TAG=${DEST_TAG}"
-echo "START_TAG=${DISPLAY_START_TAG}"
+classify_kind() {
+  local labels=$1
+  local label
 
-# Get commits in range
-ALL_COMMIT=""
-if [ -z "${START_TAG}" ]; then
-    # First release: all commits up to DEST_TAG
-    ALL_COMMIT=$(git log ${DEST_TAG} --reverse --oneline | awk '{print $1}' | tr '\n' ' ') \
-        || { echo "error, failed to get commits for tag ${DEST_TAG}" ; exit 1 ; }
-else
-    ALL_COMMIT=$(git log ${START_TAG}..${DEST_TAG} --reverse --oneline | awk '{print $1}' | tr '\n' ' ') \
-        || { echo "error, failed to get commits for range ${START_TAG}..${DEST_TAG}" ; exit 1 ; }
-fi
-echo "ALL_COMMIT: ${ALL_COMMIT}"
-
-TOTAL_COUNT="0"
-PR_LIST=""
-#
-FEATURE_PR=""
-CHANGED_PR=""
-FIX_PR=""
-for COMMIT in ${ALL_COMMIT} ; do
-  COMMIT_INFO=` curl --retry 10 -s -H "Accept: application/vnd.github.groot-preview+json" -H "Authorization: Bearer ${GH_TOKEN}" "https://api.github.com/repos/${PROJECT_REPO}/commits/${COMMIT}/pulls" `
-  PR=` jq -r '.[].number' <<< "${COMMIT_INFO}" `
-  [ -n "${PR}" ] || { echo "warning, failed to find PR number for commit ${COMMIT} " ; echo "${COMMIT_INFO}" ; echo "" ; continue ; }
-  if grep " ${PR} " <<< " ${PR_LIST} " &>/dev/null ; then
-    continue
-  else
-    PR_LIST+=" ${PR} "
+  has_line "$labels" 'kind/deprecation' && { printf 'deprecation\n'; return; }
+  has_line "$labels" 'kind/api-change' && { printf 'api-change\n'; return; }
+  has_line "$labels" 'kind/feature' && { printf 'feature\n'; return; }
+  if has_line "$labels" 'kind/bug' || has_line "$labels" 'kind/regression'; then
+    printf 'bug-or-regression\n'
+    return
   fi
-  (( TOTAL_COUNT+=1 ))
-	INFO=` gh pr view ${PR}  `
-	TITLE=` grep -E "^title:[[:space:]]+" <<< "$INFO" | sed -E 's/title:[[:space:]]+//' `
-	LABELS=` grep -E "^labels:[[:space:]][^\[]" <<< "$INFO" | sed -E 's/labels://' | tr ',' ' ' ` || true
-	#
-	PR_URL="https://github.com/${PROJECT_REPO}/pull/${PR}"
-	#
-	if grep -E "[[:space:]]${LABEL_FEATURE}[[:space:]]" <<< " ${LABELS} " &>/dev/null ; then
-	  echo "get new feature PR ${PR}"
-		FEATURE_PR+="* ${TITLE} : [PR ${PR}](${PR_URL})
-"
-	elif grep -E "[[:space:]]${LABEL_CHANGED}[[:space:]]" <<< " ${LABELS} " &>/dev/null ; then
-	  echo "get changed feature PR ${PR}"
-		CHANGED_PR+="* ${TITLE} : [PR ${PR}](${PR_URL})
-"
-	elif grep -E "[[:space:]]${LABEL_BUG}[[:space:]]" <<< " ${LABELS} " &>/dev/null ; then
-	  echo "get bug fix PR ${PR}"
-		FIX_PR+="* ${TITLE} : [PR ${PR}](${PR_URL})
-"
-	fi
-done
-#---------------------
-echo "generate changelog md"
-FILE_CHANGELOG="${OUTPUT_DIR}/changelog_from_${DISPLAY_START_TAG}_to_${DEST_TAG}.md"
-echo > ${FILE_CHANGELOG}
-echo "# ${DEST_TAG}" >> ${FILE_CHANGELOG}
-echo "Welcome to the ${DEST_TAG} release of MatrixHub!" >> ${FILE_CHANGELOG}
-echo "Compared with version:${DISPLAY_START_TAG}, version:${DEST_TAG} has the following updates." >> ${FILE_CHANGELOG}
-echo "" >> ${FILE_CHANGELOG}
-echo "***" >> ${FILE_CHANGELOG}
-echo "" >> ${FILE_CHANGELOG}
-#
-if [ -n "${FEATURE_PR}" ]; then
-    echo "## New Feature" >> ${FILE_CHANGELOG}
-    echo "" >> ${FILE_CHANGELOG}
-    while read LINE ; do
-      echo "${LINE}" >> ${FILE_CHANGELOG}
-      echo "" >> ${FILE_CHANGELOG}
-    done <<< "${FEATURE_PR}"
-    echo "***" >> ${FILE_CHANGELOG}
-    echo "" >> ${FILE_CHANGELOG}
+  has_line "$labels" 'kind/documentation' && { printf 'documentation\n'; return; }
+  for label in \
+    kind/cleanup \
+    kind/dependency \
+    kind/design \
+    kind/failing-test \
+    kind/flake \
+    kind/support; do
+    has_line "$labels" "$label" && { printf 'other\n'; return; }
+  done
+  return 1
+}
+
+join_lines() {
+  awk 'NF { if (seen++) printf ", "; printf "%s", $0 } END { print "" }'
+}
+
+process_pull() {
+  local pull_json=$1
+  local work_dir=$2
+  local number url author body labels note
+  local kind_labels='' kind_count=0 label
+  local has_release_note=false has_release_note_none=false category entry_file
+
+  number=$(printf '%s' "$pull_json" | jq -er '.number')
+  url=$(printf '%s' "$pull_json" | jq -er '.html_url')
+  author=$(printf '%s' "$pull_json" | jq -r '.user.login // "ghost"')
+  body=$(printf '%s' "$pull_json" | jq -r '.body // ""')
+  labels=$(printf '%s' "$pull_json" | jq -r '.labels[]? | if type == "string" then . else .name end')
+  note=$(printf '%s\n' "$body" | extract_release_note)
+
+  while IFS= read -r label; do
+    case "$label" in
+      kind/*)
+        if [ -z "$kind_labels" ]; then
+          kind_labels=$label
+        else
+          kind_labels="$kind_labels
+$label"
+        fi
+        kind_count=$((kind_count + 1))
+        ;;
+    esac
+  done <<EOF
+$labels
+EOF
+
+  [ "$kind_count" -gt 0 ] || append_line "$work_dir/errors" "#$number has no kind/* label"
+  has_line "$labels" 'do-not-merge/needs-kind' && \
+    append_line "$work_dir/errors" "#$number is still labeled do-not-merge/needs-kind"
+  has_line "$labels" 'do-not-merge/needs-release-note' && \
+    append_line "$work_dir/errors" "#$number is still labeled do-not-merge/needs-release-note"
+  has_line "$labels" 'release-note' && has_release_note=true
+  has_line "$labels" 'release-note-none' && has_release_note_none=true
+
+  if [ "$has_release_note" = true ] && [ "$has_release_note_none" = true ]; then
+    append_line "$work_dir/errors" "#$number has both release-note and release-note-none labels"
+    return
+  fi
+
+  if [ "$has_release_note_none" = true ]; then
+    is_no_release_note "$note" || \
+      append_line "$work_dir/errors" "#$number has release-note-none but its release-note block is not NONE or NO"
+    append_line "$work_dir/excluded" "$number"
+    return
+  fi
+
+  if [ "$has_release_note" = false ]; then
+    append_line "$work_dir/errors" "#$number has neither release-note nor release-note-none"
+    return
+  fi
+
+  if [ -z "$note" ] || is_no_release_note "$note"; then
+    append_line "$work_dir/errors" "#$number has release-note but no usable release-note content"
+    return
+  fi
+
+  if ! category=$(classify_kind "$kind_labels"); then
+    append_line "$work_dir/errors" \
+      "#$number has unsupported kind labels: $(printf '%s\n' "$kind_labels" | join_lines)"
+    return
+  fi
+
+  if [ "$kind_count" -gt 1 ]; then
+    append_line "$work_dir/warnings" \
+      "#$number has multiple kind labels ($(printf '%s\n' "$kind_labels" | join_lines)); classified as $category"
+  fi
+
+  mkdir -p "$work_dir/entries/$category"
+  entry_file=$(printf '%s/entries/%s/%012d.md' "$work_dir" "$category" "$number")
+  {
+    printf -- '- '
+    printf '%s\n' "$note" | awk 'NR == 1 { printf "%s", $0; next } { printf "\n  %s", $0 }'
+    printf ' ([#%s](%s), [@%s](https://github.com/%s))\n\n' \
+      "$number" "$url" "$author" "$author"
+  } > "$entry_file"
+}
+
+collect_pull_numbers() {
+  local start_ref=$1
+  local end_ref=$2
+  local base_branch=$3
+  local repo=$4
+  local work_dir=$5
+  local range=$end_ref sha pulls numbers number subject message message_pull_number
+  local direct_pull api_error api_response api_status found
+
+  [ -z "$start_ref" ] || range="$start_ref..$end_ref"
+  git_cmd rev-list --reverse "$range" > "$work_dir/commits"
+  : > "$work_dir/pull_numbers"
+
+  while IFS= read -r sha; do
+    [ -n "$sha" ] || continue
+    message=$(git_cmd show -s --format=%s%n%b "$sha")
+    subject=${message%%$'\n'*}
+    message_pull_number=$(printf '%s\n' "$message" | parse_pull_number_from_commit_message)
+    found=false
+
+    if [ -n "$message_pull_number" ]; then
+      api_error="$work_dir/github-api-error"
+      : > "$api_error"
+      if api_response=$(github_api "repos/$repo/pulls/$message_pull_number" \
+        --include 2> "$api_error"); then
+        direct_pull=$(printf '%s\n' "$api_response" | http_response_body)
+        if printf '%s' "$direct_pull" | jq -e \
+          --arg base "$base_branch" \
+          --arg sha "$sha" \
+          '.merged_at != null
+            and ($base == "" or .base.ref == $base)
+            and .merge_commit_sha == $sha' >/dev/null; then
+          append_line "$work_dir/pull_numbers" "$message_pull_number"
+          found=true
+        fi
+      else
+        api_status=$(printf '%s\n' "$api_response" | http_status_code)
+        if [ "$api_status" != 404 ]; then
+          cat "$api_error" >&2
+          echo "error: failed to read pull request #$message_pull_number" >&2
+          return 1
+        fi
+      fi
+    fi
+
+    if [ "$found" = false ]; then
+      if ! pulls=$(github_api "repos/$repo/commits/$sha/pulls?per_page=100"); then
+        echo "error: failed to find pull requests associated with commit $sha" >&2
+        return 1
+      fi
+      numbers=$(printf '%s' "$pulls" | jq -r --arg base "$base_branch" '
+        .[]
+        | select(.merged_at != null)
+        | select($base == "" or .base.ref == $base)
+        | .number
+      ')
+      if [ -z "$numbers" ]; then
+        append_line "$work_dir/warnings" \
+          "no merged PR found for $(printf '%.12s' "$sha") $subject"
+        continue
+      fi
+      while IFS= read -r number; do
+        [ -n "$number" ] && append_line "$work_dir/pull_numbers" "$number"
+      done <<EOF
+$numbers
+EOF
+    fi
+  done < "$work_dir/commits"
+
+  sort -n -u "$work_dir/pull_numbers" > "$work_dir/pull_numbers.sorted"
+}
+
+render_generated_block() {
+  local work_dir=$1
+  local repo=$2
+  local start_ref=$3
+  local version=$4
+  local category title directory file
+  local found=false compare_url
+
+  printf '%s\n' "$GENERATED_START"
+  printf '%s\n' '<!-- Generated by scripts/changelog.sh. Edit PR release-note blocks'
+  printf '%s\n' '     and rerun the workflow to change this block. Add hand-written overview,'
+  printf '%s\n\n' '     upgrade notes, and known issues outside this block. -->'
+  printf '%s\n\n' '### Changes by Kind'
+
+  while IFS='|' read -r category title; do
+    directory="$work_dir/entries/$category"
+    [ -d "$directory" ] || continue
+    set -- "$directory"/*.md
+    [ -e "$1" ] || continue
+    found=true
+    printf '#### %s\n\n' "$title"
+    for file in "$directory"/*.md; do
+      cat "$file"
+    done
+  done <<'EOF'
+deprecation|Deprecation
+api-change|API Change
+feature|Feature
+bug-or-regression|Bug or Regression
+documentation|Documentation
+other|Other
+EOF
+
+  if [ "$found" = false ]; then
+    printf '%s\n\n' 'No user-facing, API-facing, or operator-facing changes were reported for this release.'
+  fi
+
+  if [ -n "$start_ref" ]; then
+    compare_url="https://github.com/$repo/compare/$start_ref...$version"
+  else
+    compare_url="https://github.com/$repo/commits/$version"
+  fi
+  printf '[Full Changelog](%s)\n\n%s\n' "$compare_url" "$GENERATED_END"
+}
+
+upsert_changelog() {
+  local existing_file=$1
+  local output_file=$2
+  local version=$3
+  local generated_file=$4
+  local work_dir=$5
+  local version_number=${version#v}
+  local major=${version_number%%.*}
+  local remainder=${version_number#*.}
+  local minor=${remainder%%.*}
+  local source=/dev/null
+  local temporary="$work_dir/changelog.updated"
+
+  if [ -e "$existing_file" ] || [ -L "$existing_file" ]; then
+    if [ ! -f "$existing_file" ] || [ -L "$existing_file" ]; then
+      echo "error: changelog target is not a regular file: $existing_file" >&2
+      return 1
+    fi
+    source=$existing_file
+  fi
+  if [ "$output_file" != "$existing_file" ] && \
+    { [ -L "$output_file" ] || { [ -e "$output_file" ] && [ ! -f "$output_file" ]; }; }; then
+    echo "error: changelog target is not a regular file: $output_file" >&2
+    return 1
+  fi
+  if ! awk \
+    -v version="$version" \
+    -v major="$major" \
+    -v minor="$minor" \
+    -v block_file="$generated_file" \
+    -v generated_start="$GENERATED_START" \
+    -v generated_end="$GENERATED_END" '
+      BEGIN {
+        while ((getline line < block_file) > 0) block[++block_count] = line
+        close(block_file)
+      }
+      {
+        sub(/\r$/, "")
+        lines[NR] = $0
+      }
+      function emit_block(  i) {
+        for (i = 1; i <= block_count; i++) print block[i]
+      }
+      function emit_section() {
+        print "## " version
+        print ""
+        emit_block()
+        print ""
+        print "---"
+        print ""
+      }
+      END {
+        count = NR
+        heading = 0
+        first_heading = 0
+        has_content = 0
+        for (i = 1; i <= count; i++) {
+          value = lines[i]
+          sub(/[[:space:]]+$/, "", value)
+          if (value != "") has_content = 1
+          if (!first_heading && value ~ /^## v[0-9]+\.[0-9]+\.[0-9]+$/) first_heading = i
+          if (value == "## " version) heading = i
+        }
+
+        if (heading) {
+          section_end = count + 1
+          for (i = heading + 1; i <= count; i++) {
+            value = lines[i]
+            sub(/[[:space:]]+$/, "", value)
+            if (value ~ /^## v[0-9]+\.[0-9]+\.[0-9]+$/) {
+              section_end = i
+              break
+            }
+          }
+          block_start = 0
+          block_end = 0
+          for (i = heading + 1; i < section_end; i++) {
+            if (!block_start && lines[i] == generated_start) block_start = i
+            if (block_start && lines[i] == generated_end) {
+              block_end = i
+              break
+            }
+          }
+          if (!block_start || !block_end) {
+            print "error: the " version " section exists without a complete generated block; refusing to overwrite hand-written content" > "/dev/stderr"
+            exit 2
+          }
+          for (i = 1; i < block_start; i++) print lines[i]
+          emit_block()
+          for (i = block_end + 1; i <= count; i++) print lines[i]
+          exit
+        }
+
+        if (!count || !has_content) {
+          print "# MatrixHub v" major "." minor ".x release notes"
+          print ""
+          emit_section()
+          exit
+        }
+
+        if (first_heading) {
+          for (i = 1; i < first_heading; i++) print lines[i]
+          emit_section()
+          for (i = first_heading; i <= count; i++) print lines[i]
+          exit
+        }
+
+        for (i = 1; i <= count; i++) print lines[i]
+        if (lines[count] != "") print ""
+        emit_section()
+      }
+    ' "$source" > "$temporary"; then
+    return 1
+  fi
+
+  mkdir -p "$(dirname "$output_file")"
+  mv "$temporary" "$output_file"
+}
+
+line_count() {
+  if [ -s "$1" ]; then
+    wc -l < "$1" | tr -d ' '
+  else
+    printf '0\n'
+  fi
+}
+
+file_count() {
+  if [ -d "$1" ]; then
+    find "$1" -type f | wc -l | tr -d ' '
+  else
+    printf '0\n'
+  fi
+}
+
+append_github_output() {
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+cleanup_work_dir() {
+  local directory=${1:-}
+  if [ -n "$directory" ] && [ -d "$directory" ]; then
+    rm -rf "$directory"
+  fi
+}
+
+main() {
+  local version=''
+  local repo=${GITHUB_REPOSITORY:-}
+  local start_ref=''
+  local end_ref=HEAD
+  local base_branch=${GITHUB_BASE_REF:-${GITHUB_REF_NAME:-}}
+  local output=''
+  local dry_run=false
+  local work_dir token range number pull_json
+  local included_count excluded_count pull_count commit_count warning
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --dry-run)
+        dry_run=true
+        shift
+        ;;
+      --help)
+        usage
+        return
+        ;;
+      --version|--repo|--start-ref|--end-ref|--base-branch|--output)
+        [ "$#" -ge 2 ] || { echo "error: incomplete argument: $1" >&2; return 1; }
+        case "$1" in
+          --version) version=$2 ;;
+          --repo) repo=$2 ;;
+          --start-ref) start_ref=$2 ;;
+          --end-ref) end_ref=$2 ;;
+          --base-branch) base_branch=$2 ;;
+          --output) output=$2 ;;
+        esac
+        shift 2
+        ;;
+      *)
+        echo "error: unknown argument: $1" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  [[ $version =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+    echo "error: --version must be an official version in vX.Y.Z form, got: ${version:-<empty>}" >&2
+    return 1
+  }
+  [[ $repo =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]] || {
+    echo "error: --repo must be in OWNER/REPO form, got: ${repo:-<empty>}" >&2
+    return 1
+  }
+
+  local command
+  for command in git gh jq awk sort; do
+    require_command "$command"
+  done
+  token=${GITHUB_TOKEN:-${GH_TOKEN:-}}
+  [ -n "$token" ] || {
+    echo 'error: GITHUB_TOKEN or GH_TOKEN is required to read pull request metadata' >&2
+    return 1
+  }
+  GH_TOKEN=$token
+  export GH_TOKEN
+
+  [ -n "$base_branch" ] || base_branch=$(git_cmd branch --show-current)
+  git_cmd rev-parse --verify "$end_ref^{commit}" >/dev/null
+  if [ -n "$(git_cmd tag --list "$version")" ]; then
+    echo "$version already exists; release notes must be committed before the official tag is created" >&2
+    return 1
+  fi
+  [ -n "$start_ref" ] || start_ref=$(find_previous_official_tag "$version" "$end_ref")
+  [ -z "$start_ref" ] || git_cmd rev-parse --verify "$start_ref^{commit}" >/dev/null
+
+  if [ -z "$output" ]; then
+    local version_number=${version#v}
+    local major=${version_number%%.*}
+    local remainder=${version_number#*.}
+    local minor=${remainder%%.*}
+    output="CHANGELOG/CHANGELOG-$major.$minor.md"
+  fi
+
+  work_dir=$(mktemp -d "${TMPDIR:-/tmp}/matrixhub-changelog.XXXXXX")
+  CHANGELOG_WORK_DIR=$work_dir
+  trap 'cleanup_work_dir "${CHANGELOG_WORK_DIR:-}"' EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  mkdir -p "$work_dir/entries"
+  : > "$work_dir/errors"
+  : > "$work_dir/warnings"
+  : > "$work_dir/excluded"
+
+  range=$end_ref
+  [ -z "$start_ref" ] || range="$start_ref..$end_ref"
+  printf 'Collecting %s release notes from %s\n' "$version" "$range"
+  collect_pull_numbers "$start_ref" "$end_ref" "$base_branch" "$repo" "$work_dir"
+  commit_count=$(line_count "$work_dir/commits")
+  printf 'Inspecting %s commits in %s\n' "$commit_count" "$repo"
+
+  while IFS= read -r number; do
+    [ -n "$number" ] || continue
+    if ! pull_json=$(github_api "repos/$repo/pulls/$number"); then
+      echo "error: failed to read pull request #$number" >&2
+      return 1
+    fi
+    process_pull "$pull_json" "$work_dir"
+  done < "$work_dir/pull_numbers.sorted"
+
+  while IFS= read -r warning; do
+    [ -n "$warning" ] && printf 'warning: %s\n' "$warning" >&2
+  done < "$work_dir/warnings"
+
+  if [ -s "$work_dir/errors" ]; then
+    echo 'error: Release note metadata validation failed:' >&2
+    while IFS= read -r warning; do
+      printf -- '- %s\n' "$warning" >&2
+    done < "$work_dir/errors"
+    return 1
+  fi
+
+  render_generated_block "$work_dir" "$repo" "$start_ref" "$version" > "$work_dir/generated.md"
+  if [ "$dry_run" = true ]; then
+    printf '\n## %s\n\n' "$version"
+    cat "$work_dir/generated.md"
+    printf '\n'
+  else
+    upsert_changelog "$output" "$output" "$version" "$work_dir/generated.md" "$work_dir"
+    printf 'Updated %s\n' "$output"
+  fi
+
+  included_count=$(file_count "$work_dir/entries")
+  excluded_count=$(line_count "$work_dir/excluded")
+  pull_count=$(line_count "$work_dir/pull_numbers.sorted")
+  append_github_output output_path "$output"
+  append_github_output start_ref "${start_ref:-repository-root}"
+  append_github_output included_count "$included_count"
+  append_github_output excluded_count "$excluded_count"
+  append_github_output pull_count "$pull_count"
+
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+      printf '## %s release note collection\n\n' "$version"
+      printf -- '- Range: `%s`\n' "${start_ref:-repository-root}..$end_ref"
+      printf -- '- Pull requests found: %s\n' "$pull_count"
+      printf -- '- Included release notes: %s\n' "$included_count"
+      printf -- '- Excluded as NONE/NO: %s\n' "$excluded_count"
+      printf -- '- Commits without an associated merged PR: %s\n' \
+        "$(grep -c '^no merged PR found' "$work_dir/warnings" || true)"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+
+  cleanup_work_dir "$work_dir"
+  CHANGELOG_WORK_DIR=''
+  trap - EXIT HUP INT TERM
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  set -euo pipefail
+  main "$@"
 fi
-#
-if [ -n "${CHANGED_PR}" ]; then
-    echo "## Changed Feature" >> ${FILE_CHANGELOG}
-    echo "" >> ${FILE_CHANGELOG}
-    while read LINE ; do
-      echo "${LINE}" >> ${FILE_CHANGELOG}
-      echo "" >> ${FILE_CHANGELOG}
-    done <<< "${CHANGED_PR}"
-    echo "***" >> ${FILE_CHANGELOG}
-    echo "" >> ${FILE_CHANGELOG}
-fi
-#
-if [ -n "${FIX_PR}" ]; then
-    echo "## Fix" >> ${FILE_CHANGELOG}
-    echo "" >> ${FILE_CHANGELOG}
-    while read LINE ; do
-      echo "${LINE}" >> ${FILE_CHANGELOG}
-      echo "" >> ${FILE_CHANGELOG}
-    done <<< "${FIX_PR}"
-    echo "***" >> ${FILE_CHANGELOG}
-    echo "" >> ${FILE_CHANGELOG}
-fi
-#
-echo "## Total " >> ${FILE_CHANGELOG}
-echo "" >> ${FILE_CHANGELOG}
-echo "Pull request number: ${TOTAL_COUNT}" >> ${FILE_CHANGELOG}
-echo "" >> ${FILE_CHANGELOG}
-if [ -n "${START_TAG}" ]; then
-    echo "[ Commits ](https://github.com/${PROJECT_REPO}/compare/${START_TAG}...${DEST_TAG})" >> ${FILE_CHANGELOG}
-else
-    echo "[ Commits ](https://github.com/${PROJECT_REPO}/commits/${DEST_TAG})" >> ${FILE_CHANGELOG}
-fi
-echo "--------------------"
-echo "generate changelog to ${FILE_CHANGELOG}"

--- a/scripts/changelog.test.sh
+++ b/scripts/changelog.test.sh
@@ -1,0 +1,558 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 MatrixHub Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -u
+set -o pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=changelog.sh
+source "$SCRIPT_DIR/changelog.sh"
+
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/matrixhub-changelog-test.XXXXXX")
+PASSED=0
+FAILED=0
+
+cleanup() {
+  if [ -n "${TEST_ROOT:-}" ] && [ -d "$TEST_ROOT" ]; then
+    rm -rf "$TEST_ROOT"
+  fi
+}
+trap cleanup EXIT HUP INT TERM
+
+fail() {
+  printf '  %s\n' "$1" >&2
+  return 1
+}
+
+assert_equal() {
+  [ "$1" = "$2" ] || fail "expected <$1>, got <$2>"
+}
+
+assert_contains() {
+  case "$1" in
+    *"$2"*) return 0 ;;
+    *) fail "expected output to contain <$2>" ;;
+  esac
+}
+
+assert_not_contains() {
+  case "$1" in
+    *"$2"*) fail "expected output not to contain <$2>" ;;
+    *) return 0 ;;
+  esac
+}
+
+new_work_dir() {
+  local directory
+  directory=$(mktemp -d "$TEST_ROOT/work.XXXXXX") || return 1
+  mkdir -p "$directory/entries"
+  : > "$directory/errors"
+  : > "$directory/warnings"
+  : > "$directory/excluded"
+  printf '%s\n' "$directory"
+}
+
+pull_json() {
+  local number=$1
+  local body=$2
+  local labels=$3
+  local author=${4:-contributor}
+
+  jq -cn \
+    --argjson number "$number" \
+    --arg body "$body" \
+    --argjson labels "$labels" \
+    --arg author "$author" \
+    '{
+      number: $number,
+      html_url: ("https://github.com/matrixhub-ai/matrixhub/pull/" + ($number | tostring)),
+      body: $body,
+      labels: ($labels | map({name: .})),
+      user: {login: $author}
+    }'
+}
+
+test_release_note_parsing() {
+  local actual
+  actual=$(printf 'before\r\n```release-note\r\nFirst line.\r\nSecond line.\r\n```\r\nafter\n' | extract_release_note)
+  assert_equal $'First line.\nSecond line.' "$actual" || return 1
+  actual=$(printf 'prefix ```release-note Inline note.``` suffix\n' | extract_release_note)
+  assert_equal 'Inline note.' "$actual" || return 1
+  actual=$(printf '```release-note\n  Padded note.  \n```\n' | extract_release_note)
+  assert_equal 'Padded note.' "$actual" || return 1
+  assert_equal '' "$(printf '```release-note\nunclosed\n' | extract_release_note)" || return 1
+  is_no_release_note ' NONE ' || return 1
+  is_no_release_note 'no.' || return 1
+  if is_no_release_note '_NONE_'; then
+    fail 'underscores are word characters in the ci-bot contract'
+  fi
+  if is_no_release_note 'No user-visible change'; then
+    fail 'descriptive text must not be treated as NONE'
+  fi
+}
+
+test_version_and_kind_rules() {
+  version_is_less v0.9.9 v0.10.0 || return 1
+  if version_is_less v0.10.0 v0.9.9; then
+    fail 'numeric version ordering is reversed'
+  fi
+  version_is_less v99999999999999999999.0.0 v100000000000000000000.0.0 || return 1
+  assert_equal api-change "$(classify_kind $'kind/feature\nkind/api-change')" || return 1
+  assert_equal bug-or-regression "$(classify_kind 'kind/regression')" || return 1
+  assert_equal other "$(classify_kind 'kind/cleanup')" || return 1
+}
+
+test_previous_official_tag() (
+  git_cmd() {
+    printf '%s\n' v0.1.0 v0.2.0-rc.1 v0.2.0 v0.10.0 not-a-version
+  }
+
+  assert_equal v0.2.0 "$(find_previous_official_tag v0.3.0 HEAD)" || return 1
+  assert_equal v0.10.0 "$(find_previous_official_tag v0.11.0 HEAD)" || return 1
+  assert_equal '' "$(find_previous_official_tag v0.1.0 HEAD)" || return 1
+)
+
+test_pull_validation_and_rendering() {
+  local work feature none block errors
+  work=$(new_work_dir) || return 1
+  feature=$(pull_json 21 $'```release-note\nAdded a capability.\nMore detail.\n```' \
+    '["kind/feature", "release-note"]' alice) || return 1
+  none=$(pull_json 22 $'```release-note\nNONE\n```' \
+    '["kind/cleanup", "release-note-none"]' bob) || return 1
+
+  process_pull "$feature" "$work" || return 1
+  process_pull "$none" "$work" || return 1
+  errors=$(cat "$work/errors")
+  assert_equal '' "$errors" || return 1
+  assert_equal 22 "$(cat "$work/excluded")" || return 1
+
+  block=$(render_generated_block "$work" matrixhub-ai/matrixhub v0.1.0 v0.2.0) || return 1
+  assert_contains "$block" '#### Feature' || return 1
+  assert_contains "$block" $'- Added a capability.\n  More detail. ([#21]' || return 1
+  assert_contains "$block" '[@alice](https://github.com/alice)' || return 1
+  assert_contains "$block" '/compare/v0.1.0...v0.2.0' || return 1
+  assert_not_contains "$block" 'NONE' || return 1
+}
+
+test_invalid_metadata_is_reported() {
+  local work missing_kind conflicting blocked wrong_none missing_release unusable unsupported multiple
+  local errors warnings
+  work=$(new_work_dir) || return 1
+  missing_kind=$(pull_json 30 $'```release-note\nVisible change.\n```' '["release-note"]') || return 1
+  conflicting=$(pull_json 31 $'```release-note\nNONE\n```' \
+    '["kind/cleanup", "release-note", "release-note-none"]') || return 1
+  blocked=$(pull_json 32 $'```release-note\nFix.\n```' \
+    '["kind/bug", "release-note", "do-not-merge/needs-kind", "do-not-merge/needs-release-note"]') || return 1
+  wrong_none=$(pull_json 33 $'```release-note\nVisible change.\n```' \
+    '["kind/feature", "release-note-none"]') || return 1
+  missing_release=$(pull_json 34 $'```release-note\nFix.\n```' '["kind/bug"]') || return 1
+  unusable=$(pull_json 35 $'```release-note\nNONE\n```' \
+    '["kind/bug", "release-note"]') || return 1
+  unsupported=$(pull_json 36 $'```release-note\nChange.\n```' \
+    '["kind/unknown", "release-note"]') || return 1
+  multiple=$(pull_json 37 $'```release-note\nAPI change.\n```' \
+    '["kind/feature", "kind/api-change", "release-note"]') || return 1
+
+  process_pull "$missing_kind" "$work" || return 1
+  process_pull "$conflicting" "$work" || return 1
+  process_pull "$blocked" "$work" || return 1
+  process_pull "$wrong_none" "$work" || return 1
+  process_pull "$missing_release" "$work" || return 1
+  process_pull "$unusable" "$work" || return 1
+  process_pull "$unsupported" "$work" || return 1
+  process_pull "$multiple" "$work" || return 1
+  errors=$(cat "$work/errors")
+  warnings=$(cat "$work/warnings")
+  assert_contains "$errors" '#30 has no kind/* label' || return 1
+  assert_contains "$errors" '#31 has both release-note and release-note-none labels' || return 1
+  assert_contains "$errors" '#32 is still labeled do-not-merge/needs-kind' || return 1
+  assert_contains "$errors" '#32 is still labeled do-not-merge/needs-release-note' || return 1
+  assert_contains "$errors" '#33 has release-note-none but its release-note block is not NONE or NO' || return 1
+  assert_contains "$errors" '#34 has neither release-note nor release-note-none' || return 1
+  assert_contains "$errors" '#35 has release-note but no usable release-note content' || return 1
+  assert_contains "$errors" '#36 has unsupported kind labels: kind/unknown' || return 1
+  assert_contains "$warnings" '#37 has multiple kind labels (kind/feature, kind/api-change); classified as api-change' || return 1
+}
+
+test_release_note_is_not_executed() {
+  local work sentinel body pull output
+  work=$(new_work_dir) || return 1
+  sentinel="$work/should-not-exist"
+  body="\`\`\`release-note
+\$(touch $sentinel)
+\`\`\`"
+  pull=$(pull_json 40 "$body" '["kind/feature", "release-note"]') || return 1
+  process_pull "$pull" "$work" || return 1
+  [ ! -e "$sentinel" ] || fail 'release-note content was executed' || return 1
+  output=$(cat "$work/entries/feature/000000000040.md")
+  assert_contains "$output" "\$(touch $sentinel)" || return 1
+}
+
+test_pull_discovery_filters_and_deduplicates() (
+  local work pulls warnings
+  work=$(new_work_dir) || return 1
+
+  git_cmd() {
+    case "$1" in
+      rev-list) printf '%s\n' aaaaaaaaaaaa1111 bbbbbbbbbbbb2222 cccccccccccc3333 ;;
+      show) printf 'direct commit\n' ;;
+      *) return 90 ;;
+    esac
+  }
+  github_api() {
+    case "$1" in
+      *aaaaaaaaaaaa1111*)
+        printf '%s\n' '[{"number": 5, "merged_at": "2026-01-01", "base": {"ref": "main"}}]'
+        ;;
+      *bbbbbbbbbbbb2222*)
+        printf '%s\n' '[{"number": 5, "merged_at": "2026-01-01", "base": {"ref": "main"}}, {"number": 6, "merged_at": "2026-01-01", "base": {"ref": "release"}}]'
+        ;;
+      *cccccccccccc3333*) printf '%s\n' '[]' ;;
+      *) return 91 ;;
+    esac
+  }
+
+  collect_pull_numbers v0.1.0 HEAD main matrixhub-ai/matrixhub "$work" || return 1
+  pulls=$(cat "$work/pull_numbers.sorted")
+  warnings=$(cat "$work/warnings")
+  assert_equal 5 "$pulls" || return 1
+  assert_contains "$warnings" 'no merged PR found for cccccccccccc direct commit' || return 1
+)
+
+test_commit_message_pull_discovery() (
+  local work pulls warnings commit_sha
+  work=$(new_work_dir) || return 1
+  commit_sha=aaaaaaaaaaaa1111
+
+  assert_equal 123 "$(printf 'Merge pull request #123 from topic\n\nTitle\n' | parse_pull_number_from_commit_message)" || return 1
+  assert_equal 34 "$(printf 'docs: mention (#12) and finish (#34)\n' | parse_pull_number_from_commit_message)" || return 1
+  assert_equal '' "$(printf 'direct commit\n' | parse_pull_number_from_commit_message)" || return 1
+
+  git_cmd() {
+    case "$1" in
+      rev-list) printf '%s\n' "$commit_sha" ;;
+      show) printf 'Merge pull request #12 from topic\n\nFeature\n' ;;
+      *) return 90 ;;
+    esac
+  }
+  github_api() {
+    case "$1" in
+      repos/*/pulls/12)
+        [ "${2:-}" = --include ] || return 93
+        printf 'HTTP/2.0 200 OK\r\nContent-Type: application/json\r\n\r\n'
+        printf '{"number":12,"merged_at":"2026-01-01","base":{"ref":"main"},"merge_commit_sha":"%s"}\n' "$commit_sha"
+        ;;
+      repos/*/commits/*)
+        fail 'associated PR lookup should not run after a verified commit-message match'
+        return 91
+        ;;
+      *) return 92 ;;
+    esac
+  }
+
+  collect_pull_numbers v0.1.0 HEAD main matrixhub-ai/matrixhub "$work" || return 1
+  pulls=$(cat "$work/pull_numbers.sorted")
+  warnings=$(cat "$work/warnings")
+  assert_equal 12 "$pulls" || return 1
+  assert_equal '' "$warnings" || return 1
+)
+
+test_commit_message_pr_lookup_errors() (
+  local work error mock_api_status=404
+  work=$(new_work_dir) || return 1
+  error="$work/error"
+
+  git_cmd() {
+    case "$1" in
+      rev-list) printf '%s\n' aaaaaaaaaaaa1111 ;;
+      show) printf 'fix from a referenced pull request (#404)\n' ;;
+      *) return 90 ;;
+    esac
+  }
+  github_api() {
+    case "$1" in
+      repos/*/pulls/404)
+        [ "${2:-}" = --include ] || return 93
+        printf 'HTTP/2.0 %s Error\r\nContent-Type: application/json\r\n\r\n' "$mock_api_status"
+        printf '{"status":"%s"}\n' "$mock_api_status"
+        if [ "$mock_api_status" = 404 ]; then
+          printf 'opaque client error\n' >&2
+        else
+          printf 'gh: Not Found (HTTP 404)\n' >&2
+        fi
+        return 1
+        ;;
+      repos/*/commits/*)
+        printf '%s\n' '[{"number":45,"merged_at":"2026-01-01","base":{"ref":"main"}}]'
+        ;;
+      *) return 92 ;;
+    esac
+  }
+
+  collect_pull_numbers v0.1.0 HEAD main matrixhub-ai/matrixhub "$work" || return 1
+  assert_equal 45 "$(cat "$work/pull_numbers.sorted")" || return 1
+
+  work=$(new_work_dir) || return 1
+  error="$work/error"
+  mock_api_status=500
+  if collect_pull_numbers v0.1.0 HEAD main matrixhub-ai/matrixhub "$work" 2> "$error"; then
+    fail 'a non-404 PR lookup error should stop collection'
+    return 1
+  fi
+  assert_contains "$(cat "$error")" 'gh: Not Found (HTTP 404)' || return 1
+  assert_contains "$(cat "$error")" 'failed to read pull request #404' || return 1
+)
+
+test_prepare_workflow_uses_snapshot_lease() {
+  local workflow
+  workflow=$(cat "$SCRIPT_DIR/../.github/workflows/prepare-release-notes.yml") || return 1
+
+  assert_contains "$workflow" 'echo "expected_remote_sha=${expected_remote_sha}" >> "${GITHUB_OUTPUT}"' || return 1
+  assert_contains "$workflow" 'EXPECTED_REMOTE_SHA: ${{ steps.draft.outputs.expected_remote_sha }}' || return 1
+  assert_contains "$workflow" '--force-with-lease="refs/heads/${RELEASE_BRANCH}:${EXPECTED_REMOTE_SHA}"' || return 1
+  assert_not_contains "$workflow" 'git push --force-with-lease --set-upstream' || return 1
+}
+
+test_changelog_create_and_prepend() {
+  local work generated changelog blank_changelog content newest older
+  work=$(new_work_dir) || return 1
+  generated="$work/generated.md"
+  changelog="$work/CHANGELOG.md"
+  printf '%s\nnew generated content\n%s\n' "$GENERATED_START" "$GENERATED_END" > "$generated"
+
+  upsert_changelog "$changelog" "$changelog" v0.2.0 "$generated" "$work" || return 1
+  content=$(cat "$changelog")
+  assert_contains "$content" '# MatrixHub v0.2.x release notes' || return 1
+  assert_contains "$content" '## v0.2.0' || return 1
+
+  blank_changelog="$work/BLANK.md"
+  printf '\n  \n' > "$blank_changelog"
+  upsert_changelog "$blank_changelog" "$blank_changelog" v0.2.0 "$generated" "$work" || return 1
+  assert_contains "$(cat "$blank_changelog")" '# MatrixHub v0.2.x release notes' || return 1
+
+  upsert_changelog "$changelog" "$changelog" v0.2.1 "$generated" "$work" || return 1
+  newest=$(awk '$0 == "## v0.2.1" { print NR; exit }' "$changelog")
+  older=$(awk '$0 == "## v0.2.0" { print NR; exit }' "$changelog")
+  [ "$newest" -lt "$older" ] || fail 'new version was not inserted before the old version'
+}
+
+test_changelog_upsert_is_safe_and_idempotent() {
+  local work generated changelog before
+  work=$(new_work_dir) || return 1
+  generated="$work/generated.md"
+  changelog="$work/CHANGELOG.md"
+  printf '%s\nnew generated content\n%s\n' "$GENERATED_START" "$GENERATED_END" > "$generated"
+  printf '%s\n' \
+    '# MatrixHub v0.2.x release notes' \
+    '' \
+    '## v0.2.0' \
+    '' \
+    '### Overview' \
+    '' \
+    'Keep this overview.' \
+    '' \
+    "$GENERATED_START" \
+    'old generated content' \
+    "$GENERATED_END" \
+    '' \
+    '### Known Issues' \
+    '' \
+    'Keep this issue.' > "$changelog"
+
+  upsert_changelog "$changelog" "$changelog" v0.2.0 "$generated" "$work" || return 1
+  before=$(cat "$changelog")
+  assert_contains "$before" 'Keep this overview.' || return 1
+  assert_contains "$before" 'Keep this issue.' || return 1
+  assert_contains "$before" 'new generated content' || return 1
+  assert_not_contains "$before" 'old generated content' || return 1
+
+  upsert_changelog "$changelog" "$changelog" v0.2.0 "$generated" "$work" || return 1
+  assert_equal "$before" "$(cat "$changelog")" || return 1
+}
+
+test_changelog_refuses_unmarked_section() {
+  local work generated changelog original before
+  work=$(new_work_dir) || return 1
+  generated="$work/generated.md"
+  changelog="$work/CHANGELOG.md"
+  printf '%s\nnew block\n%s\n' "$GENERATED_START" "$GENERATED_END" > "$generated"
+  original=$'## v0.2.0\n\nHand-written notes.\n'
+  printf '%s' "$original" > "$changelog"
+  before=$(cksum < "$changelog")
+
+  if upsert_changelog "$changelog" "$changelog" v0.2.0 "$generated" "$work" 2>/dev/null; then
+    fail 'unmarked section should be rejected'
+    return 1
+  fi
+  assert_equal "$before" "$(cksum < "$changelog")" || return 1
+}
+
+test_changelog_rejects_non_regular_target() {
+  local work generated changelog
+  work=$(new_work_dir) || return 1
+  generated="$work/generated.md"
+  changelog="$work/CHANGELOG.md"
+  printf '%s\nnew block\n%s\n' "$GENERATED_START" "$GENERATED_END" > "$generated"
+  mkdir -p "$changelog"
+
+  if upsert_changelog "$changelog" "$changelog" v0.2.0 "$generated" "$work" 2>/dev/null; then
+    fail 'a directory changelog target should be rejected'
+    return 1
+  fi
+  [ ! -e "$changelog/changelog.updated" ] || fail 'content was written inside the target directory'
+}
+
+test_full_cli_contract() {
+  local case_dir repo_dir bin_dir associated pull stdout stderr sha output
+  local github_output summary write_stdout invalid_stderr hostile_tmp sentinel before
+  case_dir=$(mktemp -d "$TEST_ROOT/cli.XXXXXX") || return 1
+  repo_dir="$case_dir/repo"
+  bin_dir="$case_dir/bin"
+  mkdir -p "$repo_dir" "$bin_dir"
+
+  git -C "$repo_dir" init -q || return 1
+  git -C "$repo_dir" config user.name test || return 1
+  git -C "$repo_dir" config user.email test@example.com || return 1
+  printf 'seed\n' > "$repo_dir/content"
+  git -C "$repo_dir" add content || return 1
+  git -C "$repo_dir" commit -q -m seed || return 1
+  printf 'change\n' >> "$repo_dir/content"
+  git -C "$repo_dir" commit -qam 'feat: change' || return 1
+  sha=$(git -C "$repo_dir" rev-parse HEAD) || return 1
+
+  associated="$case_dir/associated.json"
+  pull="$case_dir/pull.json"
+  printf '[{"number":42,"merged_at":"2026-01-01","base":{"ref":"main"}}]\n' > "$associated"
+  pull_json 42 $'```release-note\nAdded from the CLI.\n```' \
+    '["kind/feature", "release-note"]' cli-author > "$pull" || return 1
+
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'endpoint=${!#}' \
+    'case "$endpoint" in' \
+    '  repos/*/commits/*/pulls*) cat "$MOCK_ASSOCIATED" ;;' \
+    '  repos/*/pulls/42) cat "$MOCK_PULL" ;;' \
+    '  *) echo "unexpected endpoint: $endpoint" >&2; exit 97 ;;' \
+    'esac' > "$bin_dir/gh"
+  chmod +x "$bin_dir/gh"
+
+  stdout="$case_dir/stdout"
+  stderr="$case_dir/stderr"
+  github_output="$case_dir/github-output"
+  summary="$case_dir/summary"
+  if ! (
+    cd "$repo_dir" || exit 1
+    PATH="$bin_dir:$PATH" \
+      GH_TOKEN='secret-test-token' \
+      GITHUB_OUTPUT="$github_output" \
+      GITHUB_STEP_SUMMARY="$summary" \
+      MOCK_ASSOCIATED="$associated" \
+      MOCK_PULL="$pull" \
+      /bin/bash "$SCRIPT_DIR/changelog.sh" \
+        --version v0.2.0 \
+        --repo matrixhub-ai/matrixhub \
+        --end-ref HEAD \
+        --base-branch main \
+        --dry-run
+  ) > "$stdout" 2> "$stderr"; then
+    cat "$stderr" >&2
+    fail 'full CLI dry-run failed'
+    return 1
+  fi
+
+  output=$(cat "$stdout")
+  assert_contains "$output" 'Collecting v0.2.0 release notes from HEAD' || return 1
+  assert_contains "$output" 'Added from the CLI.' || return 1
+  assert_contains "$output" '[@cli-author](https://github.com/cli-author)' || return 1
+  assert_not_contains "$output$(cat "$stderr")$(cat "$github_output")$(cat "$summary")" 'secret-test-token' || return 1
+  assert_contains "$(cat "$github_output")" 'output_path=CHANGELOG/CHANGELOG-0.2.md' || return 1
+  assert_contains "$(cat "$github_output")" 'start_ref=repository-root' || return 1
+  assert_contains "$(cat "$github_output")" 'included_count=1' || return 1
+  assert_contains "$(cat "$github_output")" 'excluded_count=0' || return 1
+  assert_contains "$(cat "$github_output")" 'pull_count=1' || return 1
+  assert_contains "$(cat "$summary")" 'Range: `repository-root..HEAD`' || return 1
+  assert_contains "$(cat "$summary")" 'Commits without an associated merged PR: 0' || return 1
+  [ ! -e "$repo_dir/CHANGELOG/CHANGELOG-0.2.md" ] || fail 'dry-run wrote CHANGELOG' || return 1
+  [ -n "$sha" ] || fail 'test commit was not created' || return 1
+
+  write_stdout="$case_dir/write-stdout"
+  if ! (
+    cd "$repo_dir" || exit 1
+    PATH="$bin_dir:$PATH" \
+      GH_TOKEN='secret-test-token' \
+      MOCK_ASSOCIATED="$associated" \
+      MOCK_PULL="$pull" \
+      /bin/bash "$SCRIPT_DIR/changelog.sh" \
+        --version v0.2.0 \
+        --repo matrixhub-ai/matrixhub \
+        --end-ref HEAD \
+        --base-branch main
+  ) > "$write_stdout" 2> "$stderr"; then
+    cat "$stderr" >&2
+    fail 'full CLI write failed'
+    return 1
+  fi
+  assert_contains "$(cat "$write_stdout")" 'Updated CHANGELOG/CHANGELOG-0.2.md' || return 1
+  assert_contains "$(cat "$repo_dir/CHANGELOG/CHANGELOG-0.2.md")" 'Added from the CLI.' || return 1
+  before=$(cksum < "$repo_dir/CHANGELOG/CHANGELOG-0.2.md")
+
+  pull_json 42 $'```release-note\nMissing Kind.\n```' '["release-note"]' cli-author > "$pull" || return 1
+  hostile_tmp="$case_dir/tmp'; touch trap-ran; #"
+  sentinel="$repo_dir/trap-ran"
+  invalid_stderr="$case_dir/invalid-stderr"
+  mkdir -p "$hostile_tmp"
+  if (
+    cd "$repo_dir" || exit 1
+    PATH="$bin_dir:$PATH" \
+      GH_TOKEN='secret-test-token' \
+      TMPDIR="$hostile_tmp" \
+      MOCK_ASSOCIATED="$associated" \
+      MOCK_PULL="$pull" \
+      /bin/bash "$SCRIPT_DIR/changelog.sh" \
+        --version v0.2.0 \
+        --repo matrixhub-ai/matrixhub \
+        --end-ref HEAD \
+        --base-branch main
+  ) > /dev/null 2> "$invalid_stderr"; then
+    fail 'invalid PR metadata should fail the full CLI'
+    return 1
+  fi
+  assert_contains "$(cat "$invalid_stderr")" '#42 has no kind/* label' || return 1
+  assert_equal "$before" "$(cksum < "$repo_dir/CHANGELOG/CHANGELOG-0.2.md")" || return 1
+  [ ! -e "$sentinel" ] || fail 'cleanup trap executed TMPDIR content' || return 1
+  set -- "$hostile_tmp"/matrixhub-changelog.*
+  [ ! -e "$1" ] || fail 'failed CLI left its work directory behind'
+}
+
+run_test() {
+  local name=$1
+  shift
+  if "$@"; then
+    PASSED=$((PASSED + 1))
+    printf 'ok %d - %s\n' "$PASSED" "$name"
+  else
+    FAILED=$((FAILED + 1))
+    printf 'not ok - %s\n' "$name"
+  fi
+}
+
+run_test 'release-note parsing' test_release_note_parsing
+run_test 'version and Kind rules' test_version_and_kind_rules
+run_test 'previous official tag' test_previous_official_tag
+run_test 'PR validation and rendering' test_pull_validation_and_rendering
+run_test 'invalid metadata errors' test_invalid_metadata_is_reported
+run_test 'release-note content is data' test_release_note_is_not_executed
+run_test 'PR discovery filters and deduplicates' test_pull_discovery_filters_and_deduplicates
+run_test 'commit-message PR discovery' test_commit_message_pull_discovery
+run_test 'commit-message PR lookup errors' test_commit_message_pr_lookup_errors
+run_test 'release workflow snapshot lease' test_prepare_workflow_uses_snapshot_lease
+run_test 'CHANGELOG creation and prepend' test_changelog_create_and_prepend
+run_test 'CHANGELOG upsert and idempotence' test_changelog_upsert_is_safe_and_idempotent
+run_test 'unmarked section refusal' test_changelog_refuses_unmarked_section
+run_test 'non-regular target refusal' test_changelog_rejects_non_regular_target
+run_test 'full CLI contract' test_full_cli_contract
+
+printf '1..%d\n' "$((PASSED + FAILED))"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

Introduce Kubernetes-style release-note automation:

- PR authors provide /kind and release-note text or NONE in the PR body.
- The CI bot reconciles metadata labels and blocks merges when Kind or release-note metadata is missing.
- A Git-history collector validates merged PR metadata and generates categorized CHANGELOG sections with PR and author links.
- A manually triggered workflow creates or updates a draft release-notes PR while preserving hand-written sections.
- Contributor and release-process documentation describes the workflow.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

The ci-bot/merge-blockers status is emitted by the updated workflow. Configure it as a required ruleset check only after this PR is merged and the status has appeared successfully.

Historical PRs predating this policy may need metadata backfilled before generating their first CHANGELOG.

#### Checklist

- [x] Tests(ut, e2e) added or updated, or not needed and explained
- [x] Docs(tech docs, usage docs) updated, or not needed and explained

#### Does this PR introduce a user-facing, API-facing, or operator-facing change?

```release-note
NONE
```
