### PR TITLE
test: add scheduled UI automation workflow

### DIFF
--- a/.github/workflows/ui-automation-ci.yaml
+++ b/.github/workflows/ui-automation-ci.yaml
@@ -1,0 +1,56 @@
+name: UI Automation CI
+
+on:
+  # GitHub Actions cron uses UTC. This runs Sundays at 16:00 Asia/Shanghai.
+  schedule:
+    - cron: '0 8 * * 0'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'sha, tag, or branch'
+        required: true
+        default: main
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  resolve_ref:
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.resolve.outputs.ref }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Resolve commit SHA
+        id: resolve
+        run: echo "ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  build_ci_image:
+    needs: resolve_ref
+    uses: ./.github/workflows/build-image-ci.yaml
+    with:
+      ref: ${{ needs.resolve_ref.outputs.ref }}
+      push: false
+    secrets: inherit
+
+  ui_automation_test:
+    needs: [resolve_ref, build_ci_image]
+    uses: ./.github/workflows/ui-automation-init.yaml
+    with:
+      image_tag: ${{ needs.build_ci_image.outputs.imageTag }}
+      ref: ${{ needs.resolve_ref.outputs.ref }}
+      runner_image: ${{ vars.UI_AUTOMATION_RUNNER_IMAGE }}
+      runner_registry: ${{ vars.UI_AUTOMATION_RUNNER_REGISTRY || 'ghcr.io' }}
+    secrets:
+      UI_AUTOMATION_REGISTRY_USERNAME: ${{ secrets.UI_AUTOMATION_REGISTRY_USERNAME }}
+      UI_AUTOMATION_REGISTRY_PASSWORD: ${{ secrets.UI_AUTOMATION_REGISTRY_PASSWORD }}

--- a/.github/workflows/ui-automation-init.yaml
+++ b/.github/workflows/ui-automation-init.yaml
@@ -1,0 +1,124 @@
+name: Call UI Automation
+
+env:
+  CLUSTER_NAME: matrixhub-ui-automation
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        required: true
+        type: string
+      ref:
+        required: false
+        type: string
+      runner_image:
+        description: Fixed ui-factory-ai runner image tag or digest
+        required: true
+        type: string
+      runner_registry:
+        description: Registry hosting the ui-factory-ai runner image
+        required: false
+        type: string
+        default: ghcr.io
+      k8s_version:
+        required: false
+        type: string
+        default: v1.32.3
+      artifact_profile:
+        required: false
+        type: string
+        default: failure
+    secrets:
+      UI_AUTOMATION_REGISTRY_USERNAME:
+        required: false
+      UI_AUTOMATION_REGISTRY_PASSWORD:
+        required: false
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  ui_automation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Download MatrixHub image
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: matrixhub-ci-image-${{ inputs.image_tag }}
+          path: /tmp
+
+      - name: Load MatrixHub image
+        run: docker load -i /tmp/matrixhub-ci.tar
+
+      - name: Prepare image reference
+        run: |
+          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "IMAGE_REPO_LOWER=${REPO_LOWER}" >> "$GITHUB_ENV"
+
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Golang
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install KIND and Helm
+        run: |
+          go install sigs.k8s.io/kind@v0.31.0
+          curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+          chmod 700 get_helm.sh
+          ./get_helm.sh
+          kind version
+          helm version
+
+      - name: Login to custom runner registry
+        if: ${{ inputs.runner_registry != 'ghcr.io' }}
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ inputs.runner_registry }}
+          username: ${{ secrets.UI_AUTOMATION_REGISTRY_USERNAME }}
+          password: ${{ secrets.UI_AUTOMATION_REGISTRY_PASSWORD }}
+
+      - name: Login to GitHub Container Registry
+        if: ${{ inputs.runner_registry == 'ghcr.io' }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run MatrixHub UI Automation
+        env:
+          UI_AUTOMATION_MODE: ci
+          UI_AUTOMATION_CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
+          UI_AUTOMATION_KIND_IMAGE_TAG: ${{ inputs.k8s_version }}
+          UI_AUTOMATION_MATRIXHUB_IMAGE: ghcr.io/${{ env.IMAGE_REPO_LOWER }}/matrixhub-ci:${{ inputs.image_tag }}
+          UI_AUTOMATION_RUNNER_IMAGE: ${{ inputs.runner_image }}
+          UI_AUTOMATION_RUNNER_NETWORK: host
+          UI_AUTOMATION_BASE_URL: http://127.0.0.1:30101/
+          UI_AUTOMATION_USERNAME: admin
+          UI_AUTOMATION_PASSWORD: changeme
+          UI_AUTOMATION_ARTIFACT_PROFILE: ${{ inputs.artifact_profile }}
+          UI_AUTOMATION_REPORT_DIR: test/ui-automation/reports
+          UI_AUTOMATION_RUN_ID: gh-${{ github.run_id }}-${{ github.run_attempt }}
+        run: make test.ui-automation.kind
+
+      - name: Upload UI Automation reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: ui-automation-report-${{ inputs.image_tag }}
+          path: test/ui-automation/reports
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Cleanup KIND cluster
+        if: ${{ always() }}
+        run: kind delete cluster --name="${CLUSTER_NAME}" || true

--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,14 @@ test.e2e.kind: ## Run E2E tests in KIND cluster (setup, deploy, test)
 	@echo "  kind delete cluster --name=$${E2E_CLUSTER_NAME:-matrixhub-e2e}"
 	@echo ""
 
+.PHONY: test.ui-automation
+test.ui-automation: ## Run UI automation locally (requires a running MatrixHub UI)
+	./scripts/run-ui-automation.sh
+
+.PHONY: test.ui-automation.kind
+test.ui-automation.kind: ## Run UI automation in a dedicated KIND cluster (setup, deploy, test)
+	./scripts/setup-ui-automation.sh
+
 .PHONY: chart.build
 chart.build: ## Build Helm chart package
 	helm package ./deploy/charts/matrixhub -d ./deploy/charts

--- a/docs/development.md
+++ b/docs/development.md
@@ -357,6 +357,32 @@ path therefore reaches the service via the non-loopback hostname
 `matrixhub.local` (mapped to the NodePort host); a loopback `MATRIXHUB_BASE_URL`
 records nothing and the runner warns when that happens.
 
+## UI Automation
+
+UI automation has its own workflow and does not run as part of the E2E target.
+To test an already-running local UI (port `3000` by default), run:
+
+```bash
+make test.ui-automation
+```
+
+Override `UI_AUTOMATION_BASE_URL` when the UI uses another address. Local mode
+requires a sibling `ui-factory-ai` checkout with dependencies installed and an
+active run. Set `UI_AUTOMATION_FRAMEWORK_DIR` when that checkout is not in one
+of the automatically discovered locations.
+
+To create a dedicated `matrixhub-ui-automation` cluster, deploy MatrixHub, run
+the generated UI automation assets, and delete the cluster on exit, run:
+
+```bash
+make test.ui-automation.kind
+```
+
+Set `UI_AUTOMATION_KEEP_CLUSTER=true` to retain that cluster for debugging.
+
+CI uses the KIND target with `UI_AUTOMATION_MODE=ci` and a fixed
+`UI_AUTOMATION_RUNNER_IMAGE` tag or digest.
+
 ## Development Tips
 
 ### Database

--- a/scripts/run-ui-automation.sh
+++ b/scripts/run-ui-automation.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+
+# Copyright 2026 The MatrixHub Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+fail() { echo "Error: $*" >&2; return 1; }
+is_true() { case "$1" in 1|true|TRUE|True|yes|YES|Yes) return 0 ;; *) return 1 ;; esac; }
+require_command() { command -v "$1" >/dev/null 2>&1 || fail "required command is not installed: $1"; }
+project_path() { case "$1" in /*) printf '%s\n' "$1" ;; *) printf '%s/%s\n' "${PROJECT_ROOT}" "$1" ;; esac; }
+
+normalize_url() {
+    case "$1" in http://*|https://*) ;; *) fail "UI_AUTOMATION_BASE_URL must start with http:// or https://"; return ;; esac
+    if [[ "$1" =~ [[:space:]#] ]]; then
+        fail "UI_AUTOMATION_BASE_URL must not contain whitespace or #"
+        return
+    fi
+    case "$1" in */) printf '%s\n' "$1" ;; *) printf '%s/\n' "$1" ;; esac
+}
+
+discover_framework() {
+    local path=""
+    if [ -n "${UI_AUTOMATION_FRAMEWORK_DIR:-}" ]; then
+        path="${UI_AUTOMATION_FRAMEWORK_DIR}"
+        case "${path}" in /*) ;; *) path="${PROJECT_ROOT}/${path}" ;; esac
+        [ -f "${path}/package.json" ] && [ -f "${path}/src/ai-run.ts" ] || {
+            fail "UI_AUTOMATION_FRAMEWORK_DIR is not a ui-factory-ai checkout: ${path}"
+            return
+        }
+        (cd "${path}" && pwd)
+        return
+    fi
+    for path in "${PROJECT_ROOT}/../ui-factory-ai" \
+        "${PROJECT_ROOT}/../../ai-factory-ai/ui-factory-ai" \
+        "${PROJECT_ROOT}/../../ui-factory-ai"; do
+        if [ -f "${path}/package.json" ] && [ -f "${path}/src/ai-run.ts" ]; then
+            (cd "${path}" && pwd)
+            return
+        fi
+    done
+    fail "cannot find ui-factory-ai; set UI_AUTOMATION_FRAMEWORK_DIR"
+}
+
+read_run_id() {
+    local run_id="${UI_AUTOMATION_RUN_ID:-}"
+    if [ -z "${run_id}" ] && [ -f "${RUN_STATE_FILE}" ]; then
+        run_id=$(awk '$1 == "runId:" { print $2; exit }' "${RUN_STATE_FILE}")
+    fi
+    [ -n "${run_id}" ] || { fail "set UI_AUTOMATION_RUN_ID or create an active ui-factory-ai task first"; return; }
+    [[ "${run_id}" =~ ^[A-Za-z0-9._:-]+$ ]] || { fail "invalid UI automation run ID: ${run_id}"; return; }
+    printf '%s\n' "${run_id}"
+}
+
+update_base_url() {
+    local file=$1 temporary mode
+    temporary=$(mktemp "${file}.tmp.XXXXXX")
+    if ! awk -v url="${UI_AUTOMATION_BASE_URL}" '
+        BEGIN { local_block = 0; updated = 0 }
+        /^local:[[:space:]]*(#.*)?$/ { local_block = 1; print; next }
+        local_block && /^[^[:space:]#]/ { local_block = 0 }
+        local_block && /^[[:space:]]+baseUrl:[[:space:]]*/ {
+            match($0, /^[[:space:]]*/); indent = substr($0, 1, RLENGTH); comment = ""
+            if (match($0, /[[:space:]]+#/)) comment = substr($0, RSTART)
+            print indent "baseUrl: " url comment; updated++; next
+        }
+        { print }
+        END { if (updated != 1) exit 42 }
+    ' "${file}" > "${temporary}"; then
+        rm -f "${temporary}"
+        fail "expected exactly one local.baseUrl entry in ${file}"
+        return
+    fi
+    mode=$(stat -f '%Lp' "${file}" 2>/dev/null || stat -c '%a' "${file}")
+    chmod "${mode}" "${temporary}"
+    mv "${temporary}" "${file}"
+}
+
+wait_for_ui() {
+    local elapsed=0 interval=5
+    echo "Waiting for MatrixHub UI at ${UI_AUTOMATION_HEALTH_URL}..."
+    while [ "${elapsed}" -lt "${UI_AUTOMATION_UI_TIMEOUT}" ]; do
+        if curl --fail --silent --show-error --location --max-time 5 --output /dev/null "${UI_AUTOMATION_HEALTH_URL}"; then
+            echo "MatrixHub UI is reachable."
+            return
+        fi
+        sleep "${interval}"
+        elapsed=$((elapsed + interval))
+    done
+    fail "timed out waiting for MatrixHub UI at ${UI_AUTOMATION_HEALTH_URL}"
+}
+
+configure() {
+    UI_AUTOMATION_MODE="${UI_AUTOMATION_MODE:-local}"
+    UI_AUTOMATION_HTTP_PORT="${UI_AUTOMATION_HTTP_PORT:-3000}"
+    UI_AUTOMATION_BASE_URL=$(normalize_url "${UI_AUTOMATION_BASE_URL:-http://127.0.0.1:${UI_AUTOMATION_HTTP_PORT}/}")
+    UI_AUTOMATION_HEALTH_URL="${UI_AUTOMATION_HEALTH_URL:-${UI_AUTOMATION_BASE_URL}}"
+    UI_AUTOMATION_UI_TIMEOUT="${UI_AUTOMATION_UI_TIMEOUT:-60}"
+    UI_AUTOMATION_VERIFY_RUNNER_ACCESS="${UI_AUTOMATION_VERIFY_RUNNER_ACCESS:-false}"
+    UI_AUTOMATION_RUNNER_NETWORK="${UI_AUTOMATION_RUNNER_NETWORK:-host}"
+    AUTOMATION_ROOT=$(project_path "${UI_AUTOMATION_ROOT:-test/ui-automation}")
+    MANIFEST_FILE=$(project_path "${UI_AUTOMATION_MANIFEST_FILE:-test/ui-automation/config/manifest.yaml}")
+    ENVIRONMENT_FILE=$(project_path "${UI_AUTOMATION_ENV_FILE:-test/ui-automation/ai/environment.yaml}")
+    RUN_STATE_FILE=$(project_path "${UI_AUTOMATION_RUN_STATE_FILE:-test/ui-automation/.ui-factory/runs/default/active-run.yaml}")
+    REPORT_DIR="${UI_AUTOMATION_REPORT_DIR:-}"
+    [ -z "${REPORT_DIR}" ] || REPORT_DIR=$(project_path "${REPORT_DIR}")
+    if [ "${UI_AUTOMATION_MODE}" = ci ] && [ -z "${REPORT_DIR}" ]; then
+        REPORT_DIR="${AUTOMATION_ROOT}/reports"
+    fi
+}
+
+validate() {
+    local command_name image_tag
+    case "${UI_AUTOMATION_MODE}" in local|ci) ;; *) fail "UI_AUTOMATION_MODE must be local or ci (got: ${UI_AUTOMATION_MODE})"; return ;; esac
+    for command_name in awk curl mktemp stat; do require_command "${command_name}"; done
+    [ -d "${AUTOMATION_ROOT}" ] || fail "UI automation root not found: ${AUTOMATION_ROOT}"
+    [ -f "${MANIFEST_FILE}" ] || fail "UI automation manifest not found: ${MANIFEST_FILE}"
+
+    if [ "${UI_AUTOMATION_MODE}" = local ]; then
+        require_command npm
+        [ -f "${ENVIRONMENT_FILE}" ] || fail "UI automation environment file not found: ${ENVIRONMENT_FILE}"
+        FRAMEWORK_DIR=$(discover_framework)
+        [ -d "${FRAMEWORK_DIR}/node_modules" ] || fail "run npm ci in ${FRAMEWORK_DIR} first"
+        RUN_ID=$(read_run_id)
+    else
+        require_command docker
+        require_command id
+        [ -n "${UI_AUTOMATION_RUNNER_IMAGE:-}" ] || fail "UI_AUTOMATION_RUNNER_IMAGE is required in CI mode"
+        if [[ "${UI_AUTOMATION_RUNNER_IMAGE}" != *@sha256:* ]]; then
+            image_tag="${UI_AUTOMATION_RUNNER_IMAGE##*/}"
+            [[ "${image_tag}" == *:* && "${image_tag}" != *:latest ]] || fail "UI_AUTOMATION_RUNNER_IMAGE must use a fixed tag or digest"
+        fi
+    fi
+    is_true "${UI_AUTOMATION_VERIFY_RUNNER_ACCESS}" && require_command docker
+    return 0
+}
+
+run_local() {
+    local args=(run ai:run -- "${UI_AUTOMATION_SELECTION:-matrixhub}" --run-id "${RUN_ID}")
+    [ -z "${REPORT_DIR}" ] || args+=(--report-dir "${REPORT_DIR}")
+    (cd "${FRAMEWORK_DIR}" && UI_TARGET_PROJECT_DIR="${PROJECT_ROOT}" npm "${args[@]}")
+}
+
+run_ci() {
+    local args=(
+        run --rm --pull=never --network="${UI_AUTOMATION_RUNNER_NETWORK}" --shm-size=1g
+        --read-only --init --cap-drop=ALL --security-opt=no-new-privileges
+        --pids-limit=512 --tmpfs /tmp:rw,nosuid,nodev,size=1g
+        --user "$(id -u):$(id -g)" --workdir "${AUTOMATION_ROOT}"
+        --env HOME=/tmp/ui-factory-home --env CI --env BASE_URL --env USERNAME --env PASSWORD
+        --env REPORT_DIR --env ARTIFACT_PROFILE
+        --mount "type=bind,src=${AUTOMATION_ROOT},dst=${AUTOMATION_ROOT},readonly"
+        --mount "type=bind,src=${REPORT_DIR},dst=${REPORT_DIR}"
+    )
+    [ -z "${UI_AUTOMATION_RUN_ID:-}" ] || args+=(--env UI_FACTORY_RUN_ID)
+    args+=("${UI_AUTOMATION_RUNNER_IMAGE}" "${MANIFEST_FILE}")
+    CI=true BASE_URL="${UI_AUTOMATION_BASE_URL}" \
+        USERNAME="${UI_AUTOMATION_USERNAME:-admin}" PASSWORD="${UI_AUTOMATION_PASSWORD:-changeme}" \
+        REPORT_DIR="${REPORT_DIR}" ARTIFACT_PROFILE="${UI_AUTOMATION_ARTIFACT_PROFILE:-failure}" \
+        UI_FACTORY_RUN_ID="${UI_AUTOMATION_RUN_ID:-}" docker "${args[@]}"
+}
+
+main() {
+    cd "${PROJECT_ROOT}"
+    configure
+    validate
+    [ "${1:-}" = --validate-only ] && return
+
+    if [ "${UI_AUTOMATION_MODE}" = ci ]; then
+        mkdir -p "${REPORT_DIR}"
+        docker pull "${UI_AUTOMATION_RUNNER_IMAGE}"
+        docker image inspect "${UI_AUTOMATION_RUNNER_IMAGE}" >/dev/null
+    fi
+
+    echo "UI Automation: mode=${UI_AUTOMATION_MODE}, url=${UI_AUTOMATION_BASE_URL}"
+    wait_for_ui
+    if is_true "${UI_AUTOMATION_VERIFY_RUNNER_ACCESS}"; then
+        docker run --rm --network="${UI_AUTOMATION_RUNNER_NETWORK}" busybox:latest \
+            wget -q -T 10 -O /dev/null "${UI_AUTOMATION_BASE_URL%/}/healthz"
+    fi
+    [ "${UI_AUTOMATION_MODE}" != local ] || update_base_url "${ENVIRONMENT_FILE}"
+
+    local exit_code=0
+    if [ "${UI_AUTOMATION_MODE}" = local ]; then
+        run_local || exit_code=$?
+    else
+        run_ci || exit_code=$?
+    fi
+    if [ "${exit_code}" -ne 0 ]; then
+        echo "UI Automation failed with exit code ${exit_code}." >&2
+        return "${exit_code}"
+    fi
+    return "${exit_code}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/scripts/setup-kind-cluster.sh
+++ b/scripts/setup-kind-cluster.sh
@@ -28,12 +28,41 @@ echo "Working directory: $(pwd)"
 # Environment variables with defaults
 E2E_CLUSTER_NAME=${E2E_CLUSTER_NAME:-"matrixhub-e2e"}
 E2E_KIND_IMAGE_TAG=${E2E_KIND_IMAGE_TAG:-"v1.32.3"}
+E2E_HTTP_HOST_PORT=${E2E_HTTP_HOST_PORT:-"30001"}
+E2E_SSH_HOST_PORT=${E2E_SSH_HOST_PORT:-"30022"}
+E2E_KIND_HTTP_LISTEN_ADDRESS=${E2E_KIND_HTTP_LISTEN_ADDRESS:-"127.0.0.1"}
+E2E_KIND_SSH_LISTEN_ADDRESS=${E2E_KIND_SSH_LISTEN_ADDRESS:-"127.0.0.1"}
+
+validate_port() {
+    local name=$1
+    local value=$2
+    if ! [[ "${value}" =~ ^[0-9]+$ ]] || [ "${value}" -lt 1 ] || [ "${value}" -gt 65535 ]; then
+        echo "Error: ${name} must be an integer between 1 and 65535 (got: ${value})"
+        exit 1
+    fi
+}
+
+validate_listen_address() {
+    local name=$1
+    local value=$2
+    if ! [[ "${value}" =~ ^[0-9A-Fa-f:.]+$ ]]; then
+        echo "Error: ${name} must be an IPv4 or IPv6 address (got: ${value})"
+        exit 1
+    fi
+}
+
+validate_port "E2E_HTTP_HOST_PORT" "${E2E_HTTP_HOST_PORT}"
+validate_port "E2E_SSH_HOST_PORT" "${E2E_SSH_HOST_PORT}"
+validate_listen_address "E2E_KIND_HTTP_LISTEN_ADDRESS" "${E2E_KIND_HTTP_LISTEN_ADDRESS}"
+validate_listen_address "E2E_KIND_SSH_LISTEN_ADDRESS" "${E2E_KIND_SSH_LISTEN_ADDRESS}"
 
 echo "================================================"
 echo "MatrixHub Kind Cluster Setup"
 echo "================================================"
 echo "Cluster Name: ${E2E_CLUSTER_NAME}"
 echo "K8s Version:   ${E2E_KIND_IMAGE_TAG}"
+echo "HTTP Mapping:  ${E2E_KIND_HTTP_LISTEN_ADDRESS}:${E2E_HTTP_HOST_PORT} -> 30001"
+echo "SSH Mapping:   ${E2E_KIND_SSH_LISTEN_ADDRESS}:${E2E_SSH_HOST_PORT} -> 30022"
 echo "================================================"
 
 # Check if kind is installed
@@ -73,12 +102,12 @@ nodes:
 - role: control-plane
   extraPortMappings:
   - containerPort: 30001
-    hostPort: 30001
-    listenAddress: "127.0.0.1"
+    hostPort: ${E2E_HTTP_HOST_PORT}
+    listenAddress: "${E2E_KIND_HTTP_LISTEN_ADDRESS}"
     protocol: TCP
   - containerPort: 30022
-    hostPort: 30022
-    listenAddress: "127.0.0.1"
+    hostPort: ${E2E_SSH_HOST_PORT}
+    listenAddress: "${E2E_KIND_SSH_LISTEN_ADDRESS}"
     protocol: TCP
 EOF
 kind create cluster --name="${E2E_CLUSTER_NAME}" --image=kindest/node:${E2E_KIND_IMAGE_TAG} --config=/tmp/kind-config.yaml --wait=120s

--- a/scripts/setup-ui-automation.sh
+++ b/scripts/setup-ui-automation.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# Copyright 2026 The MatrixHub Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+fail() { echo "Error: $*" >&2; exit 1; }
+is_true() { case "$1" in 1|true|TRUE|True|yes|YES|Yes) return 0 ;; *) return 1 ;; esac; }
+require_command() { command -v "$1" >/dev/null 2>&1 || fail "required command is not installed: $1"; }
+
+discover_host() {
+    local address="" interface=""
+    [ -z "${UI_AUTOMATION_HOST:-}" ] || { printf '%s\n' "${UI_AUTOMATION_HOST}"; return; }
+    case "$(uname -s)" in
+        Darwin)
+            interface=$(route -n get default 2>/dev/null | awk '/interface:/{print $2; exit}' || true)
+            [ -z "${interface}" ] || address=$(ipconfig getifaddr "${interface}" 2>/dev/null || true)
+            ;;
+        Linux)
+            if command -v ip >/dev/null 2>&1; then
+                address=$(ip route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++)if($i=="src"){print $(i+1);exit}}' || true)
+            else
+                address=$(hostname -I 2>/dev/null | awk '{print $1}' || true)
+            fi
+            ;;
+    esac
+    printf '%s\n' "${address:-host.docker.internal}"
+}
+
+validate_port() {
+    [[ "$2" =~ ^[0-9]+$ ]] && [ "$2" -ge 1 ] && [ "$2" -le 65535 ] || fail "$1 must be an integer between 1 and 65535"
+}
+
+cleanup() {
+    local exit_code=$?
+    trap - EXIT INT TERM
+    if is_true "${UI_AUTOMATION_KEEP_CLUSTER}"; then
+        echo "Keeping KIND cluster for debugging: ${UI_AUTOMATION_CLUSTER_NAME}"
+    elif ! kind delete cluster --name="${UI_AUTOMATION_CLUSTER_NAME}"; then
+        echo "Error: failed to delete KIND cluster ${UI_AUTOMATION_CLUSTER_NAME}" >&2
+        [ "${exit_code}" -ne 0 ] || exit_code=1
+    fi
+    exit "${exit_code}"
+}
+
+main() {
+    local command_name host_address
+    cd "${PROJECT_ROOT}"
+
+    export UI_AUTOMATION_MODE="${UI_AUTOMATION_MODE:-local}"
+    export UI_AUTOMATION_CLUSTER_NAME="${UI_AUTOMATION_CLUSTER_NAME:-matrixhub-ui-automation}"
+    export UI_AUTOMATION_KIND_IMAGE_TAG="${UI_AUTOMATION_KIND_IMAGE_TAG:-v1.32.3}"
+    export UI_AUTOMATION_MATRIXHUB_IMAGE="${UI_AUTOMATION_MATRIXHUB_IMAGE:-${E2E_MATRIXHUB_IMAGE:-ghcr.io/matrixhub-ai/matrixhub:latest}}"
+    export UI_AUTOMATION_HTTP_PORT="${UI_AUTOMATION_HTTP_PORT:-30101}"
+    export UI_AUTOMATION_SSH_PORT="${UI_AUTOMATION_SSH_PORT:-30122}"
+    export UI_AUTOMATION_LISTEN_ADDRESS="${UI_AUTOMATION_LISTEN_ADDRESS:-0.0.0.0}"
+    export UI_AUTOMATION_BUILD_IMAGE="${UI_AUTOMATION_BUILD_IMAGE:-false}"
+    export UI_AUTOMATION_KEEP_CLUSTER="${UI_AUTOMATION_KEEP_CLUSTER:-false}"
+    export UI_AUTOMATION_VERIFY_RUNNER_ACCESS="${UI_AUTOMATION_VERIFY_RUNNER_ACCESS:-true}"
+
+    host_address=$(discover_host)
+    export UI_AUTOMATION_BASE_URL="${UI_AUTOMATION_BASE_URL:-http://${host_address}:${UI_AUTOMATION_HTTP_PORT}/}"
+    export UI_AUTOMATION_HEALTH_URL="${UI_AUTOMATION_HEALTH_URL:-http://127.0.0.1:${UI_AUTOMATION_HTTP_PORT}/}"
+
+    validate_port UI_AUTOMATION_HTTP_PORT "${UI_AUTOMATION_HTTP_PORT}"
+    validate_port UI_AUTOMATION_SSH_PORT "${UI_AUTOMATION_SSH_PORT}"
+    [[ "${UI_AUTOMATION_LISTEN_ADDRESS}" =~ ^[0-9A-Fa-f:.]+$ ]] || fail "invalid UI_AUTOMATION_LISTEN_ADDRESS"
+    for command_name in docker helm kind kubectl; do require_command "${command_name}"; done
+    is_true "${UI_AUTOMATION_BUILD_IMAGE}" && require_command make
+    "${SCRIPT_DIR}/run-ui-automation.sh" --validate-only
+
+    if is_true "${UI_AUTOMATION_BUILD_IMAGE}"; then
+        export UI_AUTOMATION_MATRIXHUB_IMAGE="ghcr.io/matrixhub-ai/matrixhub:${UI_AUTOMATION_IMAGE_TAG:-ui-automation-local}"
+        make image-build VERSION="${UI_AUTOMATION_IMAGE_TAG:-ui-automation-local}"
+    fi
+
+    echo "UI Automation KIND: cluster=${UI_AUTOMATION_CLUSTER_NAME}, image=${UI_AUTOMATION_MATRIXHUB_IMAGE}"
+    trap cleanup EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+
+    E2E_CLUSTER_NAME="${UI_AUTOMATION_CLUSTER_NAME}" \
+    E2E_KIND_IMAGE_TAG="${UI_AUTOMATION_KIND_IMAGE_TAG}" \
+    E2E_HTTP_HOST_PORT="${UI_AUTOMATION_HTTP_PORT}" \
+    E2E_SSH_HOST_PORT="${UI_AUTOMATION_SSH_PORT}" \
+    E2E_KIND_HTTP_LISTEN_ADDRESS="${UI_AUTOMATION_LISTEN_ADDRESS}" \
+    E2E_KIND_SSH_LISTEN_ADDRESS=127.0.0.1 "${SCRIPT_DIR}/setup-kind-cluster.sh"
+
+    E2E_CLUSTER_NAME="${UI_AUTOMATION_CLUSTER_NAME}" \
+    E2E_MATRIXHUB_IMAGE="${UI_AUTOMATION_MATRIXHUB_IMAGE}" \
+    E2E_MATRIXHUB_HOST_URL="${UI_AUTOMATION_BASE_URL%/}" "${SCRIPT_DIR}/deploy-matrixhub.sh"
+
+    "${SCRIPT_DIR}/run-ui-automation.sh"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/test/ui-automation/ai/case-state.yaml
+++ b/test/ui-automation/ai/case-state.yaml
@@ -1,0 +1,23 @@
+version: 2
+lastSuccessful:
+  sourceCommit: 6bfcacc45f3ee9014e22dcf341df59eedf43bead
+  runId: matrixhub-default-20260831094440859-c690bef0
+  verifiedAt: '2026-08-31T09:46:54.045Z'
+  report: test/ui-automation/reports/matrixhub-default-20260831094440859-c690bef0-attempt1/summary.json
+outputs:
+  manifest:
+    path: test/ui-automation/config/manifest.yaml
+    hash: sha256:de5f5bf3f590baf578810b6b4d9e8c3502b17ad60bf151bccb8b00d0d8675424
+  targets:
+    - path: test/ui-automation/targets.yaml
+      hash: sha256:05a03f604708479859a6873e18fe2a5008386c37198012a635dea54580dbb8a0
+  cases:
+    login_success:
+      yaml: cases/login_success.yaml
+      yamlHash: sha256:5813bcb3cf37d5b523ea8e13d66a9c1dce390bf6868edcbb820f4248e92cff72
+    create_public_project:
+      yaml: cases/create_public_project.yaml
+      yamlHash: sha256:d2f0bd0bd443a56ab1cde4537a7dca0110a9f2195b4d8265a15b6e10544589b5
+    create_private_project:
+      yaml: cases/create_private_project.yaml
+      yamlHash: sha256:cd70b2a1663db7982cb51da375342d116404e9c53906ffdd9df64ff5cf23389a

--- a/test/ui-automation/ai/case.md
+++ b/test/ui-automation/ai/case.md
@@ -1,0 +1,14 @@
+# 这是 case.md —— 业务测试流程的源头文件，一行一个 Case，按执行顺序排列。
+# 你只需要维护这个文件（加 environment.yaml、可选 preparation.md/截图），AI 会生成其他运行资产。
+
+# 第一列是 Case ID（英文，对应 cases/<ID>.yaml），用空格与描述分隔。
+# # 开头的行（像本行）和空行会被忽略，可作为注释。
+# 用 ${VAR} 引用 environment.yaml 里的变量，不要把地址/账号/资源名写死。
+
+# 用户登录
+login_success 访问 ${BASE_URL}；确认成功进入 MatrixHub 登录页面；输入用户名 ${USERNAME}、密码 ${PASSWORD}，点击“登录”；确认用户登录成功并进入 MatrixHub 首页
+
+
+# 创建 MatrixHub 项目的 Case（公开 / 私有）
+create_public_project 在当前已登录会话中选择“项目管理”菜单并进入项目管理列表页面；点击“创建项目”，项目名称输入 ${PUBLIC_PROJECT_NAME}，勾选项目类型选项，点击“确定”；确认公开项目 ${PUBLIC_PROJECT_NAME} 创建成功、列表中出现该项目，且项目类型及信息显示正确
+create_private_project 在当前已登录会话中选择“项目管理”菜单并进入项目管理列表页面；点击“创建项目”，项目名称输入 ${PRIVATE_PROJECT_NAME}，不勾选项目类型选项，点击“确定”；确认私有项目 ${PRIVATE_PROJECT_NAME} 创建成功、列表中出现该项目，且项目类型及信息显示正确

--- a/test/ui-automation/ai/environment.yaml
+++ b/test/ui-automation/ai/environment.yaml
@@ -1,0 +1,38 @@
+# 这是 environment.yaml —— AI 调试和生成 YAML 用的环境合同。
+# ai:run 将 local 值注入受控容器；业务 pipeline 的实际值来自 GitLab CI/CD Variables 或运行时环境变量。
+
+# shared: AI 调试和 pipeline 共用的稳定测试数据，默认值两边必须一致。
+# 这里的变量会被 case.md 的 ${VAR} 引用。
+shared:
+  variables:
+    PUBLIC_PROJECT_NAME: test-project1-public   # 公开项目可见性 Case 使用
+    PRIVATE_PROJECT_NAME: test-project1-private # 私有项目可见性 Case 使用
+
+# local: 只给 AI 调试用，由 ai:run 注入 runner 容器。填你当前调试环境的真实值。
+local:
+  baseUrl: http://127.0.0.1:30101/   # AI 调试时访问的测试环境地址
+  username: admin                     # AI 调试账号
+  password: changeme                  # AI 调试密码（不要提交真实生产密码）
+
+# authorization: 声明本环境允许的操作范围。框架在 manifest 加载时强制校验:
+# Case ID 前缀 create_/update_/edit_/delete_/remove_ 映射到对应权限,false 时拒绝加载。
+authorization:
+  allowCreate: true
+  allowUpdate: true
+  allowDelete: true
+
+# execution: 控制 AI 生成和校验行为。
+execution:
+  environment: matrixhub            # 环境名，对应 config/env.<env>.yaml
+  runner:
+    type: docker
+    image: registry.example.com/ui-playwright:20260806 # 必须使用项目固定的 Playwright runner tag/digest，不能用 latest
+  # 后续若调试环境只有底座，创建同目录 preparation.md 后再取消以下注释：
+  # preparation:
+  #   document: preparation.md          # 文件名固定；未声明时即使文件存在也绝不执行
+  casesDirectory: cases               # AI 生成 YAML 的目录（相对本项目根）
+  manifest: config/manifest.yaml      # 主 manifest 路径
+  caseDocumentUpdate: safe            # safe=AI 可回写 case.md 补充稳定事实；suggest=只建议；off=不回写
+  orphanPolicy: error                 # error=有孤儿 YAML 时阻断校验；report=仅警告
+  execJsAllowed: false                # 是否允许 case 使用 exec_js（逃生通道，默认关闭）
+  shellExecAllowed: false             # 是否允许 case 使用 shell_exec（逃生通道，默认关闭）

--- a/test/ui-automation/ai/screenshots/.gitkeep
+++ b/test/ui-automation/ai/screenshots/.gitkeep
@@ -1,0 +1,2 @@
+# 参考截图放这里，命名 <CaseID>.png 或 <CaseID>-<动作>.png
+# 详见 docs/screenshots-guide.md

--- a/test/ui-automation/cases/create_private_project.yaml
+++ b/test/ui-automation/cases/create_private_project.yaml
@@ -1,0 +1,42 @@
+id: create_private_project
+name: 创建私有项目
+tags: [projects]
+env: matrixhub
+steps:
+  - name: 打开已登录首页
+    action: goto
+    url: /
+  - name: 进入项目管理
+    action: click
+    target: navigation.project_management
+  - name: 清空项目搜索条件
+    action: clear
+    target: projects.search_input
+  - name: 打开创建项目弹窗
+    action: click
+    target: projects.create_button
+  - name: 输入项目名称
+    action: fill
+    target: projects.name_input
+    value: "${PRIVATE_PROJECT_NAME}"
+  - name: 保持私有项目类型
+    action: uncheck
+    target: projects.public_checkbox
+  - name: 确认创建
+    action: click
+    target: projects.confirm_button
+  - name: 搜索新建项目
+    action: fill
+    target: projects.search_input
+    value: "${PRIVATE_PROJECT_NAME}"
+  - name: 确认项目出现在列表
+    action: expect_visible
+    target: projects.private_row
+    timeout: 30000
+  - name: 确认项目名称
+    action: expect_text
+    target: projects.private_row
+    text: "${PRIVATE_PROJECT_NAME}"
+  - name: 确认项目类型为私有
+    action: expect_visible
+    target: projects.private_type

--- a/test/ui-automation/cases/create_public_project.yaml
+++ b/test/ui-automation/cases/create_public_project.yaml
@@ -1,0 +1,42 @@
+id: create_public_project
+name: 创建公开项目
+tags: [projects]
+env: matrixhub
+steps:
+  - name: 打开已登录首页
+    action: goto
+    url: /
+  - name: 进入项目管理
+    action: click
+    target: navigation.project_management
+  - name: 清空项目搜索条件
+    action: clear
+    target: projects.search_input
+  - name: 打开创建项目弹窗
+    action: click
+    target: projects.create_button
+  - name: 输入项目名称
+    action: fill
+    target: projects.name_input
+    value: "${PUBLIC_PROJECT_NAME}"
+  - name: 选择公开项目类型
+    action: check
+    target: projects.public_checkbox
+  - name: 确认创建
+    action: click
+    target: projects.confirm_button
+  - name: 搜索新建项目
+    action: fill
+    target: projects.search_input
+    value: "${PUBLIC_PROJECT_NAME}"
+  - name: 确认项目出现在列表
+    action: expect_visible
+    target: projects.public_row
+    timeout: 30000
+  - name: 确认项目名称
+    action: expect_text
+    target: projects.public_row
+    text: "${PUBLIC_PROJECT_NAME}"
+  - name: 确认项目类型为公开
+    action: expect_visible
+    target: projects.public_type

--- a/test/ui-automation/cases/login_success.yaml
+++ b/test/ui-automation/cases/login_success.yaml
@@ -1,0 +1,30 @@
+id: login_success
+name: 登录成功
+tags: [smoke, login]
+env: matrixhub
+steps:
+  - name: 访问 MatrixHub
+    action: goto
+    url: /
+  - name: 确认进入登录页
+    action: expect_visible
+    target: login.username
+  - name: 输入用户名
+    action: fill
+    target: login.username
+    value: "${USERNAME}"
+  - name: 输入密码
+    action: fill
+    target: login.password
+    value: "${PASSWORD}"
+  - name: 登录
+    action: click
+    target: login.submit
+  - name: 等待进入首页
+    action: wait_for_url
+    url: /models
+    timeout: 30000
+  - name: 确认登录成功
+    action: expect_visible
+    target: navigation.project_management
+    timeout: 30000

--- a/test/ui-automation/config/env.matrixhub.yaml
+++ b/test/ui-automation/config/env.matrixhub.yaml
@@ -1,0 +1,9 @@
+# MatrixHub UI 自动化运行时变量合同。
+# 环境地址和账号由同名环境变量或 UI_VAR_* 注入，避免敏感信息进入生成物。
+baseUrl: ""
+
+variables:
+  USERNAME: ""
+  PASSWORD: ""
+  PUBLIC_PROJECT_NAME: test-project1-public
+  PRIVATE_PROJECT_NAME: test-project1-private

--- a/test/ui-automation/config/manifest.yaml
+++ b/test/ui-automation/config/manifest.yaml
@@ -1,0 +1,8 @@
+root: ..
+targets:
+  - targets.yaml
+
+cases:
+  - cases/login_success.yaml
+  - cases/create_public_project.yaml
+  - cases/create_private_project.yaml

--- a/test/ui-automation/targets.yaml
+++ b/test/ui-automation/targets.yaml
@@ -1,0 +1,16 @@
+# MatrixHub 业务页面 Target。需要兼容应用的中英文界面。
+login.username: 'input[name="username"]'
+login.password: 'input[name="password"]'
+login.submit: 'button[type="submit"]'
+
+navigation.project_management: 'a[href="/projects"]'
+
+projects.search_input: 'input[placeholder="请输入项目名称搜索"], input[placeholder="Search by project name"]'
+projects.create_button: 'role=button[name=/^(创建项目|Create Project)$/]'
+projects.name_input: 'role=dialog >> role=textbox[name=/^(项目名称|Project Name)$/]'
+projects.public_checkbox: 'role=dialog >> role=checkbox[name=/^(公开|Public)$/]'
+projects.confirm_button: 'role=dialog >> role=button[name=/^(确定|Confirm)$/]'
+projects.public_row: 'tr:has(a:text-is("${PUBLIC_PROJECT_NAME}"))'
+projects.private_row: 'tr:has(a:text-is("${PRIVATE_PROJECT_NAME}"))'
+projects.public_type: 'tr:has(a:text-is("${PUBLIC_PROJECT_NAME}")) >> text=/^(公开|Public)$/'
+projects.private_type: 'tr:has(a:text-is("${PRIVATE_PROJECT_NAME}")) >> text=/^(私有|Private)$/'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Adds MatrixHub UI automation coverage for:
  - Login
  - Creating a public project
  - Creating a private project
- Adds two independent Make targets:
  - `make test.ui-automation` for an existing MatrixHub UI
  - `make test.ui-automation.kind` for the complete KIND setup, deployment, test, and cleanup flow
- Adds reusable local and CI UI automation scripts.
- Adds a dedicated GitHub Actions workflow instead of running UI automation on every PR.
- Schedules UI automation for every Sunday at 16:00 Asia/Shanghai and retains manual dispatch support.
- Uploads UI automation reports, traces, and recorded videos as workflow artifacts.
- Makes KIND host ports and listen addresses configurable for isolated UI automation runs.
- Documents local and KIND-based UI automation commands.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

- UI automation is intentionally not included in the per-PR workflow.
- CI requires `UI_AUTOMATION_RUNNER_IMAGE` to use a fixed tag or digest.
- The complete workflow was validated locally using `make test.ui-automation.kind`.
- The disposable KIND cluster and temporary local registry were cleaned up after validation.

#### UI Automation validation

- Total: 3
- Passed: 3
- Failed: 0
- Skipped: 0
- Artifacts: individual case videos, Playwright traces, and a merged `full-flow.webm`

<details>
<summary>Individual case recordings</summary>

##### Login

https://github.com/user-attachments/assets/c5619940-1cd0-4d04-a729-342e5ac6207a

##### Create public project

https://github.com/user-attachments/assets/4492d2f0-5b26-4d74-8135-6c5c82b161bb

##### Create private project

https://github.com/user-attachments/assets/210f0909-397e-4ffe-bd2c-f9c5b716df7e

</details>

#### Checklist

- [x] Tests (UT, E2E) added or updated, or not needed and explained
- [x] Docs (tech docs, usage docs) updated, or not needed and explained
  - [Usage]: `docs/development.md`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```