### PR TITLE
fix(sync): populate sync policy pagination pages

### DIFF
--- a/internal/apiserver/handler/sync_policy_handler.go
+++ b/internal/apiserver/handler/sync_policy_handler.go
@@ -92,9 +92,10 @@ func (h *SyncPolicyHandler) ListSyncPolicies(ctx context.Context, request *v1alp
 	return &v1alpha1.ListSyncPoliciesResponse{
 		SyncPolicies: items,
 		Pagination: &v1alpha1.Pagination{
-			Total:    int32(total),
-			Page:     request.Page,
-			PageSize: request.PageSize,
+			Total:    utils.ClampInt32(total),
+			Page:     int32(page),
+			PageSize: int32(pageSize),
+			Pages:    utils.CalculatePages(total, int32(pageSize)),
 		},
 	}, nil
 }

--- a/internal/apiserver/handler/sync_policy_handler_test.go
+++ b/internal/apiserver/handler/sync_policy_handler_test.go
@@ -109,3 +109,33 @@ func TestListSyncJobsPaginationIncludesPageCount(t *testing.T) {
 		t.Fatalf("Pagination.PageSize = %d, want %d", got, want)
 	}
 }
+
+func TestListSyncPoliciesPaginationIncludesPageCount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	policyService := syncpolicymocks.NewMockISyncPolicyService(ctrl)
+	h := &SyncPolicyHandler{syncPolicyService: policyService}
+
+	policyService.EXPECT().
+		ListSyncPolicies(gomock.Any(), 2, 10, "").
+		Return([]*syncpolicy.SyncPolicy{}, int64(21), nil)
+
+	response, err := h.ListSyncPolicies(t.Context(), &v1alpha1.ListSyncPoliciesRequest{
+		Page:     2,
+		PageSize: 10,
+	})
+	if err != nil {
+		t.Fatalf("ListSyncPolicies() error = %v", err)
+	}
+	if got, want := response.Pagination.Pages, int32(3); got != want {
+		t.Fatalf("Pagination.Pages = %d, want %d", got, want)
+	}
+	if got, want := response.Pagination.Total, int32(21); got != want {
+		t.Fatalf("Pagination.Total = %d, want %d", got, want)
+	}
+	if got, want := response.Pagination.Page, int32(2); got != want {
+		t.Fatalf("Pagination.Page = %d, want %d", got, want)
+	}
+	if got, want := response.Pagination.PageSize, int32(10); got != want {
+		t.Fatalf("Pagination.PageSize = %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

kind/bug

#### What this PR does / why we need it:

`GET /api/v1alpha1/sync-policies` returned `Pagination.Pages = 0` because the handler did not populate the page count. This caused the sync policy list UI and API consumers to receive an incorrect pagination result.

The handler now:

- populates `Pagination.Pages` using the total count and normalized page size;
- returns the normalized `Page` and `PageSize` values;
- clamps `Total` consistently with the other paginated list handlers.

#### Which issue(s) this PR fixes:

#985 

#### Special notes for your reviewer:

Added a regression test covering 21 total resources with a page size of 10, expecting 3 pages.

The focused tests pass:

```console
go test ./internal/apiserver/handler ./internal/infra/utils ./internal/domain/syncpolicy -count=1
```

The full test suite has unrelated failures because the local HF test service and the E2E API service on `localhost:3001` are not running.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

