### PR TITLE
fix(ui): use consistent red color for delete/remove actions

### DIFF
--- a/ui/src/features/admin/registries/components/DeleteRegistryAction.tsx
+++ b/ui/src/features/admin/registries/components/DeleteRegistryAction.tsx
@@ -82,7 +82,7 @@ export function DeleteRegistryAction({
       <Button
         variant="transparent"
         size="compact-sm"
-        color="blue"
+        color="red"
         disabled={disabled}
         onClick={open}
       >

--- a/ui/src/features/admin/replications/components/DeleteReplicationAction.tsx
+++ b/ui/src/features/admin/replications/components/DeleteReplicationAction.tsx
@@ -79,7 +79,7 @@ export function DeleteReplicationAction({
       <Button
         variant="transparent"
         size="compact-sm"
-        color="blue"
+        color="red"
         disabled={disabled}
         onClick={open}
       >

--- a/ui/src/features/admin/users/components/DeleteUserAction.tsx
+++ b/ui/src/features/admin/users/components/DeleteUserAction.tsx
@@ -94,7 +94,7 @@ export function DeleteUserAction({
       <Button
         variant="transparent"
         size="compact-sm"
-        color="blue"
+        color="red"
         disabled={disabled}
         onClick={open}
       >

--- a/ui/src/features/profile/components/AccessTokenTable.tsx
+++ b/ui/src/features/profile/components/AccessTokenTable.tsx
@@ -63,6 +63,7 @@ const ActionCell = ({
     <Anchor
       component="button"
       size="sm"
+      c="red"
       onClick={() => handleDeleteOpen?.(row.original)}
     >
       {t('profile.deleteToken')}

--- a/ui/src/features/profile/components/SshKeysTable.tsx
+++ b/ui/src/features/profile/components/SshKeysTable.tsx
@@ -54,6 +54,7 @@ function ActionCell({
     <Anchor
       component="button"
       size="sm"
+      c="red"
       onClick={() => onDelete?.(row.original)}
     >
       {t('profile.sshKey.delete.action')}

--- a/ui/src/features/projects/components/ProjectsTable.tsx
+++ b/ui/src/features/projects/components/ProjectsTable.tsx
@@ -104,7 +104,7 @@ function ProjectActionsCell({
     <Anchor
       component="button"
       size="sm"
-      c={disabled ? 'dimmed' : undefined}
+      c={disabled ? 'dimmed' : 'red'}
       underline={disabled ? 'never' : 'hover'}
       disabled={disabled}
       style={disabled ? { cursor: 'not-allowed' } : undefined}

--- a/ui/src/features/projects/members/components/MembersTable.tsx
+++ b/ui/src/features/projects/members/components/MembersTable.tsx
@@ -116,7 +116,7 @@ function ActionsCell({
         component="button"
         type="button"
         size="sm"
-        c={isSelf ? 'dimmed' : undefined}
+        c={isSelf ? 'dimmed' : 'red'}
         style={isSelf ? { cursor: 'not-allowed' } : undefined}
         onClick={isSelf ? undefined : () => meta?.onRemove?.(row.original)}
       >


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Makes all "Delete"/"Remove" text actions render in a consistent red, matching the existing robots table styling:

- Admin users / registries / replications: delete `Button` color changed from `blue` to `red`
- Project members: "Remove" link now red (still dimmed for one's own row)
- Profile access tokens & SSH keys: "Delete" links now red
- Projects list: "Delete" link now red (dimmed when disabled)

Affected pages: /admin/users, /admin/registries, /admin/replications, /projects/:name/members, /profile/access-token, /profile/ssh-keys, /projects

#### Which issue(s) this PR fixes:

Fixes #968

#### Special notes for your reviewer:

Pure cosmetic change (Mantine color props only), no logic changes. Verified with typecheck and eslint, and visually against a running dev instance.

#### Checklist

- [ ] Tests(ut, e2e) added or updated, or not needed and explained — not needed: color-only styling change with no behavior change
- [ ] Docs(tech docs, usage docs) updated, or not needed and explained — not needed: no user-facing workflow or API change

#### Does this PR introduce a user-facing, API-facing, or operator-facing change?

```release-note
Delete/Remove actions across admin pages, project members, projects list, access tokens, and SSH keys now consistently display in red.
```