### PR TITLE
fix(security): make the token signing secret configurable and generated

### DIFF
--- a/.github/workflows/sqlite-test.yml
+++ b/.github/workflows/sqlite-test.yml
@@ -24,6 +24,7 @@ on:
       - 'deploy/docker-compose.sqlite.yml'
       - 'deploy/docker-compose.mysql.yml'
       - 'deploy/update-demo-env.sh'
+      - 'scripts/verify-token-signing.sh'
       - '.github/workflows/deploy-demosite.yml'
       - '.github/workflows/sqlite-test.yml'
   pull_request:
@@ -49,6 +50,7 @@ on:
       - 'deploy/docker-compose.sqlite.yml'
       - 'deploy/docker-compose.mysql.yml'
       - 'deploy/update-demo-env.sh'
+      - 'scripts/verify-token-signing.sh'
       - '.github/workflows/deploy-demosite.yml'
       - '.github/workflows/sqlite-test.yml'
 
@@ -176,3 +178,6 @@ jobs:
             echo 'Helm unexpectedly accepted SQLite'
             exit 1
           fi
+
+      - name: Verify signing secret deployment
+        run: bash scripts/verify-token-signing.sh

--- a/deploy/charts/matrixhub/README.md
+++ b/deploy/charts/matrixhub/README.md
@@ -91,6 +91,8 @@ The following table lists the configurable parameters of the MatrixHub chart and
 | `apiserver.debug` | Debug mode | `false` |
 | `apiserver.logLevel` | Log level (debug/info/warn/error) | `warn` |
 | `apiserver.port` | API server port | `9527` |
+| `apiserver.tokenSigningSecret` | Explicit signing key of at least 32 bytes | `""` (generate and reuse a release Secret) |
+| `apiserver.tokenSigningExistingSecret` | Existing Secret with a `token-signing-secret` key | `""` |
 | `apiserver.database.driver` | Database driver (`mysql` or `postgres`) | `mysql` |
 | `apiserver.database.accessType` | Database access type | `readwrite` |
 | `apiserver.database.maxOpenConns` | Max open connections | `100` |
@@ -138,6 +140,20 @@ helm install matrixhub oci://ghcr.io/matrixhub-ai/matrixhub \
   --namespace ${NAMESPACE} --create-namespace \
   -f values.yaml
 ```
+
+### Signing Keys
+
+The chart generates a random signing key in the release Secret and reuses it
+on upgrades through Helm's cluster lookup. It is injected as
+`MATRIXHUB_TOKEN_SIGNING_SECRET`, not stored in the ConfigMap. Configure
+`apiserver.tokenSigningSecret` to supply a key explicitly, or
+`apiserver.tokenSigningExistingSecret` to use a Secret containing
+`token-signing-secret`; the existing Secret takes precedence.
+
+For offline `helm template` or GitOps renderers without cluster lookup, use an
+existing Secret or a stable explicit key to avoid rotation on each render.
+All replicas must share the same key. Rotating it invalidates outstanding
+LFS tokens.
 
 ## Storage
 

--- a/deploy/charts/matrixhub/templates/matrixhub-deployment.yaml
+++ b/deploy/charts/matrixhub/templates/matrixhub-deployment.yaml
@@ -82,6 +82,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "matrixhub.fullname" . }}-secret
                   key: matrixhub.dsn
+            - name: MATRIXHUB_TOKEN_SIGNING_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.apiserver.tokenSigningExistingSecret | default (printf "%s-secret" (include "matrixhub.fullname" .)) }}
+                  key: token-signing-secret
       volumes:
         - name: {{ include "matrixhub.fullname" . }}-config
           configMap:

--- a/deploy/charts/matrixhub/templates/secret.yaml
+++ b/deploy/charts/matrixhub/templates/secret.yaml
@@ -8,3 +8,18 @@ metadata:
 type: Opaque
 data:
   matrixhub.dsn: {{ include "matrixhub.database.dsn" . | b64enc | quote }}
+  {{- if not .Values.apiserver.tokenSigningExistingSecret }}
+  {{- $signingKey := .Values.apiserver.tokenSigningSecret }}
+  {{- if not $signingKey }}
+  {{- $existing := lookup "v1" "Secret" .Release.Namespace (printf "%s-secret" (include "matrixhub.fullname" .)) }}
+  {{- if and $existing $existing.data (index $existing.data "token-signing-secret") }}
+  {{- $signingKey = index $existing.data "token-signing-secret" | b64dec }}
+  {{- else }}
+  {{- $signingKey = randAlphaNum 64 }}
+  {{- end }}
+  {{- end }}
+  {{- if lt (len $signingKey) 32 }}
+  {{- fail "apiserver.tokenSigningSecret must be at least 32 bytes" }}
+  {{- end }}
+  token-signing-secret: {{ $signingKey | b64enc | quote }}
+  {{- end }}

--- a/deploy/charts/matrixhub/values.yaml
+++ b/deploy/charts/matrixhub/values.yaml
@@ -86,6 +86,11 @@ apiserver:
   # affected UI panels. Example: https://matrixhub.example.com
   externalURL: ""
 
+  # -- Signing key (at least 32 bytes); empty generates and reuses a release Secret.
+  tokenSigningSecret: ""
+  # -- Existing Secret containing token-signing-secret; overrides tokenSigningSecret.
+  tokenSigningExistingSecret: ""
+
   # -- storage configuration for git storage (models, datasets, lfs)
   storage:
     # -- storage mode: none (no persistence), pvc (PersistentVolumeClaim), s3 (object storage)

--- a/deploy/docker-compose.mysql.yml
+++ b/deploy/docker-compose.mysql.yml
@@ -36,6 +36,7 @@ services:
       - ./config-mysql.yaml:/etc/matrixhub/config.yaml:ro
     environment:
       - MATRIXHUB_DATABASE_DSN=matrixhub:${MYSQL_PASSWORD:-changeme}@tcp(mysql:3306)/matrixhub?charset=utf8mb4&multiStatements=true&parseTime=true
+      - MATRIXHUB_TOKEN_SIGNING_SECRET=${MATRIXHUB_TOKEN_SIGNING_SECRET:-}
     depends_on:
       mysql:
         condition: service_healthy

--- a/deploy/docker-compose.sqlite.yml
+++ b/deploy/docker-compose.sqlite.yml
@@ -13,6 +13,8 @@ services:
     ports:
       - "${MATRIXHUB_HTTP_PORT:-3001}:3001"
       - "${MATRIXHUB_SSH_PORT:-2222}:22"
+    environment:
+      MATRIXHUB_TOKEN_SIGNING_SECRET: ${MATRIXHUB_TOKEN_SIGNING_SECRET:-}
     volumes:
       - ./data/matrixhub:/data/
       - ./config-sqlite.yaml:/etc/matrixhub/config.yaml:ro

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     ports:
       - "${MATRIXHUB_HTTP_PORT:-3001}:3001"
       - "${MATRIXHUB_SSH_PORT:-2222}:22"
+    environment:
+      MATRIXHUB_TOKEN_SIGNING_SECRET: ${MATRIXHUB_TOKEN_SIGNING_SECRET:-}
     volumes:
       - ./data/matrixhub:/data/
       - ./config.yaml:/etc/matrixhub/config.yaml:ro

--- a/docs/development.md
+++ b/docs/development.md
@@ -37,6 +37,21 @@ MatrixHub Helm chart does not support SQLite.
 SQLite's built-in `NOCASE` collation only folds ASCII characters; names that
 differ only by non-ASCII case may behave differently from MySQL.
 
+### Signing Keys
+
+`apiServer.tokenSigningSecret` signs temporary LFS tokens.
+`MATRIXHUB_TOKEN_SIGNING_SECRET` overrides the config value. If neither is set,
+MatrixHub generates a cryptographically random key in `dataDir/token-signing-secret`
+with mode `0600` and reuses it on subsequent starts. Keep this file private and
+persist `dataDir`; losing or rotating the key invalidates outstanding tokens.
+Instances with separate data directories must configure the same key when
+sharing a public endpoint. Explicit production keys must be at least 32 bytes.
+
+Compose accepts an optional `MATRIXHUB_TOKEN_SIGNING_SECRET`; no setting is
+required for a persistent single-node deployment. Helm generates a release
+Secret by default and supports an existing Secret; see the
+[chart configuration](../deploy/charts/matrixhub/README.md#signing-keys).
+
 ### 1. Start MySQL
 
 ```bash

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -249,11 +249,7 @@ func (server *APIServer) initGitAuth() {
 	publicKeyValidator := middleware.GitPublicKeyAuthn(server.repos.SSHKey, server.repos.User)
 	tokenValidator := middleware.GitHTTPAuthn(server.repos.AccessToken, server.repos.User, server.repos.Robot)
 
-	// TODO: Use a proper secret management solution to manage the token signing secret.
-	// Generating and validating temporary tokens.
-	// Currently only used to provide http lfs download in ssh ports.
-	tmpTokenSecret := []byte("secret-xxxxxx")
-	tokenSignValidator := authenticate.NewTokenSignValidator(tmpTokenSecret)
+	tokenSignValidator := authenticate.NewTokenSignValidator([]byte(server.config.APIServer.TokenSigningSecret))
 
 	server.gitAuth.basicAuthValidator = basicAuthValidator
 	server.gitAuth.publicKeyValidator = publicKeyValidator

--- a/internal/infra/config/config.go
+++ b/internal/infra/config/config.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"crypto/rand"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -103,6 +104,8 @@ type APIServerConfig struct {
 	SSHPort        int    `yaml:"sshPort"`
 	SSHHostKeyPath string `yaml:"sshHostKeyPath"`
 	HostURL        string `yaml:"hostURL"`
+	// Empty generates a persistent random key under DataDir.
+	TokenSigningSecret string `yaml:"tokenSigningSecret"`
 	// ExternalURL is the externally-reachable base URL of this instance. It is
 	// surfaced to the frontend (e.g. as the `HF_ENDPOINT` for `hf` CLI snippets).
 	// Empty means "not configured" and the API returns an empty string so the
@@ -148,6 +151,7 @@ func Init(configPath, sqlPath string) (*Config, error) {
 
 	// Allow env overrides (viper will use these when present)
 	_ = v.BindEnv("database.dsn", db.MATRIXHUB_DSN_ENV)
+	_ = v.BindEnv("apiServer.tokenSigningSecret", "MATRIXHUB_TOKEN_SIGNING_SECRET")
 
 	cfg := new(Config)
 	if err := v.Unmarshal(cfg); err != nil {
@@ -218,6 +222,12 @@ func Init(configPath, sqlPath string) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create data directory: %w", err)
 	}
+	if cfg.APIServer.TokenSigningSecret == "" {
+		cfg.APIServer.TokenSigningSecret, err = loadOrCreateTokenSigningSecret(cfg.DataDir)
+		if err != nil {
+			return nil, fmt.Errorf("load signing secret: %w", err)
+		}
+	}
 
 	if cfg.Database.Migrate {
 		cfg.Database.SQLPath = filepath.Join(cfg.MigrationPath, sqlPath)
@@ -231,7 +241,39 @@ func Init(configPath, sqlPath string) (*Config, error) {
 	return cfg, nil
 }
 
+func loadOrCreateTokenSigningSecret(dataDir string) (string, error) {
+	secretPath := filepath.Join(dataDir, "token-signing-secret")
+	data, err := os.ReadFile(secretPath)
+	if err == nil {
+		return string(data), nil
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+	temporary, err := os.CreateTemp(dataDir, ".token-signing-secret-")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = os.Remove(temporary.Name()) }()
+	_, writeErr := temporary.WriteString(rand.Text() + rand.Text())
+	closeErr := temporary.Close()
+	if writeErr != nil {
+		return "", writeErr
+	}
+	if closeErr != nil {
+		return "", closeErr
+	}
+	if err := os.Link(temporary.Name(), secretPath); err != nil && !os.IsExist(err) {
+		return "", err
+	}
+	data, err = os.ReadFile(secretPath)
+	return string(data), err
+}
+
 func (config *Config) Validate() error {
+	if !config.Debug && len(config.APIServer.TokenSigningSecret) < 32 {
+		return fmt.Errorf("apiServer.tokenSigningSecret must be at least 32 bytes outside debug mode")
+	}
 	fileInfo, err := os.Stat(config.MigrationPath)
 	if err != nil {
 		return err

--- a/internal/infra/config/config_test.go
+++ b/internal/infra/config/config_test.go
@@ -57,3 +57,81 @@ apiServer:
 	require.Equal(t, "FULL", dsn.Query().Get("_synchronous"))
 	require.Equal(t, "immediate", dsn.Query().Get("_txlock"))
 }
+
+func TestInitTokenSigningSecret(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		debug   bool
+		secret  string
+		env     string
+		want    string
+		wantErr bool
+	}{
+		{"generated production key", false, "", "", "", false},
+		{"short production key", false, "short", "", "", true},
+		{"configured key", false, "configured-signing-secret-32-bytes", "", "configured-signing-secret-32-bytes", false},
+		{"environment override", false, "config-value", "environment-signing-secret-32-bytes", "environment-signing-secret-32-bytes", false},
+		{"environment without config key", false, "", "environment-signing-secret-32-bytes", "environment-signing-secret-32-bytes", false},
+		{"generated development key", true, "", "", "", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("MATRIXHUB_TOKEN_SIGNING_SECRET", test.env)
+			t.Setenv(db.MATRIXHUB_DSN_ENV, "")
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			contents := fmt.Sprintf("debug: %t\nmigrationPath: %q\ndataDir: %q\ndatabase:\n  driver: sqlite\napiServer:\n  port: 3001\n", test.debug, t.TempDir(), t.TempDir())
+			if test.secret != "" {
+				contents += fmt.Sprintf("  tokenSigningSecret: %q\n", test.secret)
+			}
+			require.NoError(t, os.WriteFile(configPath, []byte(contents), 0o600))
+			cfg, err := Init(configPath, "")
+			if test.wantErr {
+				require.ErrorContains(t, err, "tokenSigningSecret")
+				return
+			}
+			require.NoError(t, err)
+			if test.want != "" {
+				require.Equal(t, test.want, cfg.APIServer.TokenSigningSecret)
+			} else {
+				require.GreaterOrEqual(t, len(cfg.APIServer.TokenSigningSecret), 32)
+			}
+		})
+	}
+}
+
+func TestInitPersistsRandomSigningSecret(t *testing.T) {
+	t.Setenv("MATRIXHUB_TOKEN_SIGNING_SECRET", "")
+	t.Setenv(db.MATRIXHUB_DSN_ENV, "")
+	var previous string
+	for range 2 {
+		dataDir := filepath.Join(t.TempDir(), "data")
+		configPath := filepath.Join(t.TempDir(), "config.yaml")
+		contents := fmt.Sprintf("migrationPath: %q\ndataDir: %q\ndatabase:\n  driver: sqlite\napiServer:\n  port: 3001\n", t.TempDir(), dataDir)
+		require.NoError(t, os.WriteFile(configPath, []byte(contents), 0o600))
+		first, err := Init(configPath, "")
+		require.NoError(t, err)
+		second, err := Init(configPath, "")
+		require.NoError(t, err)
+		require.Equal(t, first.APIServer.TokenSigningSecret, second.APIServer.TokenSigningSecret)
+		require.NotEqual(t, previous, first.APIServer.TokenSigningSecret)
+		previous = first.APIServer.TokenSigningSecret
+		keyFile := filepath.Join(dataDir, "token-signing-secret")
+		stored, err := os.ReadFile(keyFile)
+		require.NoError(t, err)
+		require.Equal(t, previous, string(stored))
+		info, err := os.Stat(keyFile)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
+}
+
+func TestInitRejectsUnreadableSigningSecret(t *testing.T) {
+	t.Setenv("MATRIXHUB_TOKEN_SIGNING_SECRET", "")
+	t.Setenv(db.MATRIXHUB_DSN_ENV, "")
+	dataDir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dataDir, "token-signing-secret"), 0o700))
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	contents := fmt.Sprintf("migrationPath: %q\ndataDir: %q\ndatabase:\n  driver: sqlite\napiServer:\n  port: 3001\n", t.TempDir(), dataDir)
+	require.NoError(t, os.WriteFile(configPath, []byte(contents), 0o600))
+	_, err := Init(configPath, "")
+	require.ErrorContains(t, err, "signing secret")
+}

--- a/scripts/verify-token-signing.sh
+++ b/scripts/verify-token-signing.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+export MATRIXHUB_TOKEN_SIGNING_SECRET=deployment-contract-secret-32-bytes
+chart=deploy/charts/matrixhub
+
+for mode in generated explicit existing; do
+  args=()
+  case "${mode}" in
+    explicit) args+=(--set-string "apiserver.tokenSigningSecret=${MATRIXHUB_TOKEN_SIGNING_SECRET}") ;;
+    existing) args+=(--set-string apiserver.tokenSigningExistingSecret=external-signing-key) ;;
+  esac
+  helm template signing-contract "${chart}" ${args[@]+"${args[@]}"} | ruby -ryaml -rbase64 -e '
+    documents = YAML.load_stream(STDIN.read).compact
+    secret = documents.find { |doc| doc["kind"] == "Secret" && doc.dig("data", "matrixhub.dsn") }
+    deployment = documents.find { |doc| doc["kind"] == "Deployment" && doc.dig("spec", "template", "spec", "containers").any? { |container| container["env"]&.any? { |env| env["name"] == "MATRIXHUB_TOKEN_SIGNING_SECRET" } } }
+    abort "missing signing secret injection" unless deployment
+    container = deployment.dig("spec", "template", "spec", "containers").find { |entry| entry["env"]&.any? { |env| env["name"] == "MATRIXHUB_TOKEN_SIGNING_SECRET" } }
+    ref = container["env"].find { |env| env["name"] == "MATRIXHUB_TOKEN_SIGNING_SECRET" }.dig("valueFrom", "secretKeyRef")
+    abort "wrong secret key" unless ref["key"] == "token-signing-secret"
+    encoded = secret.dig("data", "token-signing-secret")
+    if ARGV[0] == "existing"
+      abort "existing secret ignored" unless ref["name"] == "external-signing-key" && encoded.nil?
+    else
+      value = Base64.strict_decode64(encoded || "")
+      abort "wrong secret reference" unless ref["name"] == secret["metadata"]["name"]
+      abort "insecure generated secret" unless value.bytesize >= 32
+      abort "explicit secret ignored" if ARGV[0] == "explicit" && value != ENV.fetch("MATRIXHUB_TOKEN_SIGNING_SECRET")
+    end
+  ' "${mode}"
+done
+
+for compose in deploy/docker-compose.yml deploy/docker-compose.mysql.yml deploy/docker-compose.sqlite.yml; do
+  docker compose -f "${compose}" config --format json | ruby -rjson -e '
+    config = JSON.parse(STDIN.read)
+    abort "compose signing secret missing" unless config.dig("services", "matrixhub", "environment", "MATRIXHUB_TOKEN_SIGNING_SECRET") == ENV.fetch("MATRIXHUB_TOKEN_SIGNING_SECRET")
+  '
+  env -u MATRIXHUB_TOKEN_SIGNING_SECRET docker compose -f "${compose}" config --quiet
+done
+
+printf 'Token signing deployment checks passed\n'


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`initGitAuth` signed the temporary tokens used for LFS downloads over the SSH transport with a hardcoded key (`[]byte("secret-xxxxxx")`, marked TODO), so anyone reading the source could mint valid download tokens for any deployment.

The key now comes from `apiServer.tokenSigningSecret` (or the `MATRIXHUB_TOKEN_SIGNING_SECRET` environment variable). When neither is set, `config.Init` generates a random key once and persists it to `dataDir/token-signing-secret` (mode 0600, atomic create via hardlink) so restarts keep outstanding tokens valid. Outside debug mode an explicit key must be at least 32 bytes.

Deployment contract: the Helm chart generates a release Secret (reused across upgrades via `lookup`) or accepts `apiserver.tokenSigningExistingSecret`, and injects it as an env var rather than through the ConfigMap; the three compose files pass an optional `MATRIXHUB_TOKEN_SIGNING_SECRET`; `scripts/verify-token-signing.sh` renders the chart in generated/explicit/existing modes and the compose configs to check the wiring, and runs in the sqlite workflow.

Split out of #970, where this landed together with the storage refactor.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

`lookup` returns nothing under `helm template` or GitOps renderers, so those pipelines would rotate the key on every render — the chart README points them at `tokenSigningExistingSecret`. Multi-replica deployments must share one key.

#### Checklist

- [x] Tests(ut, e2e) added or updated, or not needed and explained
- [x] Docs(tech docs, usage docs) updated, or not needed and explained
- [Usage]: docs/development.md "Signing Keys"; deploy/charts/matrixhub/README.md "Signing Keys"

Config tests cover generation, persistence and 0600 mode, env override, and rejection of short keys; `bash scripts/verify-token-signing.sh` and `helm lint` pass locally.

#### Does this PR introduce a user-facing, API-facing, or operator-facing change?

```release-note
The LFS token signing key is no longer hardcoded. Set `apiServer.tokenSigningSecret` (or `MATRIXHUB_TOKEN_SIGNING_SECRET`, at least 32 bytes); when unset, MatrixHub generates a key and persists it under `dataDir/token-signing-secret`. The Helm chart generates or accepts a Secret (`apiserver.tokenSigningSecret` / `apiserver.tokenSigningExistingSecret`). Outstanding signed LFS tokens are invalidated on upgrade.
```
