### PR TITLE
chore: add maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,3 +11,5 @@
 | Chenyang Shi | [@scydas](https://github.com/scydas) | [DaoCloud](https://daocloud.io) |
 | Xinyi Sun | [@Phil-OSophy-42](https://github.com/Phil-OSophy-42) | [DaoCloud](https://daocloud.io) |
 | Hai Tang | [@CoderTH](https://github.com/CoderTH) | [xFusion](https://www.xfusion.com) |
+| Shuang Liu | [@lemontrees123](https://github.com/lemontrees123) | [DaoCloud](https://daocloud.io) |
+| Jinye Shi | [@shijinye](https://github.com/shijinye) | [DaoCloud](https://daocloud.io) |

--- a/OWNERS
+++ b/OWNERS
@@ -12,6 +12,8 @@ approvers:
   - scydas
   - Phil-OSophy-42
   - CoderTH
+  - lemontrees123
+  - shijinye
 
 # List of usernames who may use /lgtm
 reviewers:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds Shuang Liu (@lemontrees123) and Jinye Shi (@shijinye) to MAINTAINERS.md and aligns OWNERS approvers with the active maintainer list.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

Maintainer names and organization information are based on the NDX developer users.yaml mapping.

#### Checklist

- [x] Tests(ut, e2e) added or updated, or not needed and explained
- [x] Docs(tech docs, usage docs) updated, or not needed and explained

#### Does this PR introduce a user-facing, API-facing, or operator-facing change?

```release-note
NONE
```