### PR TITLE
fix(cleanup): reconstruct LFS object IDs from sharded paths

### DIFF
--- a/internal/repo/git_cleanup_repo.go
+++ b/internal/repo/git_cleanup_repo.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -32,6 +33,8 @@ type lfsObjectInfo struct {
 	size int64
 	path string
 }
+
+var lfsOIDPattern = regexp.MustCompile("^[0-9a-f]{64}$")
 
 // FindOrphanedRepos finds orphaned Git repositories on disk.
 func (g *gitRepo) FindOrphanedRepos(ctx context.Context, validModelPaths, validDatasetPaths []string) ([]*git.OrphanedRepo, error) {
@@ -177,8 +180,12 @@ func (g *gitRepo) scanLFSObjects(ctx context.Context) (map[string]*lfsObjectInfo
 			return ctx.Err()
 		}
 
-		oid := info.Name()
-		if len(oid) >= 8 {
+		rel, err := filepath.Rel(lfsDir, path)
+		if err != nil {
+			return err
+		}
+		oid := strings.ReplaceAll(rel, string(filepath.Separator), "")
+		if lfsOIDPattern.MatchString(oid) {
 			objects[oid] = &lfsObjectInfo{
 				size: info.Size(),
 				path: path,

--- a/internal/repo/git_cleanup_repo_test.go
+++ b/internal/repo/git_cleanup_repo_test.go
@@ -15,10 +15,72 @@
 package repo
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/matrixhub-ai/hfd/pkg/repository"
+	hfdstorage "github.com/matrixhub-ai/hfd/pkg/storage"
 )
+
+func TestFindOrphanedLFSShardedObjects(t *testing.T) {
+	ctx := context.Background()
+	store := hfdstorage.NewStorage(hfdstorage.WithRootDir(t.TempDir()))
+	referencedOID := strings.Repeat("a", 64)
+	orphanedOID := strings.Repeat("b", 64)
+	for _, oid := range []string{referencedOID, orphanedOID} {
+		objectPath := filepath.Join(store.LFSDir(), oid[:2], oid[2:4], oid[4:])
+		if err := os.MkdirAll(filepath.Dir(objectPath), 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(objectPath, []byte("object"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(store.LFSDir(), "bb", "bb", "lfsd_tmp_x"), []byte("pending"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	repoPath := store.ResolvePath("test-project/test-model")
+	if err := os.MkdirAll(filepath.Dir(repoPath), 0750); err != nil {
+		t.Fatal(err)
+	}
+	repo, err := repository.Init(ctx, repoPath, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pointer := "version https://git-lfs.github.com/spec/v1\noid sha256:" + referencedOID + "\nsize 1048576\n"
+	if _, err := repo.CreateCommit(ctx, "main", "add model", "Test", "test@example.com", []repository.CommitOperation{
+		{Type: repository.CommitOperationAdd, Path: "model.bin", Content: []byte(pointer)},
+	}, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	gitRepo := NewGitDB(store, nil)
+	orphaned, err := gitRepo.FindOrphanedLFS(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(orphaned) != 1 {
+		oids := make([]string, 0, len(orphaned))
+		for _, object := range orphaned {
+			oids = append(oids, object.OID)
+		}
+		t.Fatalf("expected one orphaned LFS object, got %d: %q", len(orphaned), oids)
+	}
+	wantPath := filepath.Join(store.LFSDir(), orphanedOID[:2], orphanedOID[2:4], orphanedOID[4:])
+	if orphaned[0].OID != orphanedOID || orphaned[0].Path != wantPath {
+		t.Fatalf("expected OID %q at %q, got %+v", orphanedOID, wantPath, orphaned[0])
+	}
+	if err := gitRepo.DeleteLFSObject(ctx, orphaned[0]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(wantPath); !os.IsNotExist(err) {
+		t.Fatalf("expected orphaned LFS file removed, got %v", err)
+	}
+}
 
 func TestConfinedPathAcceptsRelativePathAlreadyUnderRoot(t *testing.T) {
 	cwd, err := os.Getwd()

--- a/test/e2e_apiserver/cleanup/cleanup_suite_test.go
+++ b/test/e2e_apiserver/cleanup/cleanup_suite_test.go
@@ -1,0 +1,38 @@
+// Copyright The MatrixHub Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cleanup_test
+
+import (
+	"testing"
+
+	testenv "github.com/matrixhub-ai/matrixhub/test/e2e_apiserver/init"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCleanup(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cleanup Suite")
+}
+
+var _ = BeforeSuite(func() {
+	defer GinkgoRecover()
+	testenv.InitTestEnvironment()
+})
+
+var _ = AfterSuite(func() {
+	testenv.CleanupTestEnvironment()
+})

--- a/test/e2e_apiserver/cleanup/cleanup_test.go
+++ b/test/e2e_apiserver/cleanup/cleanup_test.go
@@ -1,0 +1,150 @@
+// Copyright The MatrixHub Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cleanup_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"math/rand/v2"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	v1alpha1cleanup "github.com/matrixhub-ai/matrixhub/test/client/v1alpha1/cleanup"
+	v1alpha1project "github.com/matrixhub-ai/matrixhub/test/client/v1alpha1/project"
+	"github.com/matrixhub-ai/matrixhub/test/tools"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const hfCommandTimeout = 2 * time.Minute
+
+var _ = Describe("Cleanup", Label("cleanup"), func() {
+	var (
+		ctx        context.Context
+		cleanupApi *v1alpha1cleanup.CleanupApiService
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		cleanupApi = tools.GetV1alpha1CleanupApi()
+	})
+
+	It("should report storage stats", Label("CL00001", "smoke"), func() {
+		stats, resp, err := cleanupApi.CleanupGetStorageStats(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		for _, size := range []string{stats.TotalSizeBytes, stats.RepositoriesSizeBytes, stats.LfsSizeBytes, stats.OrphanedSizeBytes} {
+			n, err := strconv.ParseInt(size, 10, 64)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(BeNumerically(">=", 0))
+		}
+	})
+
+	It("should preview and dry-run cleanup", Label("CL00002", "smoke"), func() {
+		_, resp, err := cleanupApi.CleanupPreviewCleanup(ctx, v1alpha1cleanup.V1alpha1PreviewCleanupRequest{
+			IncludeOrphanedRepos: true,
+			IncludeOrphanedLfs:   true,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		res, resp, err := cleanupApi.CleanupExecuteCleanup(ctx, v1alpha1cleanup.V1alpha1ExecuteCleanupRequest{
+			CleanOrphanedRepos: true,
+			CleanOrphanedLfs:   true,
+			DryRun:             true,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(res.Errors).To(BeEmpty())
+	})
+
+	It("should reclaim a deleted model's LFS objects and keep live ones", Label("CL00003", "smoke", "lfs"), func() {
+		root := GinkgoT().TempDir()
+		fixture, err := tools.CreateProjectUserFixture(ctx, "cleanup", v1alpha1project.EDITOR_V1alpha1ProjectRoleType)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			if err := fixture.Cleanup(context.Background()); err != nil {
+				GinkgoWriter.Printf("protocol fixture cleanup failed: %v\n", err)
+			}
+		})
+		token, err := fixture.CreateAccessToken(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		env := tools.HFCLIEnvironment(root, token)
+
+		modelA := tools.GenerateTestModelName("gc-a")
+		modelB := tools.GenerateTestModelName("gc-b")
+		DeferCleanup(func() {
+			_, _, _ = tools.GetV1alpha1ModelsApi().ModelsDeleteModel(context.Background(), fixture.Project.Name, modelB)
+		})
+
+		var hashes [2][32]byte
+		for i, model := range []string{modelA, modelB} {
+			repoID := fixture.Project.Name + "/" + model
+			create := runHF(root, env, "repos", "create", repoID, "--repo-type", "model")
+			Expect(create.Err).NotTo(HaveOccurred(), create.FailureMessage())
+
+			// Distinct pseudo-random content per model so the two uploads never share an object.
+			r := rand.New(rand.NewPCG(uint64(i+1), 0))
+			payload := make([]byte, 1<<20)
+			for j := range payload {
+				payload[j] = byte(r.Uint32())
+			}
+			hashes[i] = sha256.Sum256(payload)
+			source := filepath.Join(root, model, "weights.safetensors")
+			Expect(os.MkdirAll(filepath.Dir(source), 0755)).To(Succeed())
+			Expect(os.WriteFile(source, payload, 0600)).To(Succeed())
+
+			GinkgoWriter.Printf("uploading LFS file to %s\n", repoID)
+			upload := runHF(root, env, "upload", repoID, source, "weights.safetensors", "--commit-message", "cleanup e2e upload")
+			Expect(upload.Err).NotTo(HaveOccurred(), upload.FailureMessage())
+		}
+
+		GinkgoWriter.Printf("deleting model %s\n", modelA)
+		_, _, err = tools.GetV1alpha1ModelsApi().ModelsDeleteModel(ctx, fixture.Project.Name, modelA)
+		Expect(err).NotTo(HaveOccurred())
+
+		res, resp, err := cleanupApi.CleanupExecuteCleanup(ctx, v1alpha1cleanup.V1alpha1ExecuteCleanupRequest{CleanOrphanedLfs: true})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(res.Errors).To(BeEmpty())
+		Expect(res.LfsObjectsDeleted).To(BeNumerically(">=", 1))
+		reclaimed, err := strconv.ParseInt(res.SpaceReclaimedBytes, 10, 64)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(reclaimed).To(BeNumerically(">", 0))
+		GinkgoWriter.Printf("cleanup unlinked %d LFS objects and reclaimed %d bytes\n", res.LfsObjectsDeleted, reclaimed)
+
+		downloadDir := filepath.Join(root, "download-b")
+		download := runHF(root, env, "download", fixture.Project.Name+"/"+modelB, "weights.safetensors", "--local-dir", downloadDir, "--force-download")
+		Expect(download.Err).NotTo(HaveOccurred(), download.FailureMessage())
+		downloaded, err := os.ReadFile(filepath.Join(downloadDir, "weights.safetensors"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sha256.Sum256(downloaded)).To(Equal(hashes[1]))
+
+		again, resp, err := cleanupApi.CleanupExecuteCleanup(ctx, v1alpha1cleanup.V1alpha1ExecuteCleanupRequest{CleanOrphanedLfs: true})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(again.LfsObjectsDeleted).To(BeZero())
+	})
+})
+
+func runHF(dir string, env map[string]string, args ...string) tools.CommandResult {
+	ctx, cancel := context.WithTimeout(context.Background(), hfCommandTimeout)
+	defer cancel()
+	return tools.RunCommand(ctx, dir, env, "hf", args...)
+}

--- a/test/tools/http_client.go
+++ b/test/tools/http_client.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"sync"
 
+	v1alpha1cleanup "github.com/matrixhub-ai/matrixhub/test/client/v1alpha1/cleanup"
 	v1alpha1current_user "github.com/matrixhub-ai/matrixhub/test/client/v1alpha1/current_user"
 	v1alpha1dataset "github.com/matrixhub-ai/matrixhub/test/client/v1alpha1/dataset"
 	v1alpha1model "github.com/matrixhub-ai/matrixhub/test/client/v1alpha1/model"
@@ -44,6 +45,7 @@ var (
 	v1alpha1RegistriesApi  *v1alpha1registry.RegistriesApiService
 	v1alpha1RobotsApi      *v1alpha1robot.RobotsApiService
 	v1alpha1SyncPolicyApi  *v1alpha1sync_policy.SyncPolicyApiService
+	v1alpha1CleanupApi     *v1alpha1cleanup.CleanupApiService
 )
 
 // InitHTTPClients initializes HTTP API clients with admin authentication
@@ -138,6 +140,14 @@ func InitHTTPClients() error {
 		}
 		v1alpha1SyncPolicyApi = v1alpha1sync_policy.NewAPIClient(syncPolicyCfg).SyncPolicyApi
 
+		// Initialize Cleanup API client
+		cleanupCfg := &v1alpha1cleanup.Configuration{
+			BasePath:      baseURL,
+			DefaultHeader: defaultHeaders,
+			HTTPClient:    httpClient,
+		}
+		v1alpha1CleanupApi = v1alpha1cleanup.NewAPIClient(cleanupCfg).CleanupApi
+
 		log.Println("HTTP clients initialized successfully")
 	})
 
@@ -230,6 +240,17 @@ func GetV1alpha1SyncPolicyApi() *v1alpha1sync_policy.SyncPolicyApiService {
 		}
 	}
 	return v1alpha1SyncPolicyApi
+}
+
+// GetV1alpha1CleanupApi returns the Cleanup HTTP API client.
+func GetV1alpha1CleanupApi() *v1alpha1cleanup.CleanupApiService {
+	if v1alpha1CleanupApi == nil {
+		err := InitHTTPClients()
+		if err != nil {
+			panic(err)
+		}
+	}
+	return v1alpha1CleanupApi
 }
 
 // CreateModelClientWithCookie creates a new Model API client with a specific cookie


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Running the cleanup API with `cleanOrphanedLfs: true` deletes every LFS object on disk, including ones still referenced by live repositories.

`scanLFSObjects` in `internal/repo/git_cleanup_repo.go` used the file basename as the object ID, but hfd's local LFS store shards objects as `<oid[0:2]>/<oid[2:4]>/<oid[4:]>`, so the scanned IDs were the last 60 hex characters while `collectReferencedOIDs` collects the full 64-hex OIDs from LFS pointers. Nothing ever matched, so `FindOrphanedLFS` reported every object as orphaned. Reproduced on a sqlite build of `main`: two models each with a 1 MiB `.safetensors` uploaded via `hf upload`, then `POST /api/v1alpha1/cleanup/preview` listed both objects (with 60-char OIDs) as orphaned while both were referenced, `execute` deleted both, and the surviving model's `resolve` returned 404.

The fix rebuilds the OID from the path relative to the LFS root and only accepts 64-hex names, which also skips hfd's in-flight `lfsd_tmp_*` upload files that the previous `len(oid) >= 8` check admitted.

Not present in #970, which replaces this scanner with hfd's `pkg/gc`; found while porting its cleanup e2e suite to `main`.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

The preview/execute responses now report full 64-hex OIDs (previously the truncated 60-char basename).

#### Checklist

- [x] Tests(ut, e2e) added or updated, or not needed and explained
- [x] Docs(tech docs, usage docs) updated, or not needed and explained — behaviour now matches the existing cleanup design doc

`TestFindOrphanedLFSShardedObjects` fails on the old code (reports 3 objects incl. `lfsd_tmp_x` and the referenced one) and passes with the fix. New `cleanup` e2e suite (CL00001–CL00003): stats, preview/dry-run, and uploading two models, deleting one, and asserting exactly the deleted model's object is reclaimed while the other still downloads with the same sha256; passes locally against a sqlite build with this fix (`cleanup unlinked 1 LFS objects and reclaimed 1048576 bytes`).

#### Does this PR introduce a user-facing, API-facing, or operator-facing change?

```release-note
Fixed LFS cleanup deleting live objects: orphan detection compared truncated object IDs, so `cleanOrphanedLfs` removed every LFS object. Cleanup preview/execute now report full 64-hex OIDs.
```
