### PR TITLE
ci: align Dependabot release note handling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-
   # Maintain dependencies for go in root
   - package-ecosystem: "gomod"
     directory: "/"
@@ -9,6 +8,7 @@ updates:
     labels:
       - "dependencies"
       - "automated"
+      - "release-note-none"
     open-pull-requests-limit: 5
     groups:
       all:
@@ -25,6 +25,7 @@ updates:
     labels:
       - "dependencies"
       - "automated"
+      - "release-note-none"
     open-pull-requests-limit: 0
     groups:
       mantine:
@@ -66,6 +67,7 @@ updates:
     labels:
       - "dependencies"
       - "automated"
+      - "release-note-none"
     open-pull-requests-limit: 5
     groups:
       docusaurus:
@@ -82,6 +84,7 @@ updates:
     labels:
       - "dependencies"
       - "automated"
+      - "release-note-none"
     open-pull-requests-limit: 5
     groups:
       all:
@@ -98,4 +101,5 @@ updates:
     labels:
       - "dependencies"
       - "automated"
+      - "release-note-none"
     open-pull-requests-limit: 3

--- a/.github/workflows/ci-bot.yml
+++ b/.github/workflows/ci-bot.yml
@@ -169,20 +169,6 @@ jobs:
             If the PR is ready, use the `/auto-cc` command to assign Reviewer to Review. 
             We will review it shortly.
 
-      - name: PR Edited
-        uses: wzshiming/gh-ci-bot@v1.5.0
-        if: ${{ github.event_name == 'pull_request_target' && github.event.action == 'edited' }}
-        env:
-          MEMBERS_PLUGINS: *members_plugins
-          LOGIN: ${{ github.event.pull_request.user.login }}
-          AUTHOR: ${{ github.event.pull_request.user.login }}
-          MESSAGE: ${{ github.event.pull_request.body }}
-          ISSUE_NUMBER: ${{ github.event.pull_request.number }}
-          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
-          ISSUE_KIND: pr
-          # v1.5.0 has no edited type; comment reparses the body without greeting.
-          TYPE: comment
-
       - name: PR Synchronize
         uses: wzshiming/gh-ci-bot@v1.5.0
         if: ${{ github.event_name == 'pull_request_target' && github.event.action == 'synchronize' }}
@@ -342,13 +328,22 @@ jobs:
               core.info(`${present ? 'Added' : 'Removed'} ${label}`);
             }
 
+            const releaseNoteMatch = /```release-note[^\S\r\n]*(?:\r?\n)?([\s\S]*?)```/i
+              .exec(pull.body ?? '');
+            const releaseNote = releaseNoteMatch?.[1]?.trim() ?? '';
+            const hasNoReleaseNote = /^\W*(?:NONE|NO)\W*$/i.test(releaseNote);
+            const hasReleaseNoteContent = Boolean(releaseNote) && !hasNoReleaseNote;
+            const hasDeprecation = labels.has('kind/deprecation');
+
             // Match Kubernetes' public /hold command behavior. If a comment
             // contains more than one hold command, the last command wins.
             if (context.eventName === 'issue_comment'
                 || context.eventName === 'pull_request_review_comment') {
-              const body = (context.payload.comment?.body ?? '')
-                .replace(/<!--[\s\S]*?-->/g, '');
+              const rawBody = context.payload.comment?.body ?? '';
+              const body = rawBody.replace(/<!--[\s\S]*?-->/g, '');
               let hold = null;
+              const releaseNoteNone = context.eventName === 'issue_comment'
+                && /^\/release-note-none\s*$/im.test(rawBody);
               for (const rawLine of body.split(/\r?\n/)) {
                 const line = rawLine.trim().toLowerCase();
                 if (line === '/hold') {
@@ -362,20 +357,45 @@ jobs:
               if (hold !== null) {
                 await setLabel('do-not-merge/hold', hold);
               }
+              if (releaseNoteNone) {
+                const commenter = context.payload.comment?.user?.login;
+                const association = context.payload.comment?.author_association;
+                const isMember = ['OWNER', 'MEMBER'].includes(association);
+                const isAuthor = commenter?.toLowerCase() === pull.user.login.toLowerCase();
+                if (!isAuthor && !isMember) {
+                  await github.rest.issues.createComment({
+                    ...target,
+                    body: `@${commenter}: only the PR author or an organization member can use \`/release-note-none\`.`,
+                  });
+                } else if (hasReleaseNoteContent) {
+                  await github.rest.issues.createComment({
+                    ...target,
+                    body: `@${commenter}: \`/release-note-none\` cannot be used while the PR body contains a release note.`,
+                  });
+                } else if (hasDeprecation) {
+                  await github.rest.issues.createComment({
+                    ...target,
+                    body: `@${commenter}: \`/release-note-none\` cannot be used with \`kind/deprecation\`.`,
+                  });
+                } else {
+                  await setLabel('release-note-none', true);
+                }
+              }
             }
 
             const hasKind = [...labels].some((label) => label.startsWith('kind/'));
             await setLabel('do-not-merge/needs-kind', !hasKind);
 
-            const releaseNoteMatch = /```release-note[^\S\r\n]*(?:\r?\n)?([\s\S]*?)```/i
-              .exec(pull.body ?? '');
-            const releaseNote = releaseNoteMatch?.[1]?.trim() ?? '';
-            const hasNoReleaseNote = /^\W*(?:NONE|NO)\W*$/i.test(releaseNote);
-
-            if (!releaseNote) {
+            if (hasDeprecation && (!releaseNote || hasNoReleaseNote)) {
               await setLabel('release-note', false);
               await setLabel('release-note-none', false);
               await setLabel('do-not-merge/needs-release-note', true);
+            } else if (!releaseNote) {
+              await setLabel('release-note', false);
+              await setLabel(
+                'do-not-merge/needs-release-note',
+                !labels.has('release-note-none'),
+              );
             } else if (hasNoReleaseNote) {
               await setLabel('release-note', false);
               await setLabel('release-note-none', true);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,11 +242,15 @@ maintainer.
 ## Release notes in pull requests
 
 MatrixHub follows the [Kubernetes release notes model](https://github.com/kubernetes/community/blob/main/contributors/guide/release-notes.md).
-Every pull request must choose a `/kind` and complete the `release-note` block with
-a user-, API-, or operator-facing change, or `NONE`.
+Every pull request must choose a `/kind` and either complete the `release-note`
+block or have the `release-note-none` label.
 
-Anyone may correct Kind with `/kind` or `/remove-kind`. The bot derives release-note
-labels from the PR body, and reviewers verify the note's accuracy and wording.
+Kind commands in the initial PR body are processed once. After opening the PR,
+use a new `/kind` or `/remove-kind` comment to change it. For a change without
+a release note, the PR author or an organization member may comment
+`/release-note-none` in the PR conversation when the block is empty or
+`NONE`/`NO`. A real note takes precedence over the label, and deprecations
+require a note. Reviewers verify the decision and wording.
 
 Example:
 

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -291,8 +291,15 @@ EOF
   fi
 
   if [ "$has_release_note_none" = true ]; then
-    is_no_release_note "$note" || \
-      append_line "$work_dir/errors" "#$number has release-note-none but its release-note block is not NONE or NO"
+    if [ -n "$note" ] && ! is_no_release_note "$note"; then
+      append_line "$work_dir/errors" \
+        "#$number has release-note-none but its release-note block contains content"
+      return
+    fi
+    if has_line "$kind_labels" 'kind/deprecation'; then
+      append_line "$work_dir/errors" "#$number has kind/deprecation and release-note-none"
+      return
+    fi
     append_line "$work_dir/excluded" "$number"
     return
   fi

--- a/scripts/changelog.test.sh
+++ b/scripts/changelog.test.sh
@@ -115,18 +115,22 @@ test_previous_official_tag() (
 )
 
 test_pull_validation_and_rendering() {
-  local work feature none block errors
+  local work feature none label_only_none dependabot_body block errors
   work=$(new_work_dir) || return 1
   feature=$(pull_json 21 $'```release-note\nAdded a capability.\nMore detail.\n```' \
     '["kind/feature", "release-note"]' alice) || return 1
   none=$(pull_json 22 $'```release-note\nNONE\n```' \
     '["kind/cleanup", "release-note-none"]' bob) || return 1
+  dependabot_body=$'Bumps a dependency from 1.0.0 to 1.0.1.\n\n<details>\n<summary>Release notes</summary>\nUpstream notes.\n</details>'
+  label_only_none=$(pull_json 23 "$dependabot_body" \
+    '["kind/dependency", "release-note-none"]' 'dependabot[bot]') || return 1
 
   process_pull "$feature" "$work" || return 1
   process_pull "$none" "$work" || return 1
+  process_pull "$label_only_none" "$work" || return 1
   errors=$(cat "$work/errors")
   assert_equal '' "$errors" || return 1
-  assert_equal 22 "$(cat "$work/excluded")" || return 1
+  assert_equal $'22\n23' "$(cat "$work/excluded")" || return 1
 
   block=$(render_generated_block "$work" matrixhub-ai/matrixhub v0.1.0 v0.2.0) || return 1
   assert_contains "$block" '#### Feature' || return 1
@@ -138,6 +142,7 @@ test_pull_validation_and_rendering() {
 
 test_invalid_metadata_is_reported() {
   local work missing_kind conflicting blocked wrong_none missing_release unusable unsupported multiple
+  local deprecated_none
   local errors warnings
   work=$(new_work_dir) || return 1
   missing_kind=$(pull_json 30 $'```release-note\nVisible change.\n```' '["release-note"]') || return 1
@@ -154,6 +159,8 @@ test_invalid_metadata_is_reported() {
     '["kind/unknown", "release-note"]') || return 1
   multiple=$(pull_json 37 $'```release-note\nAPI change.\n```' \
     '["kind/feature", "kind/api-change", "release-note"]') || return 1
+  deprecated_none=$(pull_json 38 '' \
+    '["kind/deprecation", "release-note-none"]') || return 1
 
   process_pull "$missing_kind" "$work" || return 1
   process_pull "$conflicting" "$work" || return 1
@@ -163,16 +170,18 @@ test_invalid_metadata_is_reported() {
   process_pull "$unusable" "$work" || return 1
   process_pull "$unsupported" "$work" || return 1
   process_pull "$multiple" "$work" || return 1
+  process_pull "$deprecated_none" "$work" || return 1
   errors=$(cat "$work/errors")
   warnings=$(cat "$work/warnings")
   assert_contains "$errors" '#30 has no kind/* label' || return 1
   assert_contains "$errors" '#31 has both release-note and release-note-none labels' || return 1
   assert_contains "$errors" '#32 is still labeled do-not-merge/needs-kind' || return 1
   assert_contains "$errors" '#32 is still labeled do-not-merge/needs-release-note' || return 1
-  assert_contains "$errors" '#33 has release-note-none but its release-note block is not NONE or NO' || return 1
+  assert_contains "$errors" '#33 has release-note-none but its release-note block contains content' || return 1
   assert_contains "$errors" '#34 has neither release-note nor release-note-none' || return 1
   assert_contains "$errors" '#35 has release-note but no usable release-note content' || return 1
   assert_contains "$errors" '#36 has unsupported kind labels: kind/unknown' || return 1
+  assert_contains "$errors" '#38 has kind/deprecation and release-note-none' || return 1
   assert_contains "$warnings" '#37 has multiple kind labels (kind/feature, kind/api-change); classified as api-change' || return 1
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Adds `release-note-none` to every Dependabot ecosystem.
- Matches Kubernetes body-first release-note reconciliation.
- Supports `/release-note-none` for PR authors and organization members.
- Keeps changelog collection strict when labels and the PR body conflict.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Dependabot-generated `<details>` release notes are not treated as a fenced MatrixHub release-note block.

#### Checklist

- [x] Tests added or updated
- [x] Documentation updated

#### Does this PR introduce a user-facing, API-facing, or operator-facing change?

```release-note
NONE
```