### PR TITLE
fix(sync): populate pagination page count

### DIFF
--- a/internal/apiserver/handler/sync_policy_handler.go
+++ b/internal/apiserver/handler/sync_policy_handler.go
@@ -30,6 +30,7 @@ import (
 	"github.com/matrixhub-ai/matrixhub/internal/domain/syncjob"
 	"github.com/matrixhub-ai/matrixhub/internal/domain/syncpolicy"
 	"github.com/matrixhub-ai/matrixhub/internal/infra/log"
+	"github.com/matrixhub-ai/matrixhub/internal/infra/utils"
 	"github.com/matrixhub-ai/matrixhub/internal/jobserver/canceller"
 	"github.com/matrixhub-ai/matrixhub/internal/jobserver/logstore"
 )
@@ -265,9 +266,10 @@ func (h *SyncPolicyHandler) ListSyncTasks(ctx context.Context, request *v1alpha1
 	return &v1alpha1.ListSyncTasksResponse{
 		SyncTasks: items,
 		Pagination: &v1alpha1.Pagination{
-			Total:    int32(total),
-			Page:     request.Page,
-			PageSize: request.PageSize,
+			Total:    utils.ClampInt32(total),
+			Page:     int32(page),
+			PageSize: int32(pageSize),
+			Pages:    utils.CalculatePages(total, int32(pageSize)),
 		},
 	}, nil
 }
@@ -413,9 +415,10 @@ func (h *SyncPolicyHandler) ListSyncJobs(ctx context.Context, request *v1alpha1.
 	return &v1alpha1.ListSyncJobsResponse{
 		SyncJobs: items,
 		Pagination: &v1alpha1.Pagination{
-			Total:    int32(total),
-			Page:     request.Page,
-			PageSize: request.PageSize,
+			Total:    utils.ClampInt32(total),
+			Page:     int32(page),
+			PageSize: int32(pageSize),
+			Pages:    utils.CalculatePages(total, int32(pageSize)),
 		},
 	}, nil
 }

--- a/internal/apiserver/handler/sync_policy_handler_test.go
+++ b/internal/apiserver/handler/sync_policy_handler_test.go
@@ -19,7 +19,10 @@ import (
 
 	v1alpha1 "github.com/matrixhub-ai/matrixhub/api/go/v1alpha1"
 	"github.com/matrixhub-ai/matrixhub/internal/domain/syncjob"
+	syncjobmocks "github.com/matrixhub-ai/matrixhub/internal/domain/syncjob/mocks"
 	"github.com/matrixhub-ai/matrixhub/internal/domain/syncpolicy"
+	syncpolicymocks "github.com/matrixhub-ai/matrixhub/internal/domain/syncpolicy/mocks"
+	"go.uber.org/mock/gomock"
 )
 
 // syncJobToProto and syncTaskToProto convert the domain status by a plain
@@ -46,4 +49,63 @@ func TestStatusEnumsAreRepresentableInProto(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestListSyncTasksPaginationIncludesPageCount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	policyService := syncpolicymocks.NewMockISyncPolicyService(ctrl)
+	jobService := syncjobmocks.NewMockISyncJobService(ctrl)
+	h := &SyncPolicyHandler{
+		syncPolicyService: policyService,
+		syncJobService:    jobService,
+	}
+
+	policyService.EXPECT().
+		ListSyncTasksByPolicyID(gomock.Any(), 1, 2, 10, syncpolicy.SyncTaskStatusUnspecified).
+		Return([]*syncpolicy.SyncTask{}, int64(21), nil)
+
+	response, err := h.ListSyncTasks(t.Context(), &v1alpha1.ListSyncTasksRequest{
+		SyncPolicyId: 1,
+		Page:         2,
+		PageSize:     10,
+	})
+	if err != nil {
+		t.Fatalf("ListSyncTasks() error = %v", err)
+	}
+	if got, want := response.Pagination.Pages, int32(3); got != want {
+		t.Fatalf("Pagination.Pages = %d, want %d", got, want)
+	}
+	if got, want := response.Pagination.Page, int32(2); got != want {
+		t.Fatalf("Pagination.Page = %d, want %d", got, want)
+	}
+	if got, want := response.Pagination.PageSize, int32(10); got != want {
+		t.Fatalf("Pagination.PageSize = %d, want %d", got, want)
+	}
+}
+
+func TestListSyncJobsPaginationIncludesPageCount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	jobService := syncjobmocks.NewMockISyncJobService(ctrl)
+	h := &SyncPolicyHandler{syncJobService: jobService}
+
+	jobService.EXPECT().
+		ListSyncJobsByTaskID(gomock.Any(), 1, 1, 20, syncjob.SyncJobStatusUnspecified, "").
+		Return([]*syncjob.SyncJob{}, int64(1<<31)+1, nil)
+
+	response, err := h.ListSyncJobs(t.Context(), &v1alpha1.ListSyncJobsRequest{SyncTaskId: 1})
+	if err != nil {
+		t.Fatalf("ListSyncJobs() error = %v", err)
+	}
+	if got, want := response.Pagination.Pages, int32(107374183); got != want {
+		t.Fatalf("Pagination.Pages = %d, want %d", got, want)
+	}
+	if got, want := response.Pagination.Total, int32(1<<31-1); got != want {
+		t.Fatalf("Pagination.Total = %d, want %d", got, want)
+	}
+	if got, want := response.Pagination.Page, int32(1); got != want {
+		t.Fatalf("Pagination.Page = %d, want %d", got, want)
+	}
+	if got, want := response.Pagination.PageSize, int32(20); got != want {
+		t.Fatalf("Pagination.PageSize = %d, want %d", got, want)
+	}
 }

--- a/internal/infra/utils/utils.go
+++ b/internal/infra/utils/utils.go
@@ -14,15 +14,38 @@
 
 package utils
 
+const (
+	maxInt32 = int64(1<<31 - 1)
+	minInt32 = int64(-1 << 31)
+)
+
 func IsFullPageData(page, pageSize int) bool {
 	return page == 1 && pageSize == -1
 }
 
+// ClampInt32 converts value to int32 without overflowing its bounds.
+func ClampInt32(value int64) int32 {
+	if value > maxInt32 {
+		return int32(maxInt32)
+	}
+	if value < minInt32 {
+		return int32(minInt32)
+	}
+	return int32(value)
+}
+
 // CalculatePages calculates the total number of pages based on total count and page size.
-// It returns 0 if pageSize is 0 or negative.
+// It returns 0 if total or pageSize is 0 or negative.
 func CalculatePages(total int64, pageSize int32) int32 {
-	if pageSize <= 0 {
+	if total <= 0 || pageSize <= 0 {
 		return 0
 	}
-	return (int32(total) + pageSize - 1) / pageSize
+
+	pageSize64 := int64(pageSize)
+	pages := total / pageSize64
+	if total%pageSize64 != 0 {
+		pages++
+	}
+
+	return ClampInt32(pages)
 }

--- a/internal/infra/utils/utils_test.go
+++ b/internal/infra/utils/utils_test.go
@@ -1,0 +1,49 @@
+// Copyright The MatrixHub Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "testing"
+
+func TestCalculatePagesDoesNotOverflowInt32Total(t *testing.T) {
+	if got, want := CalculatePages(int64(1<<31-1), 20), int32(107374183); got != want {
+		t.Fatalf("CalculatePages() = %d, want %d", got, want)
+	}
+}
+
+func TestCalculatePagesCapsAtInt32Max(t *testing.T) {
+	if got, want := CalculatePages(int64(1<<63-1), 1), int32(1<<31-1); got != want {
+		t.Fatalf("CalculatePages() = %d, want %d", got, want)
+	}
+}
+
+func TestClampInt32(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int64
+		want int32
+	}{
+		{name: "within range", in: 42, want: 42},
+		{name: "above max", in: 1<<31 + 1, want: 1<<31 - 1},
+		{name: "below min", in: -(1 << 31) - 1, want: -1 << 31},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClampInt32(tt.in); got != tt.want {
+				t.Fatalf("ClampInt32(%d) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

- Fixes remote sync task list pagination returning `pages: 0` when `total` is non-zero.
- Populates `Pagination.Pages` for remote sync task and sync job list responses using `ceil(total / page_size)`.
- Returns the normalized page and page size values used by the service, including default pagination values.
- Prevents `int32` overflow in page-count calculations and pagination totals.
- Adds regression coverage for task and job pagination, default parameters, and integer-boundary cases.

#### Which issue(s) this PR fixes:

Fixes #462

#### Special notes for your reviewer:

- The change is limited to remote sync task/job pagination responses and shared pagination calculation utilities.
- `Pages` remains `0` when there are no results; positive totals now return the correct page count.
- The full unit-test command still encounters unrelated Git temporary-repository failures in `internal/apiserver/handler/http` (`master` refspec push failure).

#### Validation

- `go test ./internal/apiserver/handler ./internal/infra/utils -count=1` — passed
- `git diff --check` — passed
- `make test.unit` — affected packages passed; unrelated HTTP Git tests failed as noted above

#### Checklist

- [x] Tests (UT, E2E) added or updated, or not needed and explained
- [x] Docs (tech docs, usage docs) updated, or not needed and explained
  - [Not needed]: This is an API pagination bug fix with regression tests.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```