### PR TITLE
feat(ui): add documentation site link to header

### DIFF
--- a/ui/src/locales/en/nav.json
+++ b/ui/src/locales/en/nav.json
@@ -6,5 +6,6 @@
   "logout": "Log Out",
   "createModel": "Create Model",
   "createDataset": "Create Dataset",
-  "settings": "Platform Settings"
+  "settings": "Platform Settings",
+  "docs": "Docs"
 }

--- a/ui/src/locales/zh/nav.json
+++ b/ui/src/locales/zh/nav.json
@@ -6,5 +6,6 @@
   "logout": "退出登录",
   "createModel": "创建模型",
   "createDataset": "创建数据集",
-  "settings": "平台设置"
+  "settings": "平台设置",
+  "docs": "文档"
 }

--- a/ui/src/locales/zh/nav.json
+++ b/ui/src/locales/zh/nav.json
@@ -7,5 +7,5 @@
   "createModel": "创建模型",
   "createDataset": "创建数据集",
   "settings": "平台设置",
-  "docs": "文档"
+  "docs": "Docs"
 }

--- a/ui/src/routes/(auth)/route.tsx
+++ b/ui/src/routes/(auth)/route.tsx
@@ -1,4 +1,5 @@
 import {
+  Anchor,
   AppShell,
   Avatar,
   Flex,
@@ -11,6 +12,7 @@ import {
 } from '@mantine/core'
 import { Login } from '@matrixhub/api-ts/v1alpha1/login.pb'
 import {
+  IconBook2 as DocsIcon,
   IconChevronDown as ArrowDownIcon,
   IconCube as ModelIcon,
   IconLogout as LogOutIcon,
@@ -164,6 +166,32 @@ function AppNavbar() {
   )
 }
 
+const DOCS_URL = '/docs/'
+
+function DocsLink() {
+  const { t } = useTranslation()
+
+  return (
+    <Anchor
+      href={t('common.docs', { doc: DOCS_URL })}
+      target="_blank"
+      rel="noopener noreferrer"
+      c="dimmed"
+      size="sm"
+      fw={600}
+      underline="never"
+    >
+      <Group
+        gap={4}
+        wrap="nowrap"
+      >
+        <DocsIcon size={rem(18)} />
+        {t('nav.docs')}
+      </Group>
+    </Anchor>
+  )
+}
+
 function AccountMenu() {
   const { t } = useTranslation()
   const user = use(CurrentUserContext)
@@ -312,6 +340,8 @@ function AuthLayout() {
             </Group>
 
             <Group gap="md" wrap="nowrap">
+              <DocsLink />
+
               <LanguageSwitcher />
 
               <AccountMenu />

--- a/ui/src/routes/(auth)/route.tsx
+++ b/ui/src/routes/(auth)/route.tsx
@@ -166,7 +166,7 @@ function AppNavbar() {
   )
 }
 
-const DOCS_URL = '/docs/'
+const DOCS_URL = '/'
 
 function DocsLink() {
   const { t } = useTranslation()

--- a/ui/src/routes/(auth)/route.tsx
+++ b/ui/src/routes/(auth)/route.tsx
@@ -1,5 +1,4 @@
 import {
-  Anchor,
   AppShell,
   Avatar,
   Flex,
@@ -12,9 +11,9 @@ import {
 } from '@mantine/core'
 import { Login } from '@matrixhub/api-ts/v1alpha1/login.pb'
 import {
-  IconBook2 as DocsIcon,
   IconChevronDown as ArrowDownIcon,
   IconCube as ModelIcon,
+  IconFileText as DocsIcon,
   IconLogout as LogOutIcon,
   IconSettings as SettingsIcon,
   IconUser as UserIcon,
@@ -90,6 +89,8 @@ function AppLogo() {
   )
 }
 
+const DOCS_URL = '/'
+
 function AppNavbar() {
   const { t } = useTranslation()
   const navRoutes = linkOptions([
@@ -107,6 +108,22 @@ function AppNavbar() {
     },
   ])
   const matchRoute = useMatchRoute()
+
+  const navLinkStyles = (isActive: boolean) => ({
+    root: {
+      width: 'auto',
+      height: '32px',
+      borderRadius: 'var(--mantine-radius-lg)',
+      fontWeight: '600',
+      color: isActive ? 'var(--nl-color)' : '#868E96',
+    },
+    section: {
+      marginInlineEnd: '8px',
+    },
+    label: {
+      whiteSpace: 'nowrap',
+    },
+  })
 
   return (
     <Group
@@ -144,51 +161,25 @@ function AppNavbar() {
               />
             )}
             active={isActive}
-            styles={{
-              root: {
-                width: 'auto',
-                height: '32px',
-                borderRadius: 'var(--mantine-radius-lg)',
-                fontWeight: '600',
-                color: isActive ? 'var(--nl-color)' : '#868E96',
-              },
-              section: {
-                marginInlineEnd: '8px',
-              },
-              label: {
-                whiteSpace: 'nowrap',
-              },
-            }}
+            styles={navLinkStyles(isActive)}
           />
         )
       })}
+
+      <NavLink
+        label={t('nav.docs')}
+        component="a"
+        href={t('common.docs', { doc: DOCS_URL })}
+        target="_blank"
+        rel="noopener noreferrer"
+        leftSection={(
+          <DocsIcon
+            size={rem(20)}
+          />
+        )}
+        styles={navLinkStyles(false)}
+      />
     </Group>
-  )
-}
-
-const DOCS_URL = '/'
-
-function DocsLink() {
-  const { t } = useTranslation()
-
-  return (
-    <Anchor
-      href={t('common.docs', { doc: DOCS_URL })}
-      target="_blank"
-      rel="noopener noreferrer"
-      c="dimmed"
-      size="sm"
-      fw={600}
-      underline="never"
-    >
-      <Group
-        gap={4}
-        wrap="nowrap"
-      >
-        <DocsIcon size={rem(18)} />
-        {t('nav.docs')}
-      </Group>
-    </Anchor>
   )
 }
 
@@ -340,8 +331,6 @@ function AuthLayout() {
             </Group>
 
             <Group gap="md" wrap="nowrap">
-              <DocsLink />
-
               <LanguageSwitcher />
 
               <AccountMenu />


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a documentation site link to the header of the authenticated layout, placed in the main navigation group right after Projects, as shown in the design prototype.

- New Docs `NavLink` in `AppNavbar` (`ui/src/routes/(auth)/route.tsx`) sharing the existing nav item styles, with Tabler `IconFileText`; opens in a new tab.
- The URL is built from the existing `common.docs` template, so it follows the current locale: `https://matrixhub.ai/` for English and `https://matrixhub.ai/zh-cn/` for Chinese.
- New `nav.docs` copy added to both `en` and `zh` locale files ("Docs" in both, per the design).

#### Which issue(s) this PR fixes:

Fixes #994

<img width="1591" height="1119" alt="image" src="https://github.com/user-attachments/assets/d80f4095-5d9c-4c05-8c2b-660d71248810" />
<img width="1594" height="1121" alt="image" src="https://github.com/user-attachments/assets/b2478d5c-a069-4185-9c46-baef16801397" />


#### Special notes for your reviewer:

Verified locally against a running backend: the link renders in the header and switches text/URL correctly when toggling the language. Only files under `ui/` are changed.

#### Checklist

- [ ] Tests(ut, e2e) added or updated, or not needed and explained — presentational header link only, no logic to unit test; verified manually in the browser.
- [ ] Docs(tech docs, usage docs) updated, or not needed and explained — no shared primitives or conventions changed.

#### Does this PR introduce a user-facing, API-facing, or operator-facing change?

```release-note
Add a documentation site link to the header.
```


