### PR TITLE
fix(ui): match project name link font size to table text

### DIFF
--- a/ui/src/features/projects/components/ProjectsTable.tsx
+++ b/ui/src/features/projects/components/ProjectsTable.tsx
@@ -34,11 +34,12 @@ function ProjectNameCell({ row }: ProjectCellProps) {
   const name = row.original.name
 
   if (!name) {
-    return <Text fw={600}>-</Text>
+    return <Text size="sm" fw={600}>-</Text>
   }
 
   return (
     <Anchor
+      size="sm"
       fw={600}
       underline="never"
       renderRoot={props => (


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Sets `size="sm"` on the project name link (and the `-` fallback text) in the Projects table so it matches the 14px font size of the other table cells, instead of using Mantine Anchor's larger default size. This aligns with how other tables in the codebase (e.g. RegistriesTable, AccessTokenTable) render link cells.

#### Which issue(s) this PR fixes:

Fixes #964

#### Special notes for your reviewer:

Verified against a live environment: the project name link now renders at 14px, same as the rest of the table. Pure styling change; no tests or docs needed.

#### Checklist

- [ ] Tests(ut, e2e) added or updated, or not needed and explained
- [ ] Docs(tech docs, usage docs) updated, or not needed and explained

#### Does this PR introduce a user-facing, API-facing, or operator-facing change?

```release-note
Fixed the project name link font size in the Projects table to match the rest of the table text.
```